### PR TITLE
Phase 30C: Harden recall-intake contract preflight

### DIFF
--- a/app/src/routes/recall-intake.ts
+++ b/app/src/routes/recall-intake.ts
@@ -4,8 +4,15 @@
 // ADR-026C §3.1–§3.8. Endpoint prerequisites: ADR-026D §3.a–§3.d.
 // Fail-closed catalogue: ADR-026D §4.a–§4.g.
 //
+// Phase 30C — Recall-intake contract preflight: the ingress zod schema is
+// structurally aligned with `@loa/straylight/host`'s `RecallIntakeRequest`
+// so no `as unknown as` cast is required at the seam. Host-ish / legacy
+// shapes (e.g. `signature_value`, `algorithm`, `risk_profile: routine`,
+// `environment_frame: actor_private`) are refused at ingress with
+// `ingress.invalid_request` rather than silently passed through.
+//
 // Pipeline (per request):
-//   1. zod validation of body shape
+//   1. zod validation of body shape (strict — wedge-aligned)
 //   2. authenticated wallet resolution (existing JWT middleware)
 //   3. AUTHORITATIVE tenant/actor override — caller-supplied
 //      `caller.tenant_id`, `caller.actor_id`, and `request.actor_id`
@@ -52,13 +59,102 @@ import type {
   TenantResolver,
 } from '@loa/straylight/host';
 
-const RecallSignatureSchema = z
+// Phase 30C — wedge-aligned ingress schema.
+//
+// The schema below is the *real* `RecallIntakeRequest` shape exported by
+// `@loa/straylight/host`. The route refuses anything else at ingress
+// rather than silently casting a host-ish body to the wedge type.
+//
+// Closed enums (mirrored from `@loa/straylight`):
+//   * SignerType, SignatureType — wedge `SignatureEnvelope`
+//   * AssertionClass, AssertionStatus — wedge `RecallRequest` filter sets
+//   * EnvironmentFrame — full wedge vocabulary (the host narrows to
+//     {actor_private, public_discord} for surface 4/6 via `HostFrame`,
+//     but the underlying `RecallRequest.environment_frame` is the wedge
+//     enum, NOT the host one — Surface 1 intake reuses the wedge type
+//     directly, so the route schema must accept the wedge vocabulary).
+//   * RiskLevel — wedge `RecallRequest.risk_profile`
+//   * ReceiptDetailLevel — `'minimal' | 'standard' | 'debug'`
+//   * HostFrame — narrowed enum on `caller.frame` (host-side)
+//
+// A compile-time tripwire below (`_RecallIntakeBodyMatchesHost`) ensures
+// the inferred zod output is assignable to the host's `RecallIntakeRequest`
+// without an unsafe cast.
+
+const SIGNER_TYPES = [
+  'actor_controller',
+  'operator',
+  'runtime',
+  'reviewer',
+  'policy_service',
+  'admin',
+  'wallet',
+  'service_key',
+] as const;
+
+const SIGNATURE_TYPES = [
+  'ed25519',
+  'secp256k1',
+  'hmac',
+  'dev_signature',
+] as const;
+
+const ASSERTION_CLASSES = [
+  'observation',
+  'event',
+  'claim',
+  'assumption',
+  'preference',
+  'reflection',
+  'identity',
+  'relationship',
+  'permission',
+  'plan',
+  'action_trace',
+  'feedback_signal',
+  'evaluation_result',
+  'challenge',
+  'revocation',
+  'commitment',
+] as const;
+
+const ASSERTION_STATUSES = [
+  'proposed',
+  'active',
+  'contested',
+  'demoted',
+  'revoked',
+  'forgotten_from_recall',
+  'superseded',
+  'sealed',
+] as const;
+
+const ENVIRONMENT_FRAMES = [
+  'private_operator',
+  'private_chat',
+  'public_discord',
+  'public_telegram',
+  'repo_workflow',
+  'tool_action_precheck',
+  'audit_review',
+] as const;
+
+const RISK_LEVELS = ['low', 'medium', 'high', 'critical'] as const;
+
+const RECEIPT_DETAIL_LEVELS = ['minimal', 'standard', 'debug'] as const;
+
+const HOST_FRAMES = ['actor_private', 'public_discord'] as const;
+
+const SignatureEnvelopeSchema = z
   .object({
     signature_id: z.string().min(1).max(256),
     signer_id: z.string().min(1).max(256),
-    signature_value: z.string().min(1).max(4096),
-    algorithm: z.string().min(1).max(64),
+    signer_type: z.enum(SIGNER_TYPES),
+    signature_type: z.enum(SIGNATURE_TYPES),
+    signed_payload_hash: z.string().min(1).max(512),
+    signature: z.string().min(1).max(4096),
     signed_at: z.string().min(1).max(64),
+    key_ref: z.string().min(1).max(512),
   })
   .strict();
 
@@ -67,17 +163,22 @@ const RecallRequestSchema = z
     recall_request_id: z.string().min(1).max(256),
     actor_id: z.string().min(1).max(256),
     estate_id: z.string().min(1).max(256),
-    environment_frame: z.enum(['actor_private', 'public_discord']),
-    risk_profile: z.enum(['routine', 'sensitive']).default('routine'),
-    requested_classes: z.array(z.string().min(1).max(128)).max(64).optional(),
-    excluded_classes: z.array(z.string().min(1).max(128)).max(64).optional(),
-    exclude_statuses: z.array(z.string().min(1).max(64)).max(16).optional(),
-    mark_statuses: z.array(z.string().min(1).max(64)).max(16).optional(),
-    include_statuses: z.array(z.string().min(1).max(64)).max(16).optional(),
+    requested_by: z.string().min(1).max(256),
+    task: z.string().min(1).max(2048),
+    intent: z.string().min(1).max(2048).optional(),
+    environment_frame: z.enum(ENVIRONMENT_FRAMES),
+    risk_profile: z.enum(RISK_LEVELS),
+    requested_classes: z.array(z.enum(ASSERTION_CLASSES)).max(64).optional(),
+    excluded_classes: z.array(z.enum(ASSERTION_CLASSES)).max(64).optional(),
+    include_statuses: z.array(z.enum(ASSERTION_STATUSES)).max(16).optional(),
+    mark_statuses: z.array(z.enum(ASSERTION_STATUSES)).max(16).optional(),
+    exclude_statuses: z.array(z.enum(ASSERTION_STATUSES)).max(16).optional(),
     max_items: z.number().int().min(1).max(1024).optional(),
+    freshness_window: z.string().min(1).max(64).optional(),
     include_provenance: z.boolean().optional(),
-    include_receipt_detail: z.enum(['minimal', 'standard', 'debug']).default('minimal'),
-    signature: RecallSignatureSchema,
+    include_receipt_detail: z.enum(RECEIPT_DETAIL_LEVELS),
+    signature: SignatureEnvelopeSchema,
+    created_at: z.string().min(1).max(64),
   })
   .strict();
 
@@ -86,17 +187,30 @@ const HostCallerSchema = z
     tenant_id: z.string().min(1).max(256),
     actor_id: z.string().min(1).max(256),
     session_id: z.string().min(1).max(256).optional(),
-    frame: z.enum(['actor_private', 'public_discord']).optional(),
+    frame: z.enum(HOST_FRAMES).optional(),
   })
   .strict();
 
 const RecallIntakeBodySchema = z
   .object({
     request: RecallRequestSchema,
-    detail_level: z.enum(['minimal', 'standard', 'debug']),
+    detail_level: z.enum(RECEIPT_DETAIL_LEVELS),
     caller: HostCallerSchema,
   })
   .strict();
+
+// Compile-time tripwire — Phase 30C contract preflight.
+//
+// If a future Straylight type bump renames or widens any field on
+// `RecallIntakeRequest`, this assignment fails at typecheck and forces a
+// deliberate update of the ingress schema rather than allowing a silent
+// drift. The check is type-only; no runtime value is produced.
+type _ZodRecallIntakeBody = z.infer<typeof RecallIntakeBodySchema>;
+type _RecallIntakeBodyMatchesHost = _ZodRecallIntakeBody extends RecallIntakeRequest
+  ? true
+  : false;
+const _recallIntakeBodyMatchesHost: _RecallIntakeBodyMatchesHost = true;
+void _recallIntakeBodyMatchesHost;
 
 const IDEMPOTENCY_HEADER = 'idempotency-key';
 const MAX_IDEMPOTENCY_KEY_LEN = 256;
@@ -290,11 +404,14 @@ export function createRecallIntakeRoutes(deps: RecallIntakeRouteDeps): Hono {
               intakeLog: deps.intakeLog,
               now: now().toISOString(),
             };
-            // Construct the seam request from validated body. Caller is
-            // always the authoritative session wallet (cross-tenant body
-            // mismatches were rejected above).
+            // Phase 30C — wedge-aligned ingress means `body` is already
+            // structurally a `RecallIntakeRequest` (enforced by the zod
+            // schema + the `_RecallIntakeBodyMatchesHost` tripwire).
+            // No `as unknown as` cast at the seam call site. Caller fields
+            // are normalized to the authoritative session wallet (cross-
+            // tenant body mismatches were rejected above).
             const seamReq: RecallIntakeRequest = {
-              request: body.request as unknown as RecallIntakeRequest['request'],
+              request: body.request,
               detail_level: body.detail_level,
               caller: { ...body.caller, tenant_id: wallet, actor_id: wallet },
             };

--- a/app/tests/integration/recall-intake/preflight.test.ts
+++ b/app/tests/integration/recall-intake/preflight.test.ts
@@ -1,0 +1,332 @@
+// Phase 30C — Dixie recall-intake contract preflight.
+//
+// These tests pin the ingress boundary between Dixie (BFF/host) and the
+// Straylight runtime seam at `@loa/straylight/runtime/recall-intake`.
+// The contract:
+//
+//   * Bodies whose `request` shape disagrees with Straylight's
+//     `RecallIntakeRequest` (host-ish / legacy / mismatched) are REFUSED
+//     at ingress with `ingress.invalid_request` BEFORE the seam is
+//     called. There is no silent cast.
+//   * Bodies whose `request` shape *is* a wedge-aligned
+//     `RecallIntakeRequest` reach the seam and receive a wedge-shaped
+//     response (served / denied / needs_review) mapped through the
+//     existing refusal-mapping pipeline.
+//   * Refusal envelopes are stable: shape, http status, error class.
+//
+// The seam is observed via a spy on `handleRecallIntake` that the route
+// imports from `@loa/straylight/runtime/recall-intake`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import {
+  createBoundedEstateStore,
+  createCapabilityHolder,
+  createIdempotencyCache,
+  createPerEstateMutex,
+  createPerTenantRateLimit,
+} from '../../../src/services/straylight-recall-intake/index.js';
+import { createInMemoryIntakeDenyLog } from '../../../src/services/straylight-host/index.js';
+import { createRecallIntakeRoutes } from '../../../src/routes/recall-intake.js';
+import type { Actor, ActorEstate, Keyring } from '@loa/straylight';
+
+// Spy on the seam: any call into Straylight's runtime recall-intake
+// entrypoint is observable here. If preflight rejects a request, this
+// mock must NOT fire; if preflight accepts, it must fire exactly once.
+const handleRecallIntakeSpy = vi.fn();
+vi.mock('@loa/straylight/runtime/recall-intake', async () => {
+  const actual = await vi.importActual<
+    typeof import('@loa/straylight/runtime/recall-intake')
+  >('@loa/straylight/runtime/recall-intake');
+  return {
+    ...actual,
+    handleRecallIntake: (...args: Parameters<typeof actual.handleRecallIntake>) => {
+      handleRecallIntakeSpy(...args);
+      return actual.handleRecallIntake(...args);
+    },
+  };
+});
+
+const KEY = 'phase-30c-preflight-key-32-bytes-aaaaaa';
+const WALLET = '0xabcdef0000000000000000000000000000000010';
+
+function buildApp() {
+  const app = new Hono();
+  app.use('/api/recall/intake/*', async (c, next) => {
+    const w = c.req.header('x-test-wallet');
+    if (w) c.req.raw.headers.set('x-wallet-address', w);
+    await next();
+  });
+  const boundedStore = createBoundedEstateStore({
+    maxAssertionsPerTenant: 100,
+    maxAssertionBytesPerTenant: 1_000_000,
+  });
+  const actor: Actor = {
+    actor_id: WALLET,
+    actor_class: 'agent',
+    display_name: 'test',
+    created_at: '2026-05-18T00:00:00Z',
+  } as unknown as Actor;
+  const estate: ActorEstate = {
+    estate_id: WALLET,
+    actor_id: WALLET,
+    created_at: '2026-05-18T00:00:00Z',
+  } as unknown as ActorEstate;
+  const keyring: Keyring = {
+    keyring_id: `kr_${WALLET}`,
+    actor_id: WALLET,
+    signers: [
+      {
+        signer_id: 'signer_test',
+        actor_id: WALLET,
+        public_key: 'pk_test',
+        roles: ['actor_self'],
+        active: true,
+        added_at: '2026-05-18T00:00:00Z',
+      },
+    ],
+    created_at: '2026-05-18T00:00:00Z',
+  } as unknown as Keyring;
+  boundedStore.seedTenant({ tenant_id: WALLET, actor, estate, keyring });
+  app.route(
+    '/api/recall/intake',
+    createRecallIntakeRoutes({
+      bodyMaxBytes: 8_192,
+      capabilityHolder: createCapabilityHolder(),
+      boundedStore,
+      idempotencyCache: createIdempotencyCache({ ttlSec: 60, maxEntries: 64 }),
+      perEstateMutex: createPerEstateMutex(),
+      perTenantRateLimit: createPerTenantRateLimit({ rpm: 60 }),
+      intakeLog: createInMemoryIntakeDenyLog(),
+    }),
+  );
+  return app;
+}
+
+function wedgeAlignedBody(wallet: string, request_id: string) {
+  return {
+    request: {
+      recall_request_id: request_id,
+      actor_id: wallet,
+      estate_id: wallet,
+      requested_by: wallet,
+      task: 'recall-intake-preflight',
+      environment_frame: 'private_chat',
+      risk_profile: 'low',
+      include_receipt_detail: 'minimal',
+      signature: {
+        signature_id: 'sig_1',
+        signer_id: 'signer_test',
+        signer_type: 'actor_controller',
+        signature_type: 'dev_signature',
+        signed_payload_hash:
+          'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+        signature: 'devsig',
+        signed_at: '2026-05-18T00:00:00Z',
+        key_ref: 'kref_test',
+      },
+      created_at: '2026-05-18T00:00:00Z',
+    },
+    detail_level: 'minimal',
+    caller: { tenant_id: wallet, actor_id: wallet },
+  };
+}
+
+beforeEach(() => {
+  process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY = KEY;
+  handleRecallIntakeSpy.mockClear();
+});
+afterEach(() => {
+  delete process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY;
+});
+
+describe('Phase 30C — recall-intake preflight rejects host-ish/legacy shapes', () => {
+  it('rejects legacy {signature_value, algorithm} signature shape', async () => {
+    const app = buildApp();
+    const body = wedgeAlignedBody(WALLET, 'r-legacy-sig');
+    // Replace the wedge SignatureEnvelope with the pre-Phase-30C "host-ish"
+    // shape. Any field name that no longer matches the wedge contract MUST
+    // be refused at ingress, never silently cast onto the seam request.
+    (body.request as unknown as Record<string, unknown>).signature = {
+      signature_id: 'sig_1',
+      signer_id: 'signer_test',
+      signature_value: 'devsig',
+      algorithm: 'ed25519',
+      signed_at: '2026-05-18T00:00:00Z',
+    };
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-legacy-sig',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+    const j = (await res.json()) as { error: string; outcome: string };
+    expect(j.error).toBe('ingress.invalid_request');
+    expect(j.outcome).toBe('denied');
+    expect(handleRecallIntakeSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects host-ish risk_profile (routine|sensitive instead of wedge RiskLevel)', async () => {
+    const app = buildApp();
+    const body = wedgeAlignedBody(WALLET, 'r-bad-risk');
+    (body.request as unknown as { risk_profile: string }).risk_profile = 'routine';
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-bad-risk',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+    const j = (await res.json()) as { error: string };
+    expect(j.error).toBe('ingress.invalid_request');
+    expect(handleRecallIntakeSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects host-ish environment_frame value (actor_private not in wedge enum)', async () => {
+    const app = buildApp();
+    const body = wedgeAlignedBody(WALLET, 'r-bad-frame');
+    (body.request as unknown as { environment_frame: string }).environment_frame =
+      'actor_private';
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-bad-frame',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+    const j = (await res.json()) as { error: string };
+    expect(j.error).toBe('ingress.invalid_request');
+    expect(handleRecallIntakeSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects bodies missing required wedge fields (requested_by, task, created_at)', async () => {
+    const app = buildApp();
+    const body = wedgeAlignedBody(WALLET, 'r-missing-fields');
+    delete (body.request as unknown as Record<string, unknown>).requested_by;
+    delete (body.request as unknown as Record<string, unknown>).task;
+    delete (body.request as unknown as Record<string, unknown>).created_at;
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-missing-fields',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+    const j = (await res.json()) as { error: string };
+    expect(j.error).toBe('ingress.invalid_request');
+    expect(handleRecallIntakeSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects bodies with unknown extra fields (strict zod)', async () => {
+    const app = buildApp();
+    const body = wedgeAlignedBody(WALLET, 'r-extra');
+    (body.request as unknown as Record<string, unknown>).rogue_field = true;
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-extra',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+    const j = (await res.json()) as { error: string };
+    expect(j.error).toBe('ingress.invalid_request');
+    expect(handleRecallIntakeSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects bodies with unknown signature.signer_type / signature_type enum values', async () => {
+    const app = buildApp();
+    const body = wedgeAlignedBody(WALLET, 'r-bad-sig-enum');
+    (body.request.signature as unknown as { signer_type: string }).signer_type =
+      'unknown_role';
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-bad-sig-enum',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+    const j = (await res.json()) as { error: string };
+    expect(j.error).toBe('ingress.invalid_request');
+    expect(handleRecallIntakeSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('Phase 30C — recall-intake preflight admits wedge-aligned bodies', () => {
+  it('a wedge-aligned RecallIntakeRequest reaches the seam exactly once', async () => {
+    const app = buildApp();
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-aligned',
+      },
+      body: JSON.stringify(wedgeAlignedBody(WALLET, 'r-aligned')),
+    });
+    // The response may be 200 / 4xx / 503 depending on wedge state; what
+    // preflight guarantees is that the seam was *reached* (not refused at
+    // ingress before being called).
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(413);
+    expect(res.status).not.toBe(429);
+    if (res.status >= 400) {
+      const j = (await res.json()) as { error?: string };
+      // Whatever refusal class fires, it MUST NOT be an ingress.* refusal.
+      expect(j.error?.startsWith('ingress.')).toBeFalsy();
+    }
+    expect(handleRecallIntakeSpy).toHaveBeenCalledTimes(1);
+    // The seam was invoked with a request whose enums match the wedge
+    // vocabulary — i.e. preflight propagated the validated shape, not a
+    // host-ish surrogate.
+    const args = handleRecallIntakeSpy.mock.calls[0]!;
+    const seamReq = args[1] as {
+      request: { environment_frame: string; risk_profile: string };
+      caller: { tenant_id: string; actor_id: string };
+    };
+    expect(seamReq.request.environment_frame).toBe('private_chat');
+    expect(seamReq.request.risk_profile).toBe('low');
+    expect(seamReq.caller.tenant_id).toBe(WALLET);
+    expect(seamReq.caller.actor_id).toBe(WALLET);
+  });
+
+  it('refusal envelope for a rejected preflight is the documented stable shape', async () => {
+    const app = buildApp();
+    const body = wedgeAlignedBody(WALLET, 'r-stable-refusal');
+    (body.request as unknown as { risk_profile: string }).risk_profile = 'routine';
+    const res = await app.request('/api/recall/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-wallet': WALLET,
+        'idempotency-key': 'k-stable-refusal',
+      },
+      body: JSON.stringify(body),
+    });
+    expect(res.status).toBe(400);
+    const j = (await res.json()) as Record<string, unknown>;
+    // Refusal-mapping pattern: {outcome, error, message}.
+    expect(j.outcome).toBe('denied');
+    expect(j.error).toBe('ingress.invalid_request');
+    expect(typeof j.message).toBe('string');
+    expect(handleRecallIntakeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/app/tests/integration/recall-intake/route.test.ts
+++ b/app/tests/integration/recall-intake/route.test.ts
@@ -95,22 +95,34 @@ function buildApp(opts?: {
   return app;
 }
 
+// Phase 30C — wedge-aligned recall-intake body. Mirrors
+// `RecallIntakeRequest` from `@loa/straylight/host`: the inner `request`
+// is the wedge `RecallRequest` shape (full enum vocabularies, full
+// `SignatureEnvelope` keys, `requested_by` / `task` / `created_at`
+// required). The route's ingress schema rejects host-ish / legacy
+// bodies; this fixture is the only shape that should pass preflight.
 function bodyForWallet(wallet: string, request_id: string) {
   return {
     request: {
       recall_request_id: request_id,
       actor_id: wallet,
       estate_id: wallet,
-      environment_frame: 'actor_private',
-      risk_profile: 'routine',
+      requested_by: wallet,
+      task: 'recall-intake-route-test',
+      environment_frame: 'private_chat',
+      risk_profile: 'low',
       include_receipt_detail: 'minimal',
       signature: {
         signature_id: 'sig_1',
         signer_id: 'signer_test',
-        signature_value: 'devsig',
-        algorithm: 'ed25519',
+        signer_type: 'actor_controller',
+        signature_type: 'dev_signature',
+        signed_payload_hash: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+        signature: 'devsig',
         signed_at: '2026-05-18T00:00:00Z',
+        key_ref: 'kref_test',
       },
+      created_at: '2026-05-18T00:00:00Z',
     },
     detail_level: 'minimal',
     caller: {
@@ -220,7 +232,7 @@ describe('POST /api/recall/intake — body & rate caps', () => {
     const app = buildApp({ bodyMaxBytes: 256 });
     const body = bodyForWallet(WALLET, 'r1');
     // Bloat to push over 256B.
-    body.request.signature.signature_value = 'a'.repeat(2_000);
+    body.request.signature.signature = 'a'.repeat(2_000);
     const res = await app.request('/api/recall/intake', {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary

Phase 30C hardens Dixie’s recall-intake ingress preflight so the endpoint no longer accepts host-ish / legacy request bodies and silently casts them into Straylight’s runtime seam.

The route now validates a wedge-aligned `RecallIntakeRequest` shape before invoking `@loa/straylight/runtime/recall-intake`.

## Changes

- Updates `app/src/routes/recall-intake.ts`
  - replaces the legacy/host-ish ingress schema with wedge-aligned strict Zod schemas;
  - validates full `RecallRequest` / `SignatureEnvelope` shape;
  - rejects legacy `signature_value` / `algorithm` signature shape;
  - rejects host-ish `risk_profile: routine | sensitive`;
  - rejects host-ish `request.environment_frame: actor_private`;
  - requires wedge fields such as `requested_by`, `task`, and `created_at`;
  - removes the unsafe `as unknown as RecallIntakeRequest['request']` seam cast.

- Updates `app/tests/integration/recall-intake/route.test.ts`
  - rewrites the route fixture to the wedge-aligned request shape.

- Adds `app/tests/integration/recall-intake/preflight.test.ts`
  - proves invalid legacy/host-ish bodies are rejected before the seam;
  - proves a wedge-aligned body reaches the seam exactly once;
  - pins the stable refusal envelope for preflight failure.

## Boundary

Dixie remains the BFF/host boundary. Straylight remains semantic owner.

This PR does not:
- add a new endpoint;
- rewrite Straylight runtime behavior;
- import or call helpers from `@loa/straylight/host` at runtime;
- change package dependencies;
- align Hounfour versions;
- add Finn enforcement;
- add Freeside surfaces;
- add production persistence.

Import discipline remains:

- `@loa/straylight/runtime/recall-intake` is the only Straylight runtime value-import subpath.
- `@loa/straylight` and `@loa/straylight/host` remain type-only where used.
- No deep imports from `@loa/straylight/dist`, `/src`, or `/dist-types`.

## Validation

Local validation passed:

```text
npm run typecheck
npx vitest run tests/integration/recall-intake/route.test.ts tests/unit/recall-intake/consumer-contract.test.ts tests/unit/straylight-host tests/integration/recall-intake/preflight.test.ts
npm test
git diff --check
