### PR TITLE
feat: add Straylight recall-host adapter boundary

### DIFF
--- a/app/src/services/straylight-host/index.ts
+++ b/app/src/services/straylight-host/index.ts
@@ -1,0 +1,13 @@
+// Barrel for the Straylight recall-host Dixie-local adapter boundary.
+//
+// This barrel is intentionally NOT imported from `server.ts`, routes,
+// middleware, the proxy, or any other runtime entrypoint in this PR.
+// The adapter boundary is pre-consumption scaffolding only — wiring it
+// into the request path is reserved for the follow-up dependency-wiring
+// PR, which can then replace the local `./types.js` mirror with a direct
+// import from `@loa/straylight/host`.
+
+export * from './types.js';
+export * from './tenant-resolver.js';
+export * from './intake-deny-log.js';
+export * from './refusal-passthrough.js';

--- a/app/src/services/straylight-host/intake-deny-log.ts
+++ b/app/src/services/straylight-host/intake-deny-log.ts
@@ -1,0 +1,96 @@
+// Host-side intake-deny log — Dixie-local adapter mirror.
+//
+// The host emits an "intake-deny audit log entry referencing the wedge's
+// `recall_denied` event for chain-of-custody". This log is distinct from
+// the wedge's per-estate hash-chained AuditLog: it is the host's own
+// intake-side trail. It is per-tenant (NOT cross-tenant); cross-estate /
+// cross-tenant chain links are forbidden by host invariants.
+//
+// This in-memory implementation is deliberately minimal: no persistence,
+// no hash chain, no signatures. A future durable Dixie BFF will replace it
+// with a per-tenant durable store; the public shape stays the same.
+//
+// Deterministic entry IDs are computed with Node's `crypto.createHash`
+// over a canonical JSON serialisation of the entry content. We do NOT
+// import Hounfour or Straylight content-id helpers — those dependencies
+// are out of scope for this adapter-boundary slice.
+
+import { createHash } from 'node:crypto';
+
+export interface IntakeDenyEntry {
+  intake_log_entry_id: string;
+  caller_tenant: string;
+  caller_actor_id: string;
+  /** Set when the deny is bound to a specific target actor. */
+  target_actor_id?: string;
+  /** Set when the deny is bound to a specific target estate. */
+  target_estate_id?: string;
+  /** Set when the deny is bound to a specific target receipt (Surface 2). */
+  target_receipt_id?: string;
+  /** Set when the deny is bound to a specific target assertion (Surface 4). */
+  target_assertion_id?: string;
+  /** Host-classified deny reason. */
+  reason: string;
+  /** Optional reference to the wedge's `recall_denied` audit event. */
+  wedge_audit_event_ref?: string;
+  ts: string;
+}
+
+export interface IntakeDenyLog {
+  append(entry: Omit<IntakeDenyEntry, 'intake_log_entry_id'>): IntakeDenyEntry;
+  list(): readonly IntakeDenyEntry[];
+  /**
+   * Per-tenant view. Cross-tenant chain links are forbidden — callers MUST
+   * use this method when surfacing log entries to a tenant operator. The
+   * unscoped `list()` is for in-process debugging only.
+   */
+  listForTenant(tenant_id: string): IntakeDenyEntry[];
+}
+
+const CANONICAL_KEYS = [
+  'caller_tenant',
+  'caller_actor_id',
+  'target_actor_id',
+  'target_estate_id',
+  'target_receipt_id',
+  'target_assertion_id',
+  'reason',
+  'wedge_audit_event_ref',
+  'ts',
+  'seq',
+] as const;
+
+function deterministicEntryId(content: Record<string, unknown>): string {
+  const canonical = JSON.stringify(content, [...CANONICAL_KEYS]);
+  const digest = createHash('sha256').update(canonical).digest('hex');
+  return `idlog_${digest.slice(0, 32)}`;
+}
+
+export function createInMemoryIntakeDenyLog(): IntakeDenyLog {
+  const entries: IntakeDenyEntry[] = [];
+  return {
+    append(input) {
+      const id = deterministicEntryId({
+        caller_tenant: input.caller_tenant,
+        caller_actor_id: input.caller_actor_id,
+        target_actor_id: input.target_actor_id ?? null,
+        target_estate_id: input.target_estate_id ?? null,
+        target_receipt_id: input.target_receipt_id ?? null,
+        target_assertion_id: input.target_assertion_id ?? null,
+        reason: input.reason,
+        wedge_audit_event_ref: input.wedge_audit_event_ref ?? null,
+        ts: input.ts,
+        seq: entries.length,
+      });
+      const entry: IntakeDenyEntry = { ...input, intake_log_entry_id: id };
+      entries.push(entry);
+      return entry;
+    },
+    list() {
+      return entries;
+    },
+    listForTenant(tenant_id) {
+      return entries.filter((e) => e.caller_tenant === tenant_id);
+    },
+  };
+}

--- a/app/src/services/straylight-host/refusal-passthrough.ts
+++ b/app/src/services/straylight-host/refusal-passthrough.ts
@@ -1,0 +1,96 @@
+// Surface-by-surface identity relay helpers — Dixie-local adapter boundary.
+//
+// Dixie does not produce Straylight host objects. For each in-slice surface
+// (Recall intake, receipt retrieval, exclusion display, provenance walk,
+// audit-chain lookup, estate summary), Dixie receives the wedge-emitted
+// typed response and relays it verbatim. These helpers exist to:
+//
+//   1. Make the relay role explicit at every call site (so reviewers and
+//      future maintainers can see Dixie is not synthesising responses).
+//   2. Provide a single seam for later instrumentation (logging, metrics,
+//      trace propagation) without changing the surface contract.
+//
+// Every helper is an identity function on the corresponding response type:
+//   * It MUST NOT mutate the input.
+//   * It MUST NOT reclassify a `denied` / `refused` / `not_found` outcome
+//     into a `served` / `found` outcome.
+//   * It MUST NOT synthesise a success response.
+//   * It MUST NOT collapse or rewrite discriminants.
+//
+// Typed refusal reasons are preserved verbatim — the response value
+// returned is the exact value received.
+
+import type {
+  AuditChainLookupResponse,
+  EstateSummaryResponse,
+  ExclusionDisplayResponse,
+  ProvenanceWalkResponse,
+  ReceiptRetrievalResponse,
+  RecallIntakeResponse,
+} from './types.js';
+
+/**
+ * Surface 1 relay. Dixie relays Straylight's `RecallIntakeResponse`
+ * verbatim. Dixie does not produce a `RecallPack` / `RecallReceipt`,
+ * does not reclassify denial reasons, and does not synthesise a
+ * `served` outcome.
+ */
+export function relayRecallIntake(response: RecallIntakeResponse): RecallIntakeResponse {
+  return response;
+}
+
+/**
+ * Surface 2 relay. Dixie relays Straylight's `ReceiptRetrievalResponse`
+ * verbatim. Dixie does not produce a `RecallReceipt` and does not
+ * reclassify a `not_found` outcome.
+ */
+export function relayReceiptRetrieval(
+  response: ReceiptRetrievalResponse,
+): ReceiptRetrievalResponse {
+  return response;
+}
+
+/**
+ * Surface 3 relay. Dixie relays Straylight's `ExclusionDisplayResponse`
+ * verbatim. Dixie does not produce `ExclusionAggregate` /
+ * `RedactionAggregate` / `MarkedItemDisplay` shapes and does not
+ * reclassify exclusion categories.
+ */
+export function relayExclusionDisplay(
+  response: ExclusionDisplayResponse,
+): ExclusionDisplayResponse {
+  return response;
+}
+
+/**
+ * Surface 4 relay. Dixie relays Straylight's `ProvenanceWalkResponse`
+ * verbatim. Dixie does not produce provenance entries and does not
+ * reclassify a `refused` outcome.
+ */
+export function relayProvenanceWalk(
+  response: ProvenanceWalkResponse,
+): ProvenanceWalkResponse {
+  return response;
+}
+
+/**
+ * Surface 5 relay. Dixie relays Straylight's `AuditChainLookupResponse`
+ * verbatim. Dixie does not produce `AuditEvent` payloads, does not
+ * verify chain links, and does not reclassify a `broken` or `refused`
+ * outcome.
+ */
+export function relayAuditChainLookup(
+  response: AuditChainLookupResponse,
+): AuditChainLookupResponse {
+  return response;
+}
+
+/**
+ * Surface 6 relay. Dixie relays Straylight's `EstateSummaryResponse`
+ * verbatim. Dixie does not produce `EstateSummaryCounts`, does not apply
+ * frame discipline on its own, and does not reclassify a `refused`
+ * outcome.
+ */
+export function relayEstateSummary(response: EstateSummaryResponse): EstateSummaryResponse {
+  return response;
+}

--- a/app/src/services/straylight-host/tenant-resolver.ts
+++ b/app/src/services/straylight-host/tenant-resolver.ts
@@ -1,0 +1,73 @@
+// Host-side cross-tenant primitive — Dixie-local adapter mirror.
+//
+// The wedge does not model `tenant_id` as a first-class field on Actor /
+// Estate. The host must derive tenant identity from caller-supplied context
+// — and MUST fail closed when it cannot. This module makes the tenant
+// resolution dependency EXPLICIT: every host surface that makes a
+// cross-tenant decision requires a `TenantResolver` injected by the caller.
+// There is no production default resolver; passing one is the caller's
+// responsibility.
+//
+// Source of truth: `loa-straylight/src/straylight/host/tenancy.ts`. This
+// file is a pre-consumption mirror and will be replaced by a direct import
+// from `@loa/straylight/host` in the future dependency-wiring PR.
+
+import type { Context } from 'hono';
+
+/**
+ * Maps an actor_id / estate_id / receipt_id-derived id to a tenant slug.
+ * Returns `undefined` when the id cannot be resolved — callers MUST treat
+ * `undefined` as ambiguous and refuse (`tenant_unresolved`). The function
+ * MUST be pure for a given id over the lifetime of one host invocation.
+ */
+export type TenantResolver = (id: string) => string | undefined;
+
+export interface TenantCheckResult {
+  ok: boolean;
+  /** Set when `ok === false`. */
+  reason?: 'cross_tenant' | 'tenant_unresolved';
+}
+
+/**
+ * Verify that `targetId` resolves into `callerTenant`. Returns `{ ok: true }`
+ * only when the resolver returns a non-empty slug equal to `callerTenant`.
+ *
+ * Fail-closed rules:
+ *   * Empty `callerTenant` → `tenant_unresolved` (checked BEFORE resolver
+ *     invocation so a buggy caller cannot smuggle a blank tenant past a
+ *     resolver that happens to return `""`).
+ *   * Resolver returns `undefined` → `tenant_unresolved`.
+ *   * Resolver returns `""` → `tenant_unresolved` (empty string is not a
+ *     valid tenant slug and must not match an empty caller).
+ *   * Resolver returns a different slug → `cross_tenant`.
+ */
+export function checkSameTenant(
+  callerTenant: string,
+  targetId: string,
+  resolver: TenantResolver,
+): TenantCheckResult {
+  if (callerTenant === '') return { ok: false, reason: 'tenant_unresolved' };
+  const resolved = resolver(targetId);
+  if (resolved === undefined) return { ok: false, reason: 'tenant_unresolved' };
+  if (resolved === '') return { ok: false, reason: 'tenant_unresolved' };
+  if (resolved !== callerTenant) return { ok: false, reason: 'cross_tenant' };
+  return { ok: true };
+}
+
+/**
+ * Derive a `TenantResolver` from the authenticated wallet on the request
+ * context. The resolver returns the session wallet for any id (the session
+ * binds the tenant identity, not the target id). If no wallet is bound on
+ * the context, the resolver returns `undefined` so downstream surfaces
+ * fail closed with `tenant_unresolved`.
+ *
+ * There is no default tenant. There is no empty-string sentinel. There is
+ * no production tenant inference beyond the explicit session wallet.
+ */
+export function createSessionTenantResolver(c: Context): TenantResolver {
+  return () => {
+    const wallet = c.get('wallet');
+    if (!wallet) return undefined;
+    return wallet;
+  };
+}

--- a/app/src/services/straylight-host/types.ts
+++ b/app/src/services/straylight-host/types.ts
@@ -1,0 +1,228 @@
+// Straylight recall-host wire contract — Dixie-local mirror.
+//
+// Source of truth: `loa-straylight/src/straylight/host/types.ts`. This file
+// is a pre-consumption mirror that exists only until a future
+// dependency-wiring PR can replace it with
+// `import type { ... } from '@loa/straylight/host'`.
+//
+// Straylight is currently private / TS-source-only / no dist / no exports map
+// / no published release tag for Dixie consumption, and Dixie's
+// `@0xhoneyjar/loa-hounfour` pin (v8.3.1) cannot satisfy Straylight's
+// `^8.6.0` peer requirement without a separate Hounfour-skew resolution
+// that is out of scope for this slice.
+//
+// This mirror MUST NOT become Dixie's canonical Straylight schema
+// authority. Wedge-owned payloads (`RecallPack`, `RecallReceipt`,
+// `AuditEvent`, provenance entries, and the privacy/risk/status enums) are
+// carried as opaque or minimal structural shapes so the mirror cannot drift
+// into a competing schema. Anything Dixie surfaces back to a caller is
+// produced upstream by Straylight; Dixie relays.
+
+// ─── Host frame & caller envelope ────────────────────────────────────────────
+
+/**
+ * Host-facing environment frame. Narrower than the wedge's
+ * `EnvironmentFrame` by design — the host surfaces in scope are limited to
+ * these two frames per the recall-host MVP contract. Any other frame value
+ * MUST be refused at the host layer (`frame_unsupported`).
+ */
+export type HostFrame = 'actor_private' | 'public_discord';
+
+export interface HostCaller {
+  tenant_id: string;
+  actor_id: string;
+  session_id?: string;
+  /** Required for Surfaces 4 and 6; optional/unused for Surfaces 1, 2, 3, 5. */
+  frame?: HostFrame;
+}
+
+// ─── Closed enums surfaced by host outcomes ──────────────────────────────────
+
+/** Six-category receipt vocabulary pinned by ADR-020D §6. */
+export type ExclusionReason =
+  | 'included'
+  | 'excluded'
+  | 'redacted'
+  | 'challenged'
+  | 'revoked'
+  | 'blocked-by-policy';
+
+/**
+ * Closed enum of denial reasons surfaced on Surface 1. Every value is
+ * derived from a wedge outcome (class_validation, policy_decision, recall
+ * denial) or a host-layer intake refusal (cross-tenant, frame_unsupported).
+ * Dixie never invents a denial reason; it relays whichever value Straylight
+ * (or the host-layer refusal) emits.
+ */
+export type DeniedReason =
+  | 'class_validation_failed'
+  | 'policy_unavailable'
+  | 'signer_not_competent'
+  | 'cross_tenant_recall_refused'
+  | 'storage_unavailable'
+  | 'blocked_by_policy'
+  | 'privacy_scope_refusal'
+  | 'frame_unsupported'
+  | 'tenant_resolution_failed';
+
+// ─── Surface 1 — Recall intake response ──────────────────────────────────────
+
+export type RecallIntakeResponse =
+  | {
+      outcome: 'served';
+      // Wedge-owned RecallPack / RecallReceipt. Carried as opaque payloads;
+      // Dixie does NOT produce, validate, or reinterpret these objects.
+      pack: unknown;
+      receipt: unknown;
+      audit_event_id?: string;
+    }
+  | {
+      outcome: 'denied';
+      reason: DeniedReason;
+      raw_reasons: string[];
+      audit_event_id?: string;
+      intake_log_entry_id?: string;
+    }
+  | {
+      outcome: 'needs_review';
+      review_queue_id: string;
+      raw_reasons: string[];
+      audit_event_id?: string;
+    };
+
+// ─── Surface 2 — Receipt retrieval response ──────────────────────────────────
+
+export type ReceiptRetrievalResponse =
+  | { outcome: 'found'; receipt: unknown }
+  | {
+      outcome: 'not_found';
+      reason:
+        | 'unknown_receipt_id'
+        | 'cross_tenant_refused'
+        | 'storage_unavailable'
+        | 'tenant_resolution_failed';
+    };
+
+// ─── Surface 3 — Excluded-assertion reason display ───────────────────────────
+
+export interface ExclusionAggregate {
+  category: ExclusionReason;
+  raw_reason: string;
+  count: number;
+}
+
+export interface RedactionAggregate {
+  category: 'redacted';
+  raw_reason: string;
+  count: number;
+}
+
+export interface MarkedItemDisplay {
+  assertion_id: string;
+  /** Wedge-owned class taxonomy; carried as opaque string. */
+  assertion_class: string;
+  /** Wedge-owned status taxonomy; carried as opaque string. */
+  status: string;
+  category: ExclusionReason;
+  raw_reason: string;
+}
+
+export interface ExclusionDisplayResponse {
+  excluded_aggregates: ExclusionAggregate[];
+  redacted_aggregates: RedactionAggregate[];
+  marked: MarkedItemDisplay[];
+}
+
+// ─── Surface 4 — Provenance walk response ────────────────────────────────────
+
+export type ProvenanceWalkResponse =
+  | {
+      outcome: 'walked';
+      // Wedge-owned provenance entries. Carried as opaque payload; Dixie
+      // relays the array verbatim and does not reinterpret entries.
+      provenance: unknown[];
+    }
+  | {
+      outcome: 'refused';
+      reason:
+        | 'privacy_scope_refusal'
+        | 'cross_tenant_refused'
+        | 'unknown_assertion'
+        | 'storage_unavailable'
+        | 'tenant_resolution_failed'
+        | 'frame_unsupported';
+    };
+
+// ─── Surface 5 — Audit-chain lookup response ─────────────────────────────────
+
+export type AuditChainLookupResponse =
+  | {
+      outcome: 'verified';
+      // Wedge-owned AuditEvent[]. Carried as opaque payload; Dixie does NOT
+      // synthesise audit-chain truth and does NOT verify chain links.
+      events: unknown[];
+      chain_status: 'ok';
+    }
+  | {
+      outcome: 'broken';
+      events: unknown[];
+      chain_status: 'broken';
+      break_index: number;
+      break_reason: string;
+    }
+  | {
+      outcome: 'refused';
+      reason:
+        | 'cross_tenant_refused'
+        | 'unknown_estate'
+        | 'storage_unavailable'
+        | 'tenant_resolution_failed';
+    };
+
+// ─── Surface 6 — Estate summary ──────────────────────────────────────────────
+
+export interface EstateSummaryCounts {
+  /** Wedge-owned `AssertionClass` keyspace; carried as Record<string, number>. */
+  by_class: Record<string, number>;
+  /** Wedge-owned `AssertionStatus` keyspace; carried as Record<string, number>. */
+  by_status: Record<string, number>;
+  /**
+   * Spec 2-key shape. Frame discipline applied upstream by Straylight:
+   * when caller.frame is `public_discord`, the `actor_private` count is
+   * zeroed out. The widened map below still surfaces the raw counts for
+   * traceability.
+   */
+  by_privacy_scope: { actor_private: number; public_discord: number };
+  /** Wedge-owned `RiskLevel` keyspace; carried as Record<string, number>. */
+  by_risk_level: Record<string, number>;
+  /**
+   * Widened 4-key map mirroring the wedge's `PrivacyScope` enum. Frame
+   * discipline does NOT apply here; this is the raw bucket count and
+   * exists for trace/debug only. Host consumers MUST prefer
+   * `by_privacy_scope` for operator-facing render.
+   */
+  _widened_privacy_scope: {
+    public: number;
+    tenant: number;
+    actor_private: number;
+    sealed: number;
+  };
+}
+
+export type EstateSummaryResponse =
+  | {
+      outcome: 'summarized';
+      actor_id: string;
+      estate_id: string;
+      counts: EstateSummaryCounts;
+    }
+  | {
+      outcome: 'refused';
+      reason:
+        | 'cross_tenant_refused'
+        | 'unknown_estate'
+        | 'privacy_scope_refusal'
+        | 'storage_unavailable'
+        | 'tenant_resolution_failed'
+        | 'frame_unsupported';
+    };

--- a/app/tests/unit/straylight-host/intake-deny-log.test.ts
+++ b/app/tests/unit/straylight-host/intake-deny-log.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInMemoryIntakeDenyLog,
+  type IntakeDenyEntry,
+} from '../../../src/services/straylight-host/intake-deny-log.js';
+
+const FIXED_TS = '2026-05-16T12:00:00.000Z';
+
+function sampleInput(
+  overrides: Partial<Omit<IntakeDenyEntry, 'intake_log_entry_id'>> = {},
+): Omit<IntakeDenyEntry, 'intake_log_entry_id'> {
+  return {
+    caller_tenant: 'tenant-A',
+    caller_actor_id: 'actor-1',
+    reason: 'cross_tenant_recall_refused',
+    ts: FIXED_TS,
+    ...overrides,
+  };
+}
+
+describe('createInMemoryIntakeDenyLog — entry id', () => {
+  it('produces a content-addressed id with the expected prefix shape', () => {
+    const log = createInMemoryIntakeDenyLog();
+    const entry = log.append(sampleInput());
+    expect(entry.intake_log_entry_id).toMatch(/^idlog_[0-9a-f]{32}$/);
+  });
+
+  it('produces deterministic ids across fresh logs for the same content+seq', () => {
+    const a = createInMemoryIntakeDenyLog().append(sampleInput());
+    const b = createInMemoryIntakeDenyLog().append(sampleInput());
+    expect(a.intake_log_entry_id).toBe(b.intake_log_entry_id);
+  });
+
+  it('produces different ids when content differs', () => {
+    const log = createInMemoryIntakeDenyLog();
+    const a = log.append(sampleInput({ caller_actor_id: 'actor-1' }));
+    const b = createInMemoryIntakeDenyLog().append(
+      sampleInput({ caller_actor_id: 'actor-2' }),
+    );
+    expect(a.intake_log_entry_id).not.toBe(b.intake_log_entry_id);
+  });
+});
+
+describe('createInMemoryIntakeDenyLog — list', () => {
+  it('returns entries in insertion order', () => {
+    const log = createInMemoryIntakeDenyLog();
+    const first = log.append(sampleInput({ caller_actor_id: 'actor-1' }));
+    const second = log.append(sampleInput({ caller_actor_id: 'actor-2' }));
+    const third = log.append(sampleInput({ caller_actor_id: 'actor-3' }));
+    expect(log.list()).toEqual([first, second, third]);
+  });
+});
+
+describe('createInMemoryIntakeDenyLog — listForTenant', () => {
+  it('filters entries by caller_tenant', () => {
+    const log = createInMemoryIntakeDenyLog();
+    const a1 = log.append(sampleInput({ caller_tenant: 'tenant-A', caller_actor_id: 'a-1' }));
+    log.append(sampleInput({ caller_tenant: 'tenant-B', caller_actor_id: 'b-1' }));
+    const a2 = log.append(sampleInput({ caller_tenant: 'tenant-A', caller_actor_id: 'a-2' }));
+
+    const forA = log.listForTenant('tenant-A');
+    expect(forA).toEqual([a1, a2]);
+  });
+
+  it('does not leak entries across tenants when appends are interleaved', () => {
+    const log = createInMemoryIntakeDenyLog();
+    log.append(sampleInput({ caller_tenant: 'tenant-A', caller_actor_id: 'a-1' }));
+    log.append(sampleInput({ caller_tenant: 'tenant-B', caller_actor_id: 'b-1' }));
+    log.append(sampleInput({ caller_tenant: 'tenant-A', caller_actor_id: 'a-2' }));
+    log.append(sampleInput({ caller_tenant: 'tenant-B', caller_actor_id: 'b-2' }));
+    log.append(sampleInput({ caller_tenant: 'tenant-A', caller_actor_id: 'a-3' }));
+
+    const forA = log.listForTenant('tenant-A');
+    const forB = log.listForTenant('tenant-B');
+
+    expect(forA).toHaveLength(3);
+    expect(forB).toHaveLength(2);
+    expect(forA.every((e) => e.caller_tenant === 'tenant-A')).toBe(true);
+    expect(forB.every((e) => e.caller_tenant === 'tenant-B')).toBe(true);
+    expect(forA.map((e) => e.caller_actor_id)).toEqual(['a-1', 'a-2', 'a-3']);
+    expect(forB.map((e) => e.caller_actor_id)).toEqual(['b-1', 'b-2']);
+  });
+});

--- a/app/tests/unit/straylight-host/refusal-passthrough.test.ts
+++ b/app/tests/unit/straylight-host/refusal-passthrough.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import {
+  relayAuditChainLookup,
+  relayEstateSummary,
+  relayExclusionDisplay,
+  relayProvenanceWalk,
+  relayReceiptRetrieval,
+  relayRecallIntake,
+} from '../../../src/services/straylight-host/refusal-passthrough.js';
+import type {
+  AuditChainLookupResponse,
+  EstateSummaryResponse,
+  ExclusionDisplayResponse,
+  ProvenanceWalkResponse,
+  ReceiptRetrievalResponse,
+  RecallIntakeResponse,
+} from '../../../src/services/straylight-host/types.js';
+
+describe('relayRecallIntake', () => {
+  it('returns a deep-equal unchanged served response', () => {
+    const response: RecallIntakeResponse = {
+      outcome: 'served',
+      pack: { opaque: 'wedge-pack' },
+      receipt: { opaque: 'wedge-receipt' },
+      audit_event_id: 'ae-1',
+    };
+    const before = structuredClone(response);
+    const out = relayRecallIntake(response);
+    expect(out).toEqual(before);
+    expect(response).toEqual(before);
+  });
+
+  it('preserves typed denied reasons verbatim', () => {
+    const response: RecallIntakeResponse = {
+      outcome: 'denied',
+      reason: 'cross_tenant_recall_refused',
+      raw_reasons: ['caller_tenant != target_tenant'],
+      intake_log_entry_id: 'idlog_deadbeef',
+    };
+    const out = relayRecallIntake(response);
+    expect(out).toEqual(response);
+    if (out.outcome === 'denied') {
+      expect(out.reason).toBe('cross_tenant_recall_refused');
+    } else {
+      throw new Error('discriminant was rewritten');
+    }
+  });
+
+  it('preserves needs_review discriminant verbatim', () => {
+    const response: RecallIntakeResponse = {
+      outcome: 'needs_review',
+      review_queue_id: 'rq-1',
+      raw_reasons: ['policy_review_pending'],
+    };
+    const out = relayRecallIntake(response);
+    expect(out.outcome).toBe('needs_review');
+    expect(out).toEqual(response);
+  });
+});
+
+describe('relayReceiptRetrieval', () => {
+  it('returns a deep-equal unchanged found response', () => {
+    const response: ReceiptRetrievalResponse = {
+      outcome: 'found',
+      receipt: { opaque: 'wedge-receipt' },
+    };
+    const before = structuredClone(response);
+    const out = relayReceiptRetrieval(response);
+    expect(out).toEqual(before);
+    expect(response).toEqual(before);
+  });
+
+  it('preserves typed not_found reasons verbatim', () => {
+    const reasons: Array<
+      Extract<ReceiptRetrievalResponse, { outcome: 'not_found' }>['reason']
+    > = [
+      'unknown_receipt_id',
+      'cross_tenant_refused',
+      'storage_unavailable',
+      'tenant_resolution_failed',
+    ];
+    for (const reason of reasons) {
+      const response: ReceiptRetrievalResponse = { outcome: 'not_found', reason };
+      const out = relayReceiptRetrieval(response);
+      expect(out).toEqual(response);
+      if (out.outcome === 'not_found') {
+        expect(out.reason).toBe(reason);
+      } else {
+        throw new Error('discriminant was rewritten');
+      }
+    }
+  });
+});
+
+describe('relayExclusionDisplay', () => {
+  it('returns a deep-equal unchanged response and does not mutate', () => {
+    const response: ExclusionDisplayResponse = {
+      excluded_aggregates: [
+        { category: 'excluded', raw_reason: 'class_unsupported', count: 2 },
+        { category: 'blocked-by-policy', raw_reason: 'policy_X', count: 1 },
+      ],
+      redacted_aggregates: [{ category: 'redacted', raw_reason: 'pii_field', count: 3 }],
+      marked: [
+        {
+          assertion_id: 'a-1',
+          assertion_class: 'observation',
+          status: 'active',
+          category: 'challenged',
+          raw_reason: 'contested_by_b',
+        },
+      ],
+    };
+    const before = structuredClone(response);
+    const out = relayExclusionDisplay(response);
+    expect(out).toEqual(before);
+    expect(response).toEqual(before);
+  });
+});
+
+describe('relayProvenanceWalk', () => {
+  it('returns a deep-equal unchanged walked response', () => {
+    const response: ProvenanceWalkResponse = {
+      outcome: 'walked',
+      provenance: [{ opaque: 'entry-1' }, { opaque: 'entry-2' }],
+    };
+    const before = structuredClone(response);
+    const out = relayProvenanceWalk(response);
+    expect(out).toEqual(before);
+    expect(response).toEqual(before);
+  });
+
+  it('preserves typed refused reasons verbatim', () => {
+    const reasons: Array<
+      Extract<ProvenanceWalkResponse, { outcome: 'refused' }>['reason']
+    > = [
+      'privacy_scope_refusal',
+      'cross_tenant_refused',
+      'unknown_assertion',
+      'storage_unavailable',
+      'tenant_resolution_failed',
+      'frame_unsupported',
+    ];
+    for (const reason of reasons) {
+      const response: ProvenanceWalkResponse = { outcome: 'refused', reason };
+      const out = relayProvenanceWalk(response);
+      expect(out).toEqual(response);
+      if (out.outcome === 'refused') {
+        expect(out.reason).toBe(reason);
+      } else {
+        throw new Error('discriminant was rewritten');
+      }
+    }
+  });
+});
+
+describe('relayAuditChainLookup', () => {
+  it('returns a deep-equal unchanged verified response', () => {
+    const response: AuditChainLookupResponse = {
+      outcome: 'verified',
+      events: [{ opaque: 'ev-1' }, { opaque: 'ev-2' }],
+      chain_status: 'ok',
+    };
+    const before = structuredClone(response);
+    const out = relayAuditChainLookup(response);
+    expect(out).toEqual(before);
+    expect(response).toEqual(before);
+  });
+
+  it('preserves broken outcome with break metadata verbatim', () => {
+    const response: AuditChainLookupResponse = {
+      outcome: 'broken',
+      events: [{ opaque: 'ev-1' }],
+      chain_status: 'broken',
+      break_index: 0,
+      break_reason: 'hash_mismatch',
+    };
+    const out = relayAuditChainLookup(response);
+    expect(out).toEqual(response);
+    if (out.outcome === 'broken') {
+      expect(out.break_index).toBe(0);
+      expect(out.break_reason).toBe('hash_mismatch');
+    } else {
+      throw new Error('discriminant was rewritten');
+    }
+  });
+
+  it('preserves typed refused reasons verbatim', () => {
+    const reasons: Array<
+      Extract<AuditChainLookupResponse, { outcome: 'refused' }>['reason']
+    > = [
+      'cross_tenant_refused',
+      'unknown_estate',
+      'storage_unavailable',
+      'tenant_resolution_failed',
+    ];
+    for (const reason of reasons) {
+      const response: AuditChainLookupResponse = { outcome: 'refused', reason };
+      const out = relayAuditChainLookup(response);
+      expect(out).toEqual(response);
+      if (out.outcome === 'refused') {
+        expect(out.reason).toBe(reason);
+      } else {
+        throw new Error('discriminant was rewritten');
+      }
+    }
+  });
+});
+
+describe('relayEstateSummary', () => {
+  it('returns a deep-equal unchanged summarized response', () => {
+    const response: EstateSummaryResponse = {
+      outcome: 'summarized',
+      actor_id: 'actor-1',
+      estate_id: 'estate-1',
+      counts: {
+        by_class: { observation: 5, claim: 2 },
+        by_status: { active: 7 },
+        by_privacy_scope: { actor_private: 3, public_discord: 4 },
+        by_risk_level: { low: 5, medium: 2 },
+        _widened_privacy_scope: {
+          public: 1,
+          tenant: 2,
+          actor_private: 3,
+          sealed: 1,
+        },
+      },
+    };
+    const before = structuredClone(response);
+    const out = relayEstateSummary(response);
+    expect(out).toEqual(before);
+    expect(response).toEqual(before);
+  });
+
+  it('preserves typed refused reasons verbatim', () => {
+    const reasons: Array<
+      Extract<EstateSummaryResponse, { outcome: 'refused' }>['reason']
+    > = [
+      'cross_tenant_refused',
+      'unknown_estate',
+      'privacy_scope_refusal',
+      'storage_unavailable',
+      'tenant_resolution_failed',
+      'frame_unsupported',
+    ];
+    for (const reason of reasons) {
+      const response: EstateSummaryResponse = { outcome: 'refused', reason };
+      const out = relayEstateSummary(response);
+      expect(out).toEqual(response);
+      if (out.outcome === 'refused') {
+        expect(out.reason).toBe(reason);
+      } else {
+        throw new Error('discriminant was rewritten');
+      }
+    }
+  });
+});

--- a/app/tests/unit/straylight-host/tenant-resolver.test.ts
+++ b/app/tests/unit/straylight-host/tenant-resolver.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Context } from 'hono';
+import {
+  checkSameTenant,
+  createSessionTenantResolver,
+  type TenantResolver,
+} from '../../../src/services/straylight-host/tenant-resolver.js';
+
+function makeContext(wallet: string | undefined): Context {
+  return { get: (_key: string) => wallet } as unknown as Context;
+}
+
+describe('checkSameTenant fail-closed semantics', () => {
+  it('returns tenant_unresolved when callerTenant is empty', () => {
+    const resolver: TenantResolver = () => 'tenant-A';
+    expect(checkSameTenant('', 'actor-1', resolver)).toEqual({
+      ok: false,
+      reason: 'tenant_unresolved',
+    });
+  });
+
+  it('does not invoke the resolver when callerTenant is empty', () => {
+    const resolver = vi.fn<TenantResolver>(() => 'tenant-A');
+    checkSameTenant('', 'actor-1', resolver);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('returns tenant_unresolved when resolver returns undefined', () => {
+    const resolver: TenantResolver = () => undefined;
+    expect(checkSameTenant('tenant-A', 'actor-1', resolver)).toEqual({
+      ok: false,
+      reason: 'tenant_unresolved',
+    });
+  });
+
+  it('returns tenant_unresolved when resolver returns an empty string', () => {
+    const resolver: TenantResolver = () => '';
+    expect(checkSameTenant('tenant-A', 'actor-1', resolver)).toEqual({
+      ok: false,
+      reason: 'tenant_unresolved',
+    });
+  });
+
+  it('returns cross_tenant when resolver returns a different slug', () => {
+    const resolver: TenantResolver = () => 'tenant-B';
+    expect(checkSameTenant('tenant-A', 'actor-1', resolver)).toEqual({
+      ok: false,
+      reason: 'cross_tenant',
+    });
+  });
+
+  it('returns ok when resolver returns a matching slug', () => {
+    const resolver: TenantResolver = () => 'tenant-A';
+    expect(checkSameTenant('tenant-A', 'actor-1', resolver)).toEqual({ ok: true });
+  });
+});
+
+describe('createSessionTenantResolver', () => {
+  it('returns undefined when no wallet is bound on the context', () => {
+    const resolver = createSessionTenantResolver(makeContext(undefined));
+    expect(resolver('any-id')).toBeUndefined();
+  });
+
+  it('returns the wallet slug when a wallet is bound on the context', () => {
+    const resolver = createSessionTenantResolver(makeContext('0xabc'));
+    expect(resolver('any-id')).toBe('0xabc');
+  });
+});

--- a/app/tests/unit/straylight-host/types-contract.test.ts
+++ b/app/tests/unit/straylight-host/types-contract.test.ts
@@ -1,0 +1,110 @@
+// Drift detector for the Dixie-local Straylight recall-host mirror.
+//
+// This file is NOT a schema authority. Its sole job is to fail loudly if
+// the local mirror in `app/src/services/straylight-host/types.ts` drifts
+// away from the closed enums and structural shapes the wedge wire contract
+// pins. When the follow-up dependency-wiring PR replaces the local mirror
+// with `import type { ... } from '@loa/straylight/host'`, this file becomes
+// redundant and should be deleted along with the local mirror it guards.
+
+import { describe, expect, it } from 'vitest';
+import type {
+  DeniedReason,
+  EstateSummaryCounts,
+  EstateSummaryResponse,
+  ExclusionReason,
+  HostFrame,
+} from '../../../src/services/straylight-host/types.js';
+
+describe('DeniedReason mirror', () => {
+  it('exactly matches the Straylight host contract values', () => {
+    const expected = [
+      'class_validation_failed',
+      'policy_unavailable',
+      'signer_not_competent',
+      'cross_tenant_recall_refused',
+      'storage_unavailable',
+      'blocked_by_policy',
+      'privacy_scope_refusal',
+      'frame_unsupported',
+      'tenant_resolution_failed',
+    ] as const satisfies readonly DeniedReason[];
+
+    // Compile-time guard: any DeniedReason value NOT in `expected` makes
+    // _Missing non-never, and the assignment of literal `true` to the
+    // resulting `false` type fails to typecheck.
+    type _Missing = Exclude<DeniedReason, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(9);
+    expect(new Set<string>(expected).size).toBe(9);
+  });
+});
+
+describe('ExclusionReason mirror', () => {
+  it('exactly matches the six receipt categories', () => {
+    const expected = [
+      'included',
+      'excluded',
+      'redacted',
+      'challenged',
+      'revoked',
+      'blocked-by-policy',
+    ] as const satisfies readonly ExclusionReason[];
+
+    type _Missing = Exclude<ExclusionReason, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(6);
+    expect(new Set<string>(expected).size).toBe(6);
+  });
+});
+
+describe('HostFrame mirror', () => {
+  it('is exactly actor_private | public_discord', () => {
+    const expected = ['actor_private', 'public_discord'] as const satisfies readonly HostFrame[];
+
+    type _Missing = Exclude<HostFrame, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(2);
+  });
+});
+
+describe('Surface 6 EstateSummaryCounts shape', () => {
+  const counts: EstateSummaryCounts = {
+    by_class: {},
+    by_status: {},
+    by_privacy_scope: { actor_private: 0, public_discord: 0 },
+    by_risk_level: {},
+    _widened_privacy_scope: {
+      public: 0,
+      tenant: 0,
+      actor_private: 0,
+      sealed: 0,
+    },
+  };
+
+  it('_widened_privacy_scope retains the four-key trace shape', () => {
+    const keys = Object.keys(counts._widened_privacy_scope).sort();
+    expect(keys).toEqual(['actor_private', 'public', 'sealed', 'tenant']);
+  });
+
+  it('by_privacy_scope retains the two-key served shape', () => {
+    const keys = Object.keys(counts.by_privacy_scope).sort();
+    expect(keys).toEqual(['actor_private', 'public_discord']);
+  });
+
+  it('is the counts payload type used by summarized EstateSummaryResponse', () => {
+    const response: EstateSummaryResponse = {
+      outcome: 'summarized',
+      actor_id: 'actor-1',
+      estate_id: 'estate-1',
+      counts,
+    };
+    expect(response.outcome).toBe('summarized');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Dixie-local Straylight recall-host adapter boundary.

This is a preparatory slice for #95. It does **not** wire `@loa/straylight` as a dependency yet. Inspection found that `@loa/straylight` is not currently package-consumable by Dixie without crossing package/Hounfour constraints, so this PR creates the local adapter seam first and leaves the actual dependency wiring for a later PR.

## What changed

New source boundary:

- `app/src/services/straylight-host/types.ts`
  - Local mirror of the host wire contract:
    - `HostFrame`
    - `HostCaller`
    - `DeniedReason`
    - `ExclusionReason`
    - six response unions
    - `EstateSummaryCounts`
  - Marks Straylight as source-of-truth.
  - Keeps this as transitional until a later `@loa/straylight/host` type import is possible.

- `app/src/services/straylight-host/tenant-resolver.ts`
  - Adds explicit tenant-resolution boundary.
  - Fails closed for:
    - empty caller tenant;
    - unresolved tenant;
    - empty resolver result;
    - cross-tenant mismatch.
  - Adds `createSessionTenantResolver(c)` using `c.get('wallet')`.
  - Adds no default tenant fallback.

- `app/src/services/straylight-host/intake-deny-log.ts`
  - Adds in-memory `IntakeDenyLog`.
  - Keeps entries tenant-scoped.
  - Uses deterministic SHA-256 IDs.
  - Does not import Hounfour or Straylight helpers.

- `app/src/services/straylight-host/refusal-passthrough.ts`
  - Adds six identity relay helpers:
    - `relayRecallIntake`
    - `relayReceiptRetrieval`
    - `relayExclusionDisplay`
    - `relayProvenanceWalk`
    - `relayAuditChainLookup`
    - `relayEstateSummary`
  - Preserves typed refusal responses verbatim.
  - Does not mutate, rewrite, collapse, or synthesize outcomes.

- `app/src/services/straylight-host/index.ts`
  - Barrel export for the local adapter boundary.
  - Not wired into routes, middleware, server, proxy, or runtime entrypoints.

New tests:

- `app/tests/unit/straylight-host/tenant-resolver.test.ts`
- `app/tests/unit/straylight-host/intake-deny-log.test.ts`
- `app/tests/unit/straylight-host/refusal-passthrough.test.ts`
- `app/tests/unit/straylight-host/types-contract.test.ts`

## Boundary

This PR is **adapter-boundary only**.

It does not:

- add `@loa/straylight` as a dependency;
- modify `app/package.json` or `app/package-lock.json`;
- wire server/runtime entrypoints;
- add routes, middleware, HTTP, NATS, RPC, Discord, Telegram, or operator-facing rendering;
- edit existing services;
- edit docs, grimoires, migrations, deploy files, or web files;
- edit Straylight, Finn, Freeside, or Hounfour repos;
- consume Hounfour main or unpublished commits;
- adopt Hounfour #116 directly;
- adopt `0xhoneyjar:straylight:*`;
- adopt the Hounfour `recall-wedge` conformance category;
- implement vector 9;
- implement vectors 10–11;
- add public commitment-root behavior;
- make Dixie produce `RecallPack`, `RecallReceipt`, `dispositionFor`, `privacy_scope`, or audit-chain truth.

## Validation

Ran from `app/`:

```bash
npm run typecheck
npm run lint
npm run test