### PR TITLE
Phase 32A refresh Straylight recall wedge contract

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.6.0",
         "@hono/node-server": "^1.14.0",
-        "@loa/straylight": "github:0xHoneyJar/loa-straylight#7f7bf9b",
+        "@loa/straylight": "github:0xHoneyJar/loa-straylight#34bfff8",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.57.0",
         "@opentelemetry/resources": "^1.30.0",
@@ -781,7 +781,7 @@
     },
     "node_modules/@loa/straylight": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/0xHoneyJar/loa-straylight.git#7f7bf9bbc92dcbe297f4bc3437761f6af56a7c57",
+      "resolved": "git+ssh://git@github.com/0xHoneyJar/loa-straylight.git#34bfff8de67500849b1f5fed4c82ddae5cc278d6",
       "dependencies": {
         "@0xhoneyjar/loa-hounfour": "8.7.0"
       },

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@0xhoneyjar/loa-hounfour": "github:0xHoneyJar/loa-hounfour#v8.6.0",
     "@hono/node-server": "^1.14.0",
-    "@loa/straylight": "github:0xHoneyJar/loa-straylight#7f7bf9b",
+    "@loa/straylight": "github:0xHoneyJar/loa-straylight#34bfff8",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.57.0",
     "@opentelemetry/resources": "^1.30.0",

--- a/app/tests/integration/recall-intake/served-path.test.ts
+++ b/app/tests/integration/recall-intake/served-path.test.ts
@@ -346,5 +346,23 @@ describe('Phase 30E — POST /api/recall/intake served path with self-consistent
     // Policy decision must be `allow` for a competence-passing low/private
     // recall; needs_review or deny would mean the seed is wrong.
     expect(j.pack?.policy_decision.decision).toBe('allow');
+
+    // Phase 32A — enriched-receipt consumer-contract assertions.
+    //
+    // Phase 31E added `RecallReceipt.redacted_counts_by_reason` and folded
+    // it into `receipt_hash` computation (loa-straylight 12f85d2). Phase
+    // 32A proves Dixie passes that field through verbatim from the
+    // Straylight seam. The live empty-estate fixture redacts nothing, so
+    // these assertions lock the always-present + sum-invariant + hash
+    // shape without asserting any semantic content of the counter.
+    expect(Array.isArray(j.receipt?.redacted_counts_by_reason)).toBe(true);
+    const sumByReason = (j.receipt?.redacted_counts_by_reason ?? []).reduce(
+      (acc, r) => acc + r.count,
+      0,
+    );
+    expect(sumByReason).toBe(j.receipt?.redacted_count);
+    expect(typeof j.receipt?.excluded_counts_by_reason).toBe('object');
+    expect(j.receipt?.excluded_counts_by_reason).not.toBeNull();
+    expect(j.receipt?.receipt_hash?.startsWith('sha256:')).toBe(true);
   });
 });

--- a/app/tests/unit/straylight-host/phase-32a-recall-receipt-enriched-shape.test.ts
+++ b/app/tests/unit/straylight-host/phase-32a-recall-receipt-enriched-shape.test.ts
@@ -1,0 +1,159 @@
+// Phase 32A — Dixie consumer contract for the enriched Straylight
+// `RecallReceipt` shape introduced by Phase 31E (loa-straylight 12f85d2)
+// and shipped through Phase 31F (operator recall wedge demo,
+// loa-straylight 34bfff8).
+//
+// Phase 31E added two coupled obligations on the Straylight seam:
+//   1. `RecallReceipt.redacted_counts_by_reason: RedactionSummary[]` is now
+//      an explicit field of every recall receipt, alongside the existing
+//      scalar `redacted_count` and the `excluded_counts_by_reason` map.
+//   2. `redacted_counts_by_reason` is folded into the canonical
+//      `receipt_hash` computation, so any consumer that strips it (or
+//      replaces it with an empty array) breaks the receipt-hash chain.
+//
+// Dixie is a consumer / served-path / BFF layer. Dixie must NOT redefine
+// what counts as redaction, exclusion, contested marking, revocation, or
+// forgetting — those remain Straylight semantics. Dixie's only obligation
+// at this seam is to faithfully type, accept, and propagate every field
+// that Straylight emits on a `RecallReceipt`, including the Phase 31E
+// `redacted_counts_by_reason`.
+//
+// This file is the consumer-contract proof for Phase 32A. It is
+// intentionally NOT a runtime/integration test: the live Phase 30E
+// served-path fixture seeds an empty estate, so it can only exercise the
+// zero-redaction branch end-to-end. The unit-level proof below populates
+// `redacted_counts_by_reason` with > 0 entries and locks the shape that
+// Dixie's `import type { RecallReceipt }` is willing to accept and pass
+// through, without taking ownership of any Straylight semantics.
+//
+// Type-only imports from `@loa/straylight` are unchanged from existing
+// Dixie test files — the recall-intake adapter and route remain on the
+// `@loa/straylight/runtime/recall-intake` value-import discipline, which
+// is enforced by `tests/unit/recall-intake/consumer-contract.test.ts`.
+
+import { describe, expect, it } from 'vitest';
+import type { RecallReceipt, RedactionSummary } from '@loa/straylight';
+
+// ── Local builder for a Phase 31E-shaped receipt ────────────────────────────
+//
+// The values are deliberately synthetic: this file does not call any
+// Straylight runtime, does not reproduce Straylight's canonicalization or
+// hashing, and does not assert any Straylight-side invariant beyond the
+// shape Dixie is expected to consume. The `redacted_count ===
+// sum(redacted_counts_by_reason.count)` invariant tested below is the
+// Straylight-side contract that Dixie relies on as a consumer; a Dixie
+// integration that silently drops `redacted_counts_by_reason` would break
+// that invariant on its way out, even though Straylight itself preserves
+// it. The test locks Dixie's pass-through behavior against that breakage.
+
+function buildEnrichedReceipt(
+  redacted_counts_by_reason: RedactionSummary[],
+  excluded_counts_by_reason: Record<string, number>,
+): RecallReceipt {
+  const redacted_count = redacted_counts_by_reason.reduce((acc, r) => acc + r.count, 0);
+  return {
+    receipt_id: 'rcpt:phase32a-fixture',
+    recall_request_id: 'rreq:phase32a-fixture',
+    recall_pack_id: 'rpack:phase32a-fixture',
+    actor_id: '0xabcdef0000000000000000000000000000000032',
+    estate_id: '0xabcdef0000000000000000000000000000000032',
+    filters_applied: [],
+    included_assertion_ids: [],
+    marked_assertion_ids: [],
+    redacted_count,
+    redacted_counts_by_reason,
+    excluded_counts_by_reason,
+    policy_decision_ref: 'straylight.default-recall.v0',
+    requester_signature_ref: 'sig:phase32a-fixture',
+    pack_hash: 'sha256:0000000000000000000000000000000000000000000000000000000000000001',
+    receipt_hash: 'sha256:0000000000000000000000000000000000000000000000000000000000000002',
+    created_at: '2026-05-24T00:00:00.000Z',
+    detail_level: 'standard',
+  };
+}
+
+// A Dixie BFF would receive the Straylight `RecallReceipt` through the
+// `RecallIntakeResponse.served` envelope and then JSON-serialize it onto
+// the wire. The pass-through under test is exactly that: structuredClone
+// (a structural identity) followed by JSON round-trip (the wire-format
+// identity). If either step silently drops a Phase 31E field, the
+// downstream HTTP body would no longer match the Straylight emission.
+
+function passThrough(r: RecallReceipt): RecallReceipt {
+  return JSON.parse(JSON.stringify(r)) as RecallReceipt;
+}
+
+describe('Phase 32A — Dixie consumer contract for the enriched RecallReceipt shape', () => {
+  it('accepts and propagates redacted_counts_by_reason with > 0 entries', () => {
+    const enriched = buildEnrichedReceipt(
+      [
+        { reason: 'tenant_redacted', count: 2 },
+        { reason: 'actor_private_excluded', count: 1 },
+      ],
+      { policy_excluded: 3, contested: 1 },
+    );
+    const out = passThrough(enriched);
+
+    expect(out.redacted_counts_by_reason).toBeDefined();
+    expect(Array.isArray(out.redacted_counts_by_reason)).toBe(true);
+    expect(out.redacted_counts_by_reason).toEqual(enriched.redacted_counts_by_reason);
+  });
+
+  it('preserves redacted_count === sum(redacted_counts_by_reason.count)', () => {
+    const enriched = buildEnrichedReceipt(
+      [
+        { reason: 'tenant_redacted', count: 4 },
+        { reason: 'forgotten', count: 7 },
+      ],
+      {},
+    );
+    const out = passThrough(enriched);
+
+    const summed = out.redacted_counts_by_reason.reduce((acc, r) => acc + r.count, 0);
+    expect(out.redacted_count).toBe(summed);
+    expect(out.redacted_count).toBe(11);
+  });
+
+  it('preserves excluded_counts_by_reason as a plain Record<string,number>', () => {
+    const enriched = buildEnrichedReceipt([], { contested: 5, revoked: 2 });
+    const out = passThrough(enriched);
+
+    expect(typeof out.excluded_counts_by_reason).toBe('object');
+    expect(out.excluded_counts_by_reason).not.toBeNull();
+    expect(out.excluded_counts_by_reason).toEqual({ contested: 5, revoked: 2 });
+  });
+
+  it('preserves sha256-prefixed pack_hash and receipt_hash through JSON pass-through', () => {
+    const enriched = buildEnrichedReceipt([{ reason: 'tenant_redacted', count: 1 }], {});
+    const out = passThrough(enriched);
+
+    expect(out.pack_hash.startsWith('sha256:')).toBe(true);
+    expect(out.receipt_hash.startsWith('sha256:')).toBe(true);
+    expect(out.pack_hash).toBe(enriched.pack_hash);
+    expect(out.receipt_hash).toBe(enriched.receipt_hash);
+  });
+
+  it('zero-redaction case still emits redacted_counts_by_reason as an empty array', () => {
+    const enriched = buildEnrichedReceipt([], {});
+    const out = passThrough(enriched);
+
+    expect(out.redacted_counts_by_reason).toEqual([]);
+    expect(out.redacted_count).toBe(0);
+  });
+});
+
+describe('Phase 32A — RedactionSummary type structure (compile-time)', () => {
+  it('RedactionSummary carries reason and count keys', () => {
+    type Required = 'reason' | 'count';
+    type _HasRequired = Required extends keyof RedactionSummary ? true : false;
+    const _ok: _HasRequired = true;
+    expect(_ok).toBe(true);
+  });
+
+  it('RecallReceipt exposes Phase 31E redacted_counts_by_reason as RedactionSummary[]', () => {
+    type Field = RecallReceipt['redacted_counts_by_reason'];
+    type _IsArray = Field extends RedactionSummary[] ? true : false;
+    const _ok: _IsArray = true;
+    expect(_ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 32A refreshes Dixie against the latest Straylight Recall Wedge contract.

This updates Dixie’s `@loa/straylight` dependency pin from the Phase 30 host-contract export commit to the Phase 31F operator Recall Wedge demo commit.

Changed files:

- `app/package.json`
- `app/package-lock.json`
- `app/tests/integration/recall-intake/served-path.test.ts`
- `app/tests/unit/straylight-host/phase-32a-recall-receipt-enriched-shape.test.ts`

No `app/src/**` source code was modified. Dixie remains a consumer of Straylight semantics and does not redefine recall, redaction, exclusion, contesting, revocation, forgetting, or policy behavior.

## Dependency refresh

Old Straylight pin:

```text
github:0xHoneyJar/loa-straylight#7f7bf9b
