### PR TITLE
Phase 32H chore: add GitHub Packages auth for Railway builds

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,0 +1,5 @@
+# GitHub Packages auth for the @0xhoneyjar scope (build/install only).
+# The token is injected at build time via the NODE_AUTH_TOKEN env var.
+# No secret is stored in this file.
+@0xhoneyjar:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Summary

Phase 32H adds the minimal npm registry configuration needed for Railway builds to install private GitHub Packages dependencies used by Dixie.

Railway deployment reached `npm ci` and failed with a GitHub Packages 401 because the build environment did not have an npm registry config for the `@0xhoneyjar` scope. CI gets this config from setup-node, but Railway does not auto-generate it.

This PR adds `app/.npmrc` with GitHub Packages registry config and `NODE_AUTH_TOKEN` interpolation only. It does not store a token.

## Files

Added:

- app/.npmrc

Intentionally untouched:

- app/package.json
- app/package-lock.json
- runtime/source files
- generated files
- docs
- Railway config files
- Freeside repos or code

## Behavior

`app/.npmrc` configures:

- `@0xhoneyjar` packages to resolve through `https://npm.pkg.github.com`
- auth through `${NODE_AUTH_TOKEN}` at build/install time

The required token remains a Railway service environment variable. No secret is committed.

## Results

Local validation:

- git diff --check: passed
- app/.npmrc contains `NODE_AUTH_TOKEN` interpolation
- app/.npmrc contains no literal token
- npm run typecheck: passed
- npm run build: passed

Codex audit:

- VERDICT: ACCEPT
- Scope accepted as app/.npmrc only
- GitHub Packages auth config accepted
- No raw token/PAT/secret leak found
- app/.npmrc confirmed committable and not ignored

## Operational note

For Railway deployment to succeed, the `loa-dixie` Railway service must set `NODE_AUTH_TOKEN` to a GitHub token with package read access for the required `@0xhoneyjar` packages.

Do not paste or record the token in docs, PR comments, chat, logs, or committed files.

## Non-goals

This PR does not:

- deploy Dixie
- claim deployment acceptance
- add a JWT mint helper
- change recall-intake auth
- change middleware order
- change runtime source
- modify package or lockfiles
- add generated files
- change Freeside
- include raw secrets, PATs, tokens, IDs, screenshots, or deployment credentials
- claim Phase 41D smoke-test acceptance
