### PR TITLE
Phase 30B: Refresh Straylight host contract types

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.6.0",
         "@hono/node-server": "^1.14.0",
-        "@loa/straylight": "github:0xHoneyJar/loa-straylight#00b17e586687ea199fef88837cf1a9407cd78ece",
+        "@loa/straylight": "github:0xHoneyJar/loa-straylight#7f7bf9b",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.57.0",
         "@opentelemetry/resources": "^1.30.0",
@@ -781,13 +781,39 @@
     },
     "node_modules/@loa/straylight": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/0xHoneyJar/loa-straylight.git#00b17e586687ea199fef88837cf1a9407cd78ece",
-      "integrity": "sha512-25IoXvFSIwSqynjsKfXoOG8i1kynNpcojXxCw/QYw48SFpyVFTXWmhESFXItrDHk6j2Xz8+Bn5oz/LQ15jOCFA==",
+      "resolved": "git+ssh://git@github.com/0xHoneyJar/loa-straylight.git#7f7bf9bbc92dcbe297f4bc3437761f6af56a7c57",
       "dependencies": {
-        "@0xhoneyjar/loa-hounfour": "^8.6.0"
+        "@0xhoneyjar/loa-hounfour": "8.7.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
+      }
+    },
+    "node_modules/@loa/straylight/node_modules/@0xhoneyjar/loa-hounfour": {
+      "version": "8.7.0",
+      "resolved": "https://npm.pkg.github.com/download/@0xhoneyjar/loa-hounfour/8.7.0/fc136f4f6a267f9ebbc932eee748f7e60132da89",
+      "integrity": "sha512-QzDDSEbz+AF4JpqDXW6qWumZr+7UbR+UhKdMJ1lGVd34NDhGqvQdpBEhvXbjSaO1k5jCV4MCqRUPBIeTbfcyXw==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1",
+        "@sinclair/typebox": "^0.34.48",
+        "canonicalize": "^2.1.0",
+        "jose": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@loa/straylight/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/ciphers": {

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.6.0",
     "@hono/node-server": "^1.14.0",
-    "@loa/straylight": "github:0xHoneyJar/loa-straylight#00b17e586687ea199fef88837cf1a9407cd78ece",
+    "@loa/straylight": "github:0xHoneyJar/loa-straylight#7f7bf9b",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.57.0",
     "@opentelemetry/resources": "^1.30.0",

--- a/app/tests/unit/straylight-host/phase-30-recall-wedge-contract-types.test.ts
+++ b/app/tests/unit/straylight-host/phase-30-recall-wedge-contract-types.test.ts
@@ -1,0 +1,275 @@
+// Phase 30 — Recall Wedge contract type-availability tripwire.
+//
+// Phase 30 (loa-straylight 7f7bf9b) re-exports the Phase 29B Recall Wedge
+// host contract through `@loa/straylight/host`. `@loa/straylight/host` is
+// a TYPES-ONLY surface for Dixie: this file proves the new Phase 30
+// contract names compile under `import type` from that subpath, without
+// runtime-importing or invoking any helper values.
+//
+// Runtime invocation of helper values (e.g. `summarizeRecallWedgeInspection`,
+// `createRecallWedgeInspectionReceipt`) is deferred to a later authorized
+// runtime host export or Dixie-side adapter — not Phase 30B.
+//
+// If a future Straylight tag bump renames or removes any of the names
+// guarded below, this file fails at typecheck. The runtime assertions
+// exercise only locally constructed plain values and do NOT touch
+// `@loa/straylight/host` at runtime.
+
+import { describe, expect, it } from 'vitest';
+import type {
+  RecallWedgeActorScope,
+  RecallWedgeBoundaryOwner,
+  RecallWedgeContractBoundary,
+  RecallWedgeEnvironmentFrame,
+  RecallWedgeEnvironmentSurface,
+  RecallWedgeHostKind,
+  RecallWedgeInclusionDecision,
+  RecallWedgeInspectionItem,
+  RecallWedgeInspectionReceipt,
+  RecallWedgeInspectionRequest,
+  RecallWedgeInspectionSummary,
+  RecallWedgeRiskLevel,
+  RecallWedgeSourceCorpusRef,
+  StraylightRecallWedgeContractVersion,
+} from '@loa/straylight/host';
+
+// Helper-signature types are sourced via `typeof Host.<helper>`, which
+// remains a type-only reference — no value binding is created.
+import type * as Host from '@loa/straylight/host';
+
+type AssertRecallWedgeContractReadOnlyBoundarySig =
+  typeof Host.assertRecallWedgeContractReadOnlyBoundary;
+type CreateRecallWedgeSourceCorpusRefSig = typeof Host.createRecallWedgeSourceCorpusRef;
+type CreateRecallWedgeInspectionReceiptSig = typeof Host.createRecallWedgeInspectionReceipt;
+type SummarizeRecallWedgeInspectionSig = typeof Host.summarizeRecallWedgeInspection;
+type DefaultRecallWedgeHostKindType = typeof Host.DEFAULT_RECALL_WEDGE_HOST_KIND;
+type RecallWedgeActiveHostKindsType = typeof Host.RECALL_WEDGE_ACTIVE_HOST_KINDS;
+type RecallWedgeContractBoundaryConstType = typeof Host.RECALL_WEDGE_CONTRACT_BOUNDARY;
+type StraylightRecallWedgeContractVersionConstType =
+  typeof Host.STRAYLIGHT_RECALL_WEDGE_CONTRACT_VERSION;
+
+describe('@loa/straylight/host — Phase 30 contract version is the pinned literal', () => {
+  it('StraylightRecallWedgeContractVersion is exactly the Phase 29B literal', () => {
+    type Expected = 'phase-29b.recall-wedge-contract.v0';
+    type _Same = StraylightRecallWedgeContractVersion extends Expected
+      ? Expected extends StraylightRecallWedgeContractVersion
+        ? true
+        : false
+      : false;
+    const _same: _Same = true;
+    expect(_same).toBe(true);
+  });
+
+  it('the constant export is structurally the same literal type', () => {
+    type _Same = StraylightRecallWedgeContractVersionConstType extends StraylightRecallWedgeContractVersion
+      ? StraylightRecallWedgeContractVersion extends StraylightRecallWedgeContractVersionConstType
+        ? true
+        : false
+      : false;
+    const _same: _Same = true;
+    expect(_same).toBe(true);
+  });
+});
+
+describe('@loa/straylight/host — Phase 30 boundary-owner closed vocabulary', () => {
+  it('RecallWedgeBoundaryOwner matches the five enumerated lanes exactly', () => {
+    const expected = [
+      'straylight',
+      'hounfour',
+      'dixie',
+      'finn',
+      'loa',
+    ] as const satisfies readonly RecallWedgeBoundaryOwner[];
+
+    type _Missing = Exclude<RecallWedgeBoundaryOwner, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(5);
+    expect(new Set<string>(expected).size).toBe(5);
+  });
+});
+
+describe('@loa/straylight/host — Phase 30 host-kind closed vocabulary', () => {
+  it('RecallWedgeHostKind matches the three enumerated host kinds exactly', () => {
+    const expected = [
+      'dixie-first-inspection-bff',
+      'finn-runtime-enforcement-later',
+      'test',
+    ] as const satisfies readonly RecallWedgeHostKind[];
+
+    type _Missing = Exclude<RecallWedgeHostKind, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(3);
+  });
+
+  it('RECALL_WEDGE_ACTIVE_HOST_KINDS is a readonly tuple over RecallWedgeHostKind', () => {
+    type _ActiveIsHostKind = RecallWedgeActiveHostKindsType[number] extends RecallWedgeHostKind
+      ? true
+      : false;
+    const _ok: _ActiveIsHostKind = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('DEFAULT_RECALL_WEDGE_HOST_KIND is a RecallWedgeHostKind', () => {
+    type _IsHostKind = DefaultRecallWedgeHostKindType extends RecallWedgeHostKind ? true : false;
+    const _ok: _IsHostKind = true;
+    expect(_ok).toBe(true);
+  });
+});
+
+describe('@loa/straylight/host — Phase 30 surface / risk / decision closed vocabularies', () => {
+  it('RecallWedgeEnvironmentSurface matches the four enumerated surfaces exactly', () => {
+    const expected = [
+      'operator',
+      'dixie-bff',
+      'finn-runtime',
+      'test',
+    ] as const satisfies readonly RecallWedgeEnvironmentSurface[];
+
+    type _Missing = Exclude<RecallWedgeEnvironmentSurface, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(4);
+  });
+
+  it('RecallWedgeRiskLevel matches the four enumerated risk levels exactly', () => {
+    const expected = [
+      'low',
+      'standard',
+      'high',
+      'restricted',
+    ] as const satisfies readonly RecallWedgeRiskLevel[];
+
+    type _Missing = Exclude<RecallWedgeRiskLevel, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(4);
+  });
+
+  it('RecallWedgeInclusionDecision matches the four total outcomes exactly', () => {
+    const expected = [
+      'include',
+      'exclude',
+      'redact',
+      'refuse',
+    ] as const satisfies readonly RecallWedgeInclusionDecision[];
+
+    type _Missing = Exclude<RecallWedgeInclusionDecision, (typeof expected)[number]>;
+    const _noExtras: _Missing extends never ? true : false = true;
+    expect(_noExtras).toBe(true);
+
+    expect(expected).toHaveLength(4);
+  });
+});
+
+describe('@loa/straylight/host — Phase 30 record shapes are reachable', () => {
+  it('RecallWedgeSourceCorpusRef carries the Phase 29A metadata keys', () => {
+    type Required = 'packageName' | 'packageVersion' | 'corpus' | 'pathPrefix';
+    type _HasRequired = Required extends keyof RecallWedgeSourceCorpusRef ? true : false;
+    const _ok: _HasRequired = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('RecallWedgeActorScope carries actor_id and estate_id', () => {
+    type _HasRequired = 'actor_id' | 'estate_id' extends keyof RecallWedgeActorScope ? true : false;
+    const _ok: _HasRequired = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('RecallWedgeEnvironmentFrame carries purpose and surface', () => {
+    type _HasRequired = 'purpose' | 'surface' extends keyof RecallWedgeEnvironmentFrame
+      ? true
+      : false;
+    const _ok: _HasRequired = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('RecallWedgeInspectionRequest exposes the explicit boolean knobs', () => {
+    type Required =
+      | 'request_id'
+      | 'actor_scope'
+      | 'environment'
+      | 'include_challenged'
+      | 'include_revoked'
+      | 'include_forgotten'
+      | 'source_corpus';
+    type _HasRequired = Required extends keyof RecallWedgeInspectionRequest ? true : false;
+    const _ok: _HasRequired = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('RecallWedgeInspectionItem carries decision, reason, and source_ref', () => {
+    type Required = 'decision' | 'reason' | 'source_ref';
+    type _HasRequired = Required extends keyof RecallWedgeInspectionItem ? true : false;
+    const _ok: _HasRequired = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('RecallWedgeInspectionReceipt carries the four decision counters', () => {
+    type Counters =
+      | 'included_count'
+      | 'excluded_count'
+      | 'redacted_count'
+      | 'refused_count';
+    type _HasCounters = Counters extends keyof RecallWedgeInspectionReceipt ? true : false;
+    const _ok: _HasCounters = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('RecallWedgeInspectionSummary carries the four decision counters', () => {
+    type Counters =
+      | 'included_count'
+      | 'excluded_count'
+      | 'redacted_count'
+      | 'refused_count';
+    type _Same = Counters extends keyof RecallWedgeInspectionSummary
+      ? keyof RecallWedgeInspectionSummary extends Counters
+        ? true
+        : false
+      : false;
+    const _same: _Same = true;
+    expect(_same).toBe(true);
+  });
+});
+
+describe('@loa/straylight/host — Phase 30 contract-boundary constant type', () => {
+  it('RecallWedgeContractBoundary mirrors the constant boundary export', () => {
+    type _Same = RecallWedgeContractBoundary extends RecallWedgeContractBoundaryConstType
+      ? RecallWedgeContractBoundaryConstType extends RecallWedgeContractBoundary
+        ? true
+        : false
+      : false;
+    const _same: _Same = true;
+    expect(_same).toBe(true);
+  });
+
+  it('the boundary constant pins the Phase 29B contract_version literal', () => {
+    type Version = RecallWedgeContractBoundary['contract_version'];
+    type _Same = Version extends StraylightRecallWedgeContractVersion
+      ? StraylightRecallWedgeContractVersion extends Version
+        ? true
+        : false
+      : false;
+    const _same: _Same = true;
+    expect(_same).toBe(true);
+  });
+});
+
+describe('@loa/straylight/host — Phase 30 helper signatures are reachable as types', () => {
+  it('helper-signature types resolve as functions (type-only)', () => {
+    type _IsFn<T> = T extends (...args: never[]) => unknown ? true : false;
+    const _assert: _IsFn<AssertRecallWedgeContractReadOnlyBoundarySig> = true;
+    const _create: _IsFn<CreateRecallWedgeSourceCorpusRefSig> = true;
+    const _receipt: _IsFn<CreateRecallWedgeInspectionReceiptSig> = true;
+    const _summary: _IsFn<SummarizeRecallWedgeInspectionSig> = true;
+    expect(_assert).toBe(true);
+    expect(_create).toBe(true);
+    expect(_receipt).toBe(true);
+    expect(_summary).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 30B refreshes Dixie's `@loa/straylight` dependency to the merged Straylight Phase 30 commit and proves Dixie can type-check against the new Recall Wedge host contract names from `@loa/straylight/host`.

This PR does not add runtime behavior. It is a dependency/type-consumption proof.

## Changes

- Updates `app/package.json`:
  - `@loa/straylight` from `00b17e586687ea199fef88837cf1a9407cd78ece`
  - to `7f7bf9b`
- Regenerates `app/package-lock.json`.
- Adds `app/tests/unit/straylight-host/phase-30-recall-wedge-contract-types.test.ts`.

## Boundary

`@loa/straylight/host` remains a types-only package surface.

Dixie may:
- `import type` from `@loa/straylight/host`;
- type-check the Phase 30 Recall Wedge host contract names;
- use `typeof Host.someHelper` through `import type * as Host` as type-only signature proof.

Dixie must not:
- value-import from `@loa/straylight/host`;
- call helper values from `@loa/straylight/host`;
- add new endpoint behavior in this phase;
- change existing recall-intake runtime behavior;
- change Straylight package exports;
- touch sibling repos.

`@loa/straylight/runtime/recall-intake` remains the only authorized Straylight value-import runtime subpath for existing recall-intake behavior.

## Validation

Local validation passed:

```text
npm run typecheck
npx vitest run tests/unit/straylight-host tests/unit/recall-intake/consumer-contract.test.ts tests/integration/recall-intake/route.test.ts
npm test
git diff --check
