### PR TITLE
Phase 32G fix: honor platform port for Dixie deploys

### DIFF
--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -87,7 +87,8 @@ export interface DixieConfig {
  *
  * FINN_URL              (required) — loa-finn backend URL (e.g. http://localhost:3000)
  * FINN_WS_URL           (optional) — WebSocket URL for loa-finn; defaults to FINN_URL with ws:// scheme
- * DIXIE_PORT            (optional) — HTTP listen port; default 3001
+ * PORT                  (optional) — Railway/platform-injected HTTP listen port; takes precedence over DIXIE_PORT
+ * DIXIE_PORT            (optional) — local/dev fallback & legacy override for the HTTP listen port; default 3001 (used only when PORT is unset)
  * DIXIE_JWT_PRIVATE_KEY (required) — JWT signing key; HS256 raw secret (min 32 chars) or EC P-256 PEM for ES256
  * DIXIE_JWT_ALG         (optional) — explicit algorithm override: 'ES256' or 'HS256'; auto-detected from key format if not set
  * DIXIE_JWT_LEGACY_HS256_SECRET (optional) — old HS256 secret for dual-algorithm transition; only used when JWT_ALG=ES256
@@ -160,7 +161,11 @@ export function loadConfig(): DixieConfig {
     }
   }
 
-  const port = safeParseInt(process.env.DIXIE_PORT, 3001, 65535);
+  // Railway (and most PaaS) inject PORT and expect the web service to listen on it.
+  // PORT takes precedence; DIXIE_PORT is the local/dev fallback & legacy override; default 3001.
+  // A present-but-invalid PORT is selected by ?? and falls through safeParseInt to the default
+  // (it does not fall back to DIXIE_PORT) — the simpler, predictable behavior.
+  const port = safeParseInt(process.env.PORT ?? process.env.DIXIE_PORT, 3001, 65535);
   const finnWsUrl = process.env.FINN_WS_URL
     ?? finnUrl.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
 

--- a/app/tests/unit/config.test.ts
+++ b/app/tests/unit/config.test.ts
@@ -19,6 +19,8 @@ describe('loadConfig', () => {
 
   it('loads with defaults when FINN_URL is set', () => {
     process.env.FINN_URL = 'http://localhost:4000';
+    delete process.env.PORT;
+    delete process.env.DIXIE_PORT;
     const config = loadConfig();
 
     expect(config.finnUrl).toBe('http://localhost:4000');
@@ -32,9 +34,43 @@ describe('loadConfig', () => {
 
   it('respects custom port', () => {
     process.env.FINN_URL = 'http://finn:4000';
+    delete process.env.PORT;
     process.env.DIXIE_PORT = '8080';
     const config = loadConfig();
     expect(config.port).toBe(8080);
+  });
+
+  it('honors Railway PORT when set', () => {
+    process.env.FINN_URL = 'http://finn:4000';
+    delete process.env.DIXIE_PORT;
+    process.env.PORT = '5005';
+    const config = loadConfig();
+    expect(config.port).toBe(5005);
+  });
+
+  it('falls back to DIXIE_PORT when PORT is absent', () => {
+    process.env.FINN_URL = 'http://finn:4000';
+    delete process.env.PORT;
+    process.env.DIXIE_PORT = '8080';
+    const config = loadConfig();
+    expect(config.port).toBe(8080);
+  });
+
+  it('PORT takes precedence over DIXIE_PORT when both are set', () => {
+    process.env.FINN_URL = 'http://finn:4000';
+    process.env.PORT = '5005';
+    process.env.DIXIE_PORT = '8080';
+    const config = loadConfig();
+    expect(config.port).toBe(5005);
+  });
+
+  it('invalid PORT falls through safeParseInt to the default (not to DIXIE_PORT)', () => {
+    process.env.FINN_URL = 'http://finn:4000';
+    process.env.PORT = 'not-a-number';
+    process.env.DIXIE_PORT = '8080';
+    const config = loadConfig();
+    // A present-but-invalid PORT is selected by ?? and parseInt -> NaN -> default 3001.
+    expect(config.port).toBe(3001);
   });
 
   it('splits CORS origins by comma', () => {


### PR DESCRIPTION
## Summary

Phase 32G makes Dixie deployment-ready for Railway-style platform networking by honoring the platform-injected `PORT` environment variable before falling back to `DIXIE_PORT` and then the existing default `3001`.

This is a narrow deploy-readiness patch for the Recall Wedge smoke-test path. It does not deploy Dixie, does not claim smoke-test acceptance, and does not change recall-intake authentication or runtime behavior beyond HTTP listen-port resolution.

## Behavior

Port resolution is now:

- `PORT` when present
- otherwise `DIXIE_PORT`
- otherwise default `3001`

A present-but-invalid `PORT` is selected and falls through existing `safeParseInt` behavior to the default `3001`; it does not fall back to `DIXIE_PORT`.

## Files

Modified:

- app/src/config.ts
- app/tests/unit/config.test.ts

Intentionally untouched:

- app/src/index.ts
- recall-intake routes/services
- auth/JWT middleware
- middleware order
- package files
- lockfiles
- generated files
- Railway config files
- Freeside repos or code

## Results

Validation run locally:

- git diff --check: passed
- npm run typecheck: passed
- npm run build: passed
- npx vitest run tests/unit/config.test.ts tests/unit/recall-intake/config-fail-closed.test.ts: passed, 18 tests
- PORT=5005 npx vitest run tests/unit/config.test.ts: passed

Codex audit:

- VERDICT: ACCEPT
- Scope accepted as only app/src/config.ts and app/tests/unit/config.test.ts
- Railway PORT compatibility accepted
- Test isolation accepted
- No secret/raw-token leak found

## Non-goals

This PR does not:

- add a JWT mint helper
- change recall-intake auth
- change middleware order
- change Freeside
- add or change package/lockfile files
- add generated files
- add Railway config files
- include raw secrets, IDs, tokens, screenshots, or deployment credentials
- deploy Dixie
- claim Phase 41D smoke-test acceptance
