### PR TITLE
Phase 32I fix: package Dixie migration assets for deploy

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-migrations.mjs",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/app/scripts/copy-migrations.mjs
+++ b/app/scripts/copy-migrations.mjs
@@ -1,0 +1,62 @@
+/**
+ * copy-migrations.mjs — Build asset packaging for SQL migrations.
+ *
+ * `tsc` compiles only `.ts` sources and does not copy `.sql` assets. The
+ * migration runner (`src/db/migrate.ts`) resolves its migrations directory
+ * relative to the compiled file via `import.meta.url`, so at runtime
+ * `dist/db/migrate.js` scans `dist/db/migrations/`. Without this step that
+ * directory is absent and the app crashes on start with:
+ *   ENOENT: no such file or directory, scandir '/app/dist/db/migrations'
+ *
+ * This script mirrors `src/db/migrations/*.sql` into `dist/db/migrations/`
+ * after `tsc`, preserving the migrator's existing discovery semantics
+ * (including its `_down` filtering at runtime). It fails closed if the
+ * source migrations directory is missing.
+ *
+ * Run after `tsc` via the package `build` script.
+ */
+import { readdir, mkdir, copyFile, access } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = resolve(__dirname, '..', 'src', 'db', 'migrations');
+const DEST_DIR = resolve(__dirname, '..', 'dist', 'db', 'migrations');
+
+async function main() {
+  // Fail closed: the source migrations directory must exist.
+  try {
+    await access(SRC_DIR);
+  } catch {
+    throw new Error(
+      `copy-migrations: source migrations directory not found: ${SRC_DIR}`,
+    );
+  }
+
+  const entries = await readdir(SRC_DIR, { withFileTypes: true });
+  // Copy only SQL migration assets — the only files the migrator reads.
+  const sqlFiles = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.sql'))
+    .map((e) => e.name);
+
+  if (sqlFiles.length === 0) {
+    throw new Error(
+      `copy-migrations: no .sql migration files found in ${SRC_DIR}`,
+    );
+  }
+
+  await mkdir(DEST_DIR, { recursive: true });
+
+  for (const name of sqlFiles) {
+    await copyFile(join(SRC_DIR, name), join(DEST_DIR, name));
+  }
+
+  console.log(
+    `copy-migrations: copied ${sqlFiles.length} migration file(s) to ${DEST_DIR}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Phase 32I packages Dixie database migration SQL assets into the production build output expected by the compiled migrator.

After Phases 32G and 32H, Railway deploys reached runtime: `npm ci` passed, `npm run build` passed, and `npm run start` began. The app then connected to Postgres and crashed because the compiled migrator tried to scan `dist/db/migrations`, but TypeScript had not copied SQL migration assets there.

This PR adds a narrow build-time asset copy step. It does not change migration runtime semantics.

## Root cause

`app/src/db/migrate.ts` resolves migrations relative to the compiled module directory:

- source: `src/db/migrate.ts`
- compiled runtime: `dist/db/migrate.js`
- expected migration directory at runtime: `dist/db/migrations`

`tsc` compiles TypeScript but does not copy `.sql` assets, so `dist/db/migrations` was missing in Railway.

## Files

Added:

- app/scripts/copy-migrations.mjs

Modified:

- app/package.json

Intentionally untouched:

- app/package-lock.json
- app/src/db/migrate.ts
- recall-intake code
- JWT/admin auth
- middleware order
- Railway variables/config files
- Freeside repos or code
- generated `dist/` output

## Behavior

The build script now runs:

- `tsc && node scripts/copy-migrations.mjs`

The copy script:

- fails closed if `src/db/migrations` is missing
- fails closed if no `.sql` migration files are found
- creates `dist/db/migrations`
- copies all `.sql` files from `src/db/migrations` to `dist/db/migrations`
- preserves existing runtime filtering semantics, including the migrator's existing `_down` exclusion behavior

## Results

Local validation:

- git diff --check: passed
- npm run typecheck: passed
- npm run build: passed
- build copied 16 migration SQL files into `dist/db/migrations`
- source/dist SQL migration file lists matched exactly
- npx vitest run tests/unit/config.test.ts tests/unit/recall-intake/config-fail-closed.test.ts tests/unit/migrate.test.ts tests/unit/migration-safety.test.ts: passed, 4 files, 33 tests
- generated `dist/` remained ignored and not staged
- secret/raw-token scan: clean

Codex audit:

- VERDICT: ACCEPT
- Scope accepted as app/package.json plus app/scripts/copy-migrations.mjs
- Migration asset packaging accepted
- Runtime migration semantics unchanged
- Auth/JWT/recall-intake/middleware/Freeside/Railway variables untouched
- No package-lock change
- No dist committed
- No secret/raw-token leak found

## Non-goals

This PR does not:

- change migration semantics
- change recall-intake auth
- change JWT/admin auth
- change middleware order
- change Railway variables
- change Freeside
- add secrets, tokens, raw IDs, screenshots, or deployment credentials
- commit generated output
- claim deployment acceptance
- claim Phase 41D smoke-test acceptance
