### PR TITLE
chore: align Hounfour to v8.6.0 for Gate 3

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dixie-bff",
       "version": "2.0.0",
       "dependencies": {
-        "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.3.1",
+        "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.6.0",
         "@hono/node-server": "^1.14.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.57.0",
@@ -42,14 +42,14 @@
       }
     },
     "node_modules/@0xhoneyjar/loa-hounfour": {
-      "version": "8.3.1",
-      "resolved": "git+ssh://git@github.com/0xHoneyJar/loa-hounfour.git#aed755f7fea8d2739cf9c755b45aaa580b6af6a9",
-      "license": "MIT",
+      "version": "8.6.0",
+      "resolved": "git+ssh://git@github.com/0xHoneyJar/loa-hounfour.git#c041cdd4c0fc44aab34720a2721760cd828ff2df",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@noble/hashes": "^2.0.1",
         "@sinclair/typebox": "^0.34.48",
         "canonicalize": "^2.1.0",
-        "jose": "^6.1.3"
+        "jose": "^6.2.2"
       },
       "engines": {
         "node": ">=22"
@@ -71,7 +71,8 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -794,6 +795,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -818,7 +820,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2344,7 +2345,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2723,7 +2723,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2754,7 +2753,8 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ajv": {
       "version": "6.14.0",
@@ -3106,7 +3106,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3280,6 +3279,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -3298,6 +3298,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -3306,13 +3307,15 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3534,7 +3537,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3682,9 +3684,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -4068,7 +4070,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -4166,7 +4167,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4671,7 +4671,8 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -4679,7 +4680,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4719,7 +4719,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4832,7 +4831,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5063,7 +5061,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5143,7 +5140,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,7 @@
     "@noble/hashes": "Transitive via @0xhoneyjar/loa-hounfour — provides sha256 for audit-trail-hash and chain-bound-hash modules"
   },
   "dependencies": {
-    "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.3.1",
+    "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.6.0",
     "@hono/node-server": "^1.14.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.57.0",

--- a/app/tests/fixtures/hounfour-generated-samples.json
+++ b/app/tests/fixtures/hounfour-generated-samples.json
@@ -1,9 +1,9 @@
 {
-  "generated_at": "2026-02-23T22:50:37.930Z",
+  "generated_at": "2026-05-17T08:32:30.662Z",
   "hounfour_version": "linked",
-  "total_schemas": 53,
+  "total_schemas": 60,
   "generated_count": 39,
-  "skipped_count": 14,
+  "skipped_count": 21,
   "manual_count": 25,
   "samples": [
     {
@@ -671,6 +671,55 @@
         "conservation_status": "conserved",
         "contract_version": "7.9.2"
       }
+    },
+    {
+      "schema": "panelDecisionArtifact",
+      "valid": false,
+      "sample": null,
+      "skipped": true,
+      "skip_reason": "String types with formats must specify a default value"
+    },
+    {
+      "schema": "panelVerdict",
+      "valid": false,
+      "sample": null,
+      "skipped": true,
+      "skip_reason": "String types with formats must specify a default value"
+    },
+    {
+      "schema": "deliberationDissent",
+      "valid": false,
+      "sample": null,
+      "skipped": true,
+      "skip_reason": "String types with patterns must specify a default value"
+    },
+    {
+      "schema": "crossScoreReport",
+      "valid": false,
+      "sample": null,
+      "skipped": true,
+      "skip_reason": "String types with formats must specify a default value"
+    },
+    {
+      "schema": "orgIdentity",
+      "valid": false,
+      "sample": null,
+      "skipped": true,
+      "skip_reason": "String types with formats must specify a default value"
+    },
+    {
+      "schema": "orgRepresentativeDelegation",
+      "valid": false,
+      "sample": null,
+      "skipped": true,
+      "skip_reason": "String types with formats must specify a default value"
+    },
+    {
+      "schema": "successionPolicy",
+      "valid": false,
+      "sample": null,
+      "skipped": true,
+      "skip_reason": "String types with formats must specify a default value"
     }
   ]
 }

--- a/docs/ecosystem-architecture.md
+++ b/docs/ecosystem-architecture.md
@@ -54,7 +54,7 @@ graph TB
 | 5 — Product | `loa-dixie` | dNFT Oracle — first product customer | **Staging** |
 | 4 — Platform | `loa-freeside` | API, Discord/TG, token-gating, billing, IaC | In progress |
 | 3 — Runtime | `loa-finn` | Persistent sessions, tool sandbox, memory | **Staging** |
-| 2 — Protocol | `loa-hounfour` | Schemas, state machines, model routing contracts | **Shipping** (v8.3.1) |
+| 2 — Protocol | `loa-hounfour` | Schemas, state machines, model routing contracts | **Shipping** (v8.6.0) |
 | 1 — Framework | `loa` | Agent dev framework, skills, Bridgebuilder | **Shipping** |
 
 Each layer depends only on layers below it. Protocol contracts flow upward: lower layers define contracts, upper layers consume them.
@@ -229,7 +229,7 @@ The `@0xhoneyjar/loa-hounfour` package provides the shared governance type syste
 | Service | Target Version | Status | Details |
 |---------|---------------|--------|---------|
 | **hounfour (package)** | v8.3.0 | Published | Source of truth for all protocol types |
-| **Dixie** | v8.3.0 | Complete | PR #64 (initial), #69 (chain-bound-hash). `package.json`: `github:0xHoneyJar/loa-hounfour#v8.3.0` |
+| **Dixie** | v8.6.0 | Complete | PR #64 (initial), #69 (chain-bound-hash), Gate 3 alignment to v8.6.0. `package.json`: `github:0xHoneyJar/loa-hounfour#v8.6.0` |
 | **Finn** | v8.3.0 | In progress | Runtime contract alignment underway |
 | **Freeside** | v8.3.0 | In progress | Platform integration pending Finn completion |
 
@@ -247,7 +247,7 @@ The `@0xhoneyjar/loa-hounfour` package provides the shared governance type syste
 #### Dixie --> Hounfour (Protocol)
 
 - **Protocol**: npm package dependency (build-time)
-- **Version**: `@0xhoneyjar/loa-hounfour#v8.3.0`
+- **Version**: `@0xhoneyjar/loa-hounfour#v8.6.0`
 - **Imports**: Core types (AccessPolicy, AgentIdentity, CircuitState), governance types (TaskType, ReputationEvent, ScoringPath), economy types (computeCostMicro, verifyPricingConservation), validators and schemas
 - **Contract surface**: Type validation, economic conservation laws, governance state machines
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,7 +131,7 @@ loa-dixie/
       utils/                # Shared utilities (crypto, etc.)
       __tests__/            # Unit tests co-located with source
     tests/                  # Integration and e2e test suites
-    package.json            # Dependencies including @0xhoneyjar/loa-hounfour#v8.3.0
+    package.json            # Dependencies including @0xhoneyjar/loa-hounfour#v8.6.0
   deploy/                   # Deployment configuration
     Dockerfile              # Multi-stage production build
     docker-compose.yml      # Local dev: Dixie + Finn
@@ -175,7 +175,7 @@ The critical governance invariant is positions 11-12-13: **allowlist -> payment 
 
 ### Hounfour Protocol Types
 
-Dixie consumes the `@0xhoneyjar/loa-hounfour` package (v8.3.0) for shared governance types, schema validators, and economic conservation laws. All types in `app/src/types.ts` document their alignment with hounfour protocol types.
+Dixie consumes the `@0xhoneyjar/loa-hounfour` package (v8.6.0) for shared governance types, schema validators, and economic conservation laws. All types in `app/src/types.ts` document their alignment with hounfour protocol types.
 
 ### Circuit Breaker (Finn Connection)
 

--- a/grimoires/loa/context/adr-hounfour-alignment.md
+++ b/grimoires/loa/context/adr-hounfour-alignment.md
@@ -191,3 +191,11 @@ and migration proposals are generated automatically.
 - `app/src/services/migration-proposal.ts` — Migration Proposal Generator (Sprint 12, Level 6)
 - `grimoires/loa/context/adr-constitutional-amendment.md` — Constitutional amendment process (Sprint 12)
 - `app/tests/unit/protocol-evolution.test.ts` — Level 6 foundation tests (Sprint 12)
+
+## Addendum — Gate 3 Hounfour Alignment (2026-05-17)
+
+Dixie aligned to Hounfour `v8.6.0` (from `v8.3.1`).
+
+- **Rationale**: Gate 3 prerequisite for future Straylight `@loa/straylight/host` type-only adoption. Straylight depends on `@0xhoneyjar/loa-hounfour@^8.6.0`; resolving the Dixie/Hounfour skew unblocks the future host-adapter dependency flip.
+- **Scope**: Hounfour dependency pin update + lockfile regeneration + conformance fixture regeneration (mechanical, via `scripts/generate-conformance-fixtures.ts`; schema count grew 53 → 60). No Straylight dependency flip in this PR. The local `app/src/services/straylight-host/` adapter boundary from PR #96 remains dormant.
+- **Validation**: typecheck, lint, 2530 tests, and build all pass against Hounfour `v8.6.0`. No source edits required for API drift.


### PR DESCRIPTION
## Summary

Aligns Dixie’s Hounfour dependency from `v8.3.1` to `v8.6.0`.

This resolves Gate 3 for the future `@loa/straylight/host` type-only dependency flip, without performing the Straylight dependency flip in this PR.

## What changed

Updated:

- `app/package.json`
  - `@0xhoneyjar/loa-hounfour`
  - from `github:0xHoneyJar/loa-hounfour#v8.3.1`
  - to `github:0xHoneyJar/loa-hounfour#v8.6.0`

- `app/package-lock.json`
  - regenerated via `npm install`
  - resolves Hounfour `v8.6.0` to:
    - `c041cdd4c0fc44aab34720a2721760cd828ff2df`

- `app/tests/fixtures/hounfour-generated-samples.json`
  - mechanically regenerated with the project generator
  - required because Hounfour validator registry grew from 53 to 60 schemas
  - no hand edits

- `docs/getting-started.md`
  - updates stale Hounfour version references

- `docs/ecosystem-architecture.md`
  - updates stale Hounfour version references

- `grimoires/loa/context/adr-hounfour-alignment.md`
  - appends a short Gate 3 alignment note
  - no restructure

## Gate status

After this PR:

- Gate 1: satisfied
  - Straylight selected private + tag-pinned git-source posture.
- Gate 2: satisfied
  - Straylight annotated tag `v0.0.1` exists.
- Gate 3: satisfied by this PR if merged
  - Dixie aligns to Hounfour `v8.6.0`, matching Straylight’s `^8.6.0` requirement.

This PR does **not** perform the future `@loa/straylight/host` dependency flip.

## Boundary

This PR does not:

- add `@loa/straylight`;
- import from `@loa/straylight`;
- import from `@loa/straylight/host`;
- edit `app/src/services/straylight-host/**`;
- edit `app/tests/unit/straylight-host/**`;
- add package aliases, overrides, resolutions, or import maps;
- edit routes, middleware, server, proxy, endpoints, HTTP, NATS, RPC, Discord, Telegram, or rendering;
- edit Straylight, Finn, Freeside, or Hounfour repos;
- consume Hounfour `main`;
- pin a raw Hounfour SHA as a silent fix;
- adopt Hounfour #116 directly;
- adopt `0xhoneyjar:straylight:*`;
- adopt Hounfour `recall-wedge`;
- implement vector 9;
- implement vectors 10–11;
- add public commitment-root behavior.

## Validation

Ran from `app/`:

```bash
npm install
npm run typecheck
npm run lint
npm run test
npm run build