### PR TITLE
Phase 32K feat: add dev seeded live estate recall

### DIFF
--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -80,7 +80,29 @@ export interface DixieConfig {
   recallIntakeMaxAssertionBytesPerTenant: number;
   recallIntakeIdempotencyTtlSec: number;
   recallIntakeIdempotencyMaxEntries: number;
+
+  // Phase 32K: dev/operator-only seeded live estate (default-off smoke).
+  // When enabled, the server seeds ONE synthetic dev/operator tenant slot
+  // into the process-local bounded estate store after createBoundedEstateStore
+  // so a direct POST /api/recall/intake smoke for that tenant can return a
+  // served recall instead of seam.storage_unavailable. dev/operator ONLY,
+  // never production admission. See
+  // docs/RECALL-WEDGE-SEEDED-LIVE-ESTATE-STORAGE-DESIGN.md §11 (Phase 32K).
+  recallIntakeDevSeedEnabled: boolean;
+  /** Synthetic dev/operator tenant id to seed (empty when disabled). */
+  recallIntakeDevSeedTenantId: string;
 }
+
+/**
+ * EVM-address-shaped tenant/session identity check.
+ *
+ * Phase 32K: the dev-seed tenant id must match the wallet/address format the
+ * recall-intake route's tenant/session identity uses (the JWT `sub` wallet,
+ * normalized via viem `getAddress` in the allowlist middleware). We validate
+ * the canonical `0x` + 40-hex shape at config load so an enabled-but-malformed
+ * seed fails closed at startup instead of silently seeding nothing.
+ */
+const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 
 /**
  * Environment variables:
@@ -120,6 +142,20 @@ export interface DixieConfig {
  * BILLING_INTERNAL_JWT_SECRET  (optional) — shared secret for S2S JWT to freeside settlement API
  * DIXIE_PRICING_API_URL        (optional) — freeside dynamic pricing API URL; null uses hardcoded rates
  * DIXIE_PRICING_TTL            (optional) — pricing cache TTL in seconds; default 300
+ *
+ * Phase 32K additions (dev/operator-only seeded live estate; default OFF):
+ * DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED   (optional) — when 'true', seed ONE synthetic
+ *                                          dev/operator tenant into the in-process bounded
+ *                                          estate store so a direct recall-intake smoke can
+ *                                          return a served recall. Default 'false'. Requires
+ *                                          DIXIE_RECALL_INTAKE_ENABLED=true. dev/operator
+ *                                          ONLY — never production memory admission.
+ * DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID (required when the dev seed is enabled) — synthetic
+ *                                          0x-prefixed 40-hex dev/operator wallet/address to
+ *                                          seed. Must match the recall-intake tenant/session
+ *                                          identity format. Enabled + missing/invalid → throws
+ *                                          at startup (fail-closed; never silently seed nothing).
+ *                                          Provide via env/secret — do NOT commit a live id.
  */
 export function loadConfig(): DixieConfig {
   const finnUrl = process.env.FINN_URL;
@@ -279,5 +315,39 @@ export function loadConfig(): DixieConfig {
       4_096,
       1_000_000,
     ),
+
+    // Phase 32K: dev/operator seeded live estate gate (default off; fail-closed
+    // at startup when enabled with a missing/invalid synthetic tenant id).
+    // Validation runs in the IIFE below; the parsed pair is spread in after.
+    ...(() => {
+      const enabled = process.env.DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED === 'true';
+      if (!enabled) {
+        return {
+          recallIntakeDevSeedEnabled: false,
+          recallIntakeDevSeedTenantId: '',
+        };
+      }
+      // The dev seed only makes sense when the recall route is mounted; an
+      // enabled seed without an enabled route would seed a store nothing
+      // reads. Fail closed rather than silently no-op.
+      const routeEnabled = process.env.DIXIE_RECALL_INTAKE_ENABLED === 'true';
+      if (!routeEnabled) {
+        throw new Error(
+          'DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED=true requires DIXIE_RECALL_INTAKE_ENABLED=true (Phase 32K dev/operator seed)',
+        );
+      }
+      const tenantId = (process.env.DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID ?? '').trim();
+      if (!EVM_ADDRESS_RE.test(tenantId)) {
+        // Do NOT echo the raw value — it may be operator-provided. Report the
+        // expected shape only.
+        throw new Error(
+          'DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED=true requires a valid DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID (0x + 40 hex chars); fail-closed (Phase 32K)',
+        );
+      }
+      return {
+        recallIntakeDevSeedEnabled: true,
+        recallIntakeDevSeedTenantId: tenantId,
+      };
+    })(),
   };
 }

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -31,6 +31,7 @@ import {
   createIdempotencyCache,
   createPerEstateMutex,
   createPerTenantRateLimit,
+  seedDevOperatorEstate,
 } from './services/straylight-recall-intake/index.js';
 import { createInMemoryIntakeDenyLog } from './services/straylight-host/index.js';
 import { FinnClient } from './proxy/finn-client.js';
@@ -569,6 +570,26 @@ export function createDixieApp(config: DixieConfig): DixieApp {
       maxAssertionsPerTenant: config.recallIntakeMaxAssertionsPerTenant,
       maxAssertionBytesPerTenant: config.recallIntakeMaxAssertionBytesPerTenant,
     });
+
+    // --- Phase 32K: dev/operator-only seeded live estate (default OFF) ---
+    // Narrow smoke mechanism only (see Phase 32J design gate, PR #116). When
+    // the dedicated dev-seed gate is enabled, seed exactly ONE synthetic
+    // dev/operator tenant slot here — after createBoundedEstateStore and
+    // before the store serves requests — so a direct POST /api/recall/intake
+    // for that tenant returns a served recall instead of
+    // seam.storage_unavailable. Idempotent (seedTenant replaces the slot);
+    // non-durable (lost on restart; re-seeded next startup). This seeds NO
+    // assertions, NEVER reads request/Discord/user input, stores NO secrets,
+    // and is NOT production memory admission. Config has already validated the
+    // synthetic tenant id format (fail-closed). The raw tenant id is NOT
+    // logged — only that the dev seed ran.
+    if (config.recallIntakeDevSeedEnabled) {
+      seedDevOperatorEstate(recallBoundedStore, config.recallIntakeDevSeedTenantId);
+      log('warn', {
+        event: 'recall_intake_dev_seed_active',
+        note: 'dev/operator seeded estate enabled — NOT production memory admission',
+      });
+    }
     const recallIdempotencyCache = createIdempotencyCache({
       ttlSec: config.recallIntakeIdempotencyTtlSec,
       maxEntries: config.recallIntakeIdempotencyMaxEntries,

--- a/app/src/services/straylight-recall-intake/dev-seeded-estate.ts
+++ b/app/src/services/straylight-recall-intake/dev-seeded-estate.ts
@@ -1,0 +1,161 @@
+// Phase 32K — dev/operator seeded live estate (default-off smoke mechanism).
+//
+// Phase 32J (PR #116, docs/RECALL-WEDGE-SEEDED-LIVE-ESTATE-STORAGE-DESIGN.md)
+// established that a live Dixie `POST /api/recall/intake` reaches the
+// Straylight seam but returns `seam.storage_unavailable` because the
+// process-local bounded estate store has no seeded tenant slot. Phase 32J
+// recommended the narrowest safe path: a dev/operator-only, default-off,
+// idempotent, in-process `seedTenant` seed wired near the recall-intake
+// mount in `server.ts`, using the `served-path.test.ts` seed shape as the
+// canonical real-runtime reference. This module is that helper.
+//
+// SCOPE / NON-GOALS (carried verbatim from the Phase 32J design gate):
+//   * dev/operator ONLY — never a user-facing or public write path;
+//   * default-OFF — only runs when the dedicated env gate is enabled;
+//   * idempotent — `seedTenant` replaces the tenant slot, so re-seeding the
+//     same tenant on every process startup is a no-op-equivalent overwrite;
+//   * NO production memory admission, NO Discord/Telegram ingestion, NO
+//     "remember this" / candidate-memory write, NO public rollout;
+//   * NO secrets, private keys, live IDs, tokens, URLs, or signatures are
+//     stored. The seed carries only synthetic signer/keyring METADATA. The
+//     `dev_signature` a caller presents at request time is computed by the
+//     CALLER (HMAC_SHA256 over the canonical recall payload, keyed by the
+//     PUBLIC `key_ref` label below) and is NEVER persisted here — see
+//     `@loa/straylight` `signatures.ts#verifyEnvelopeSelfConsistency`, which
+//     checks only the envelope's internal consistency, not key custody. The
+//     `dev_signature` type is explicitly marked DEVELOPMENT-ONLY upstream
+//     and carries no cryptographic authority.
+//
+// Import discipline (mirrors `bounded-estate-store.ts`): type-only imports
+// from `@loa/straylight` are safe under ADR-026A §"Decision" §5. This module
+// performs NO runtime value import from Straylight; it only constructs
+// plain data objects and calls the Dixie-local `BoundedEstateStore.seedTenant`.
+
+import type { Actor, ActorEstate, Keyring, SignerType } from '@loa/straylight';
+import type { BoundedEstateStore } from './bounded-estate-store.js';
+
+// ── Synthetic, public-safe seed identity ─────────────────────────────────────
+//
+// These are PUBLIC labels, not secrets. They are exported so a dev/operator
+// caller (and the Phase 32K tests) can construct a self-consistent
+// `dev_signature` whose `signer_id` / `signer_type` / `key_ref` match the
+// seeded keyring. Reusing these constants keeps the seed and the caller in
+// lockstep without copying seed shape into tests or importing test material
+// into production source.
+//
+// `DEV_SEED_KEY_REF` is the HMAC key label the caller signs with. It is a
+// synthetic dev-only identifier — NOT a private key, NOT live key material.
+export const DEV_SEED_SIGNER_ID = 'signer:dixie-dev-seeded-operator';
+export const DEV_SEED_SIGNER_TYPE: SignerType = 'actor_controller';
+export const DEV_SEED_KEY_REF = 'dev-seed-key:dixie-operator-smoke';
+
+// Fixed, synthetic timestamps. `valid_from` is far enough in the past that
+// the seeded signer is currently-valid under any real wall clock
+// (`isSignerCurrentlyValid` rejects `now < valid_from`). The recall path does
+// NOT enforce a timelock or `valid_until` for `recall_estate_context`, so a
+// stable past `valid_from` is sufficient and keeps the seed fully
+// deterministic across process restarts.
+export const DEV_SEED_VALID_FROM = '2020-01-01T00:00:00.000Z';
+const DEV_SEED_CREATED_AT = '2020-01-01T00:00:00.000Z';
+
+// Competence vocabulary for the served recall path. Mirrors the canonical
+// `served-path.test.ts` seed: a single `recall_estate_context` rule whose
+// `required_signer_roles` admits the seeded signer's role. No quorum, no
+// timelock, no human-review requirement — a low-risk private-frame recall by
+// the actor's own controller is an `allow`.
+const DEV_SEED_REQUIRED_ROLES: SignerType[] = [
+  DEV_SEED_SIGNER_TYPE,
+  'operator',
+  'runtime',
+  'reviewer',
+];
+
+export interface DevSeedMaterial {
+  actor: Actor;
+  estate: ActorEstate;
+  keyring: Keyring;
+}
+
+/**
+ * Build deterministic, synthetic, public-safe seed material for one
+ * dev/operator tenant. All ids are derived from `tenantId` so the seed is
+ * stable across restarts; no live identifiers, secrets, or signatures are
+ * present. The estate/actor/keyring ids that the recall seam reads
+ * (`estate_id`, `actor_id`, `keyring_id`) are bound to `tenantId` because the
+ * route enforces `request.actor_id === request.estate_id === session wallet`,
+ * and the bounded store scopes every write to the bound estate.
+ */
+export function buildDevSeedMaterial(tenantId: string): DevSeedMaterial {
+  const keyringId = `kr:dev-seed:${tenantId}`;
+
+  const actor: Actor = {
+    actor_id: tenantId,
+    actor_type: 'agent',
+    estate_id: tenantId,
+    keyring_id: keyringId,
+    status: 'active',
+    controller_refs: [tenantId],
+    schema_version: '0.1.0',
+    created_at: DEV_SEED_CREATED_AT,
+    updated_at: DEV_SEED_CREATED_AT,
+  };
+
+  const estate: ActorEstate = {
+    estate_id: tenantId,
+    actor_id: tenantId,
+    schema_version: '0.1.0',
+    status: 'active',
+    assertion_index_ref: `index:dev-seed:${tenantId}`,
+    keyring_id: keyringId,
+    policy_id: 'straylight.default-agent-estate.v0',
+    audit_log_ref: `audit:dev-seed:${tenantId}`,
+    created_at: DEV_SEED_CREATED_AT,
+    updated_at: DEV_SEED_CREATED_AT,
+  };
+
+  const keyring: Keyring = {
+    keyring_id: keyringId,
+    actor_id: tenantId,
+    estate_id: tenantId,
+    version: '0.1.0',
+    signer_entries: [
+      {
+        signer_id: DEV_SEED_SIGNER_ID,
+        signer_type: DEV_SEED_SIGNER_TYPE,
+        key_ref: DEV_SEED_KEY_REF,
+        status: 'active',
+        valid_from: DEV_SEED_VALID_FROM,
+        scopes: [`estate:${tenantId}`],
+      },
+    ],
+    competence_rules: [
+      {
+        rule_id: 'rule:dixie-dev-seed-recall-default',
+        transition_type: 'recall_estate_context',
+        required_signer_roles: DEV_SEED_REQUIRED_ROLES,
+      },
+    ],
+    revoked_key_refs: [],
+    created_at: DEV_SEED_CREATED_AT,
+    updated_at: DEV_SEED_CREATED_AT,
+  };
+
+  return { actor, estate, keyring };
+}
+
+/**
+ * Seed exactly one explicitly-configured dev/operator tenant into the
+ * process-local bounded estate store. Idempotent: `seedTenant` replaces the
+ * slot, so calling this on every startup (or more than once) leaves a single,
+ * empty (zero-assertion) seeded estate. Seeds NO assertions — a served recall
+ * over an empty estate returns an `allow` pack with `included: []`, which is
+ * the dev/operator smoke target. This NEVER seeds arbitrary tenants, NEVER
+ * reads request/Discord/user input, and NEVER admits production memory.
+ */
+export function seedDevOperatorEstate(
+  store: BoundedEstateStore,
+  tenantId: string,
+): void {
+  const { actor, estate, keyring } = buildDevSeedMaterial(tenantId);
+  store.seedTenant({ tenant_id: tenantId, actor, estate, keyring });
+}

--- a/app/src/services/straylight-recall-intake/index.ts
+++ b/app/src/services/straylight-recall-intake/index.ts
@@ -30,6 +30,17 @@ export {
   type MinimalRecallStore,
 } from './bounded-estate-store.js';
 
+// Phase 32K — dev/operator-only seeded live estate (default-off smoke).
+export {
+  buildDevSeedMaterial,
+  seedDevOperatorEstate,
+  DEV_SEED_SIGNER_ID,
+  DEV_SEED_SIGNER_TYPE,
+  DEV_SEED_KEY_REF,
+  DEV_SEED_VALID_FROM,
+  type DevSeedMaterial,
+} from './dev-seeded-estate.js';
+
 export {
   createIdempotencyCache,
   type IdempotencyCache,

--- a/app/src/services/straylight-recall-intake/refusal-mapping.ts
+++ b/app/src/services/straylight-recall-intake/refusal-mapping.ts
@@ -173,13 +173,40 @@ export function mapSeamResponseToRefusal(
   const m = reasonMap[response.reason];
   const cls: RefusalClass = m ? m.cls : 'seam.storage_unavailable';
   const status: RefusalEnvelope['http_status'] = m ? m.status : 503;
+
+  // Phase 32K — sanitize public storage / internal-seam denial bodies.
+  //
+  // `storage_unavailable` is the ONE denial class whose seam `raw_reasons`
+  // is an UNCONTROLLED exception message rather than public Straylight
+  // vocabulary, so its raw reasons must never reach the public HTTP body:
+  //   * producer A — unseeded tenant: the Straylight host try/catch
+  //     (`@loa/straylight/.../host/intake.js`) coerces the bounded store's
+  //     `getKeyring()` throw into `reason:'storage_unavailable'` with
+  //     `raw_reasons:[err.message]`, where `err.message` carries the
+  //     bounded-store implementation text AND the raw tenant id
+  //     (`bounded-estate-store: no slot for tenant <id>`);
+  //   * producer C — the Dixie route internal-error fallback
+  //     (`routes/recall-intake.ts`) synthesizes
+  //     `raw_reasons:['runtime_seam:internal:' + err.message]`.
+  // Both are dropped from the public `body` here and retained ONLY on the
+  // internal `audit` object below (no new logging system is introduced —
+  // the existing emitAudit/intake-deny trail keeps the raw reason). The
+  // public message is a fixed, classification-only string. Every OTHER
+  // denial class keeps its public `raw_reasons` (public wedge vocabulary —
+  // the Phase 32D denied-no-leak contract).
+  const isInternalSeamFailure = cls === 'seam.storage_unavailable';
   return {
     http_status: status,
     body: {
       outcome: 'denied',
       error: cls,
-      message: `seam denial: ${response.reason}`,
-      raw_reasons: response.raw_reasons,
+      message: isInternalSeamFailure
+        ? 'recall storage unavailable'
+        : `seam denial: ${response.reason}`,
+      // Omit the key entirely (not just empty) for internal-seam failures so
+      // the public wire body contains neither the `raw_reasons` key nor any
+      // bounded-store / tenant / internal-seam text.
+      ...(isInternalSeamFailure ? {} : { raw_reasons: response.raw_reasons }),
       audit_event_id: response.audit_event_id,
       intake_log_entry_id: response.intake_log_entry_id,
     },

--- a/app/tests/integration/recall-intake/dev-seeded-live-estate.test.ts
+++ b/app/tests/integration/recall-intake/dev-seeded-live-estate.test.ts
@@ -1,0 +1,550 @@
+// Phase 32K — dev/operator seeded live estate, end-to-end through the real
+// Dixie app and the REAL Straylight runtime (no `vi.mock` of
+// handleRecallIntake).
+//
+// Phase 32J (PR #116) established that a live recall-intake reaches the
+// Straylight seam but returns `seam.storage_unavailable` because the
+// process-local bounded estate store has no seeded tenant slot. Phase 32K
+// wires a default-off, dev/operator-only, idempotent in-process seed after
+// createBoundedEstateStore. This test proves the seam returns a served
+// recall for the seeded tenant through the production route + middleware
+// stack, while every fail-closed guarantee is preserved.
+//
+// Canonical seed reference (Phase 32J correction): the real-runtime served
+// seed shape is `served-path.test.ts` (buildSeedMaterial + seedTenant
+// against the real Straylight runtime). Phase 32B/32C are the additional
+// mocked-seam served pass-through / replay proofs. This test deliberately
+// exercises the REAL runtime via the real seed helper — it does NOT mock the
+// seam — so a green run is the live-equivalent served proof for the seeded
+// dev/operator tenant.
+//
+// The `dev_signature` is computed HERE by the caller (the role a real
+// dev/operator caller plays) using the PUBLIC `DEV_SEED_KEY_REF` label
+// exported by the seed helper. No secret is stored in the seed or this test.
+// The dev-sign algorithm is reproduced locally with node:crypto, mirroring
+// `@loa/straylight` signatures.ts/canonical.ts (the same approach
+// served-path.test.ts uses) so this file takes no extra Straylight runtime
+// value import.
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { serve } from '@hono/node-server';
+import { createHash, createHmac } from 'node:crypto';
+import * as jose from 'jose';
+import { createDixieApp, type DixieApp } from '../../../src/server.js';
+import type { DixieConfig } from '../../../src/config.js';
+import {
+  DEV_SEED_KEY_REF,
+  DEV_SEED_SIGNER_ID,
+  DEV_SEED_SIGNER_TYPE,
+} from '../../../src/services/straylight-recall-intake/index.js';
+import type { RecallPack, RecallReceipt } from '@loa/straylight';
+
+// ── Synthetic, public-safe identities (no live ids/secrets) ─────────────────
+const JWT_SECRET = 'phase-32k-dev-seed-jwt-secret-32chars!!';
+const RUNTIME_KEY = 'phase-32k-runtime-dixie-key-32-bytes-aa';
+// Seeded dev/operator tenant. Synthetic 0x + 40 hex, ALL-LOWERCASE so viem's
+// getAddress() (used by the allowlist gate) accepts and re-checksums it
+// without throwing on a bad mixed-case checksum. The JWT `sub`, the route's
+// `x-wallet-address`, the body caller/actor/estate ids, and the seed tenant
+// id are all this exact lowercase string, so every exact-string comparison
+// (route tenant override, bounded-store slot key) lines up. UNSEEDED_TENANT
+// is genuinely unseeded for the negative case below.
+const SEEDED_TENANT = '0xabcdef0000000000000000000000000000000032';
+const UNSEEDED_TENANT = '0xabcdef0000000000000000000000000000000099';
+const CROSS_TENANT = '0xabcdef0000000000000000000000000000000077';
+
+// ── Local re-implementation of the Straylight dev-sign algorithm ────────────
+// (read-only mirror of signatures.ts/canonical.ts; not a value import).
+function canonicalize(v: unknown): string {
+  if (v === null) return 'null';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'number') {
+    if (!Number.isFinite(v)) throw new Error('canonicalize: non-finite number');
+    return JSON.stringify(v);
+  }
+  if (typeof v === 'string') return JSON.stringify(v);
+  if (Array.isArray(v)) return '[' + v.map(canonicalize).join(',') + ']';
+  if (typeof v === 'object') {
+    const obj = v as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    const parts: string[] = [];
+    for (const k of keys) {
+      const child = obj[k];
+      if (child === undefined) continue;
+      parts.push(JSON.stringify(k) + ':' + canonicalize(child));
+    }
+    return '{' + parts.join(',') + '}';
+  }
+  throw new Error(`canonicalize: unsupported type ${typeof v}`);
+}
+function sha256Of(value: unknown): string {
+  const bytes = typeof value === 'string' ? value : canonicalize(value);
+  return 'sha256:' + createHash('sha256').update(bytes).digest('hex');
+}
+function devSignatureFor(keyRef: string, payloadHash: string): string {
+  return `dev:${createHmac('sha256', keyRef).update(payloadHash).digest('hex')}`;
+}
+
+// Build a fully self-consistent wedge-aligned recall-intake body. `actor_id`,
+// `estate_id`, caller.* are all bound to `wallet` (the route's authoritative
+// tenant override requires this). The signature is computed by the caller —
+// no stored secret.
+function buildSignedBody(opts: {
+  wallet: string;
+  requestId: string;
+  task: string;
+  signerId?: string;
+  signerType?:
+    | 'actor_controller'
+    | 'operator'
+    | 'runtime'
+    | 'reviewer'
+    | 'policy_service'
+    | 'admin'
+    | 'wallet'
+    | 'service_key';
+  keyRef?: string;
+}) {
+  const signerId = opts.signerId ?? DEV_SEED_SIGNER_ID;
+  const signerType = opts.signerType ?? DEV_SEED_SIGNER_TYPE;
+  const keyRef = opts.keyRef ?? DEV_SEED_KEY_REF;
+  const payload = {
+    actor_id: opts.wallet,
+    estate_id: opts.wallet,
+    task: opts.task,
+    environment_frame: 'private_chat',
+    risk_profile: 'low',
+  };
+  const signed_payload_hash = sha256Of(payload);
+  const signature = devSignatureFor(keyRef, signed_payload_hash);
+  return {
+    request: {
+      recall_request_id: opts.requestId,
+      actor_id: opts.wallet,
+      estate_id: opts.wallet,
+      requested_by: opts.wallet,
+      task: opts.task,
+      environment_frame: 'private_chat' as const,
+      risk_profile: 'low' as const,
+      include_receipt_detail: 'standard' as const,
+      signature: {
+        signature_id: 'sig_phase32k',
+        signer_id: signerId,
+        signer_type: signerType,
+        signature_type: 'dev_signature' as const,
+        signed_payload_hash,
+        signature,
+        signed_at: '2026-05-30T00:00:00.000Z',
+        key_ref: keyRef,
+      },
+      created_at: '2026-05-30T00:00:00.000Z',
+    },
+    detail_level: 'standard' as const,
+    caller: { tenant_id: opts.wallet, actor_id: opts.wallet },
+  };
+}
+
+async function mintJwt(wallet: string): Promise<string> {
+  const secret = new TextEncoder().encode(JWT_SECRET);
+  return new jose.SignJWT({ sub: wallet, tier: 'free' })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setIssuer('dixie-bff')
+    .setAudience('dixie-bff')
+    .sign(secret);
+}
+
+async function mintExpiredJwt(wallet: string): Promise<string> {
+  const secret = new TextEncoder().encode(JWT_SECRET);
+  return new jose.SignJWT({ sub: wallet })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
+    .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
+    .setIssuer('dixie-bff')
+    .setAudience('dixie-bff')
+    .sign(secret);
+}
+
+// ── Mock loa-finn (only health is touched in these tests) ───────────────────
+function createMockFinn(): Hono {
+  const mock = new Hono();
+  mock.get('/api/health', (c) => c.json({ status: 'ok', version: '1.0.0-mock' }));
+  return mock;
+}
+
+function baseConfig(finnPort: number): DixieConfig {
+  return {
+    port: 3599,
+    finnUrl: `http://localhost:${finnPort}`,
+    finnWsUrl: `ws://localhost:${finnPort}`,
+    corsOrigins: ['*'],
+    allowlistPath: '',
+    adminKey: 'phase-32k-admin-key',
+    jwtPrivateKey: JWT_SECRET,
+    jwtAlgorithm: 'HS256',
+    jwtLegacyHs256Secret: null,
+    nodeEnv: 'test',
+    logLevel: 'error',
+    rateLimitRpm: 1000,
+    otelEndpoint: null,
+    databaseUrl: null,
+    redisUrl: null,
+    natsUrl: null,
+    memoryProjectionTtlSec: 300,
+    memoryMaxEventsPerQuery: 100,
+    convictionTierTtlSec: 300,
+    personalityTtlSec: 1800,
+    autonomousPermissionTtlSec: 300,
+    autonomousBudgetDefaultMicroUsd: 100_000,
+    databasePoolSize: 10,
+    rateLimitBackend: 'memory',
+    scheduleCallbackSecret: 'phase-32k-callback-secret',
+    x402Enabled: false,
+    x402FacilitatorUrl: null,
+    billingJwtSecret: null,
+    pricingApiUrl: null,
+    pricingTtlSec: 300,
+    recallIntakeEnabled: true,
+    straylightRuntimeDixieKey: RUNTIME_KEY,
+    recallIntakeBodyMaxBytes: 32_768,
+    recallIntakeRateRpm: 1000,
+    recallIntakeMaxAssertionsPerTenant: 512,
+    recallIntakeMaxAssertionBytesPerTenant: 1_048_576,
+    recallIntakeIdempotencyTtlSec: 900,
+    recallIntakeIdempotencyMaxEntries: 4_096,
+    // Phase 32K dev seed defaults (overridden per-suite below).
+    recallIntakeDevSeedEnabled: false,
+    recallIntakeDevSeedTenantId: '',
+  };
+}
+
+let mockFinnServer: ReturnType<typeof serve>;
+const MOCK_FINN_PORT = 14800 + Math.floor(Math.random() * 700);
+
+beforeAll(() => {
+  mockFinnServer = serve({ fetch: createMockFinn().fetch, port: MOCK_FINN_PORT });
+});
+afterAll(() => {
+  mockFinnServer?.close();
+});
+
+// The capability holder reads STRAYLIGHT_RUNTIME_DIXIE_KEY from env at mint
+// time (per-request). Set it for the whole suite.
+beforeEach(() => {
+  process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY = RUNTIME_KEY;
+});
+afterEach(() => {
+  delete process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY;
+});
+
+function buildSeededApp(): DixieApp {
+  const config: DixieConfig = {
+    ...baseConfig(MOCK_FINN_PORT),
+    recallIntakeDevSeedEnabled: true,
+    recallIntakeDevSeedTenantId: SEEDED_TENANT,
+  };
+  const app = createDixieApp(config);
+  // Allowlist the seeded + unseeded + cross tenants so requests clear the
+  // allowlist gate and reach the recall route (the route's own
+  // tenant/seed/seam logic is what's under test, not the allowlist).
+  app.allowlistStore.addEntry('wallet', SEEDED_TENANT);
+  app.allowlistStore.addEntry('wallet', UNSEEDED_TENANT);
+  app.allowlistStore.addEntry('wallet', CROSS_TENANT);
+  return app;
+}
+
+async function postRecall(
+  app: DixieApp,
+  jwt: string | null,
+  body: unknown,
+  idempotencyKey: string,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'idempotency-key': idempotencyKey,
+  };
+  if (jwt) headers.authorization = `Bearer ${jwt}`;
+  return app.app.request('/api/recall/intake', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+// Private fingerprints that must never appear on the served wire surface.
+// (The served envelope for an empty seeded estate carries no tenant payload;
+// these guard against any future regression that echoes internals.)
+const NO_LEAK_TOKENS = [
+  'no slot for tenant',
+  'bounded-estate-store',
+  'BoundedStore',
+  'runtime_seam:',
+  'getKeyring',
+  RUNTIME_KEY,
+  JWT_SECRET,
+  DEV_SEED_KEY_REF,
+];
+
+// Phase 32K — internal/store fingerprints that must never appear on an
+// UNSEEDED / default-off `503` storage_unavailable denial body. Before this
+// patch the host coerced the bounded store's `getKeyring()` throw into
+// `raw_reasons:['bounded-estate-store: no slot for tenant <tenant_id>']`
+// (producer A), and the route internal fallback into
+// `raw_reasons:['runtime_seam:internal:<message>']` (producer C); both were
+// forwarded verbatim into the public body via refusal-mapping. The public
+// body must now expose neither the `raw_reasons` key nor any of these
+// tokens — including the raw tenant ids, which are the request identities
+// the unseeded throw embeds.
+const DENIAL_NO_LEAK_TOKENS = [
+  'raw_reasons',
+  'bounded-estate-store',
+  'BoundedStore',
+  'no slot for tenant',
+  'runtime_seam:internal',
+  'runtime_seam:',
+  'getKeyring',
+  'stack',
+  'at Object.',
+  '.ts:',
+  SEEDED_TENANT,
+  UNSEEDED_TENANT,
+  CROSS_TENANT,
+  RUNTIME_KEY,
+  JWT_SECRET,
+  DEV_SEED_KEY_REF,
+];
+
+// Assert an unseeded/default-off storage_unavailable denial leaks no raw
+// reasons, bounded-store detail, tenant material, or internal seam/debug
+// text — on BOTH the parsed JSON shape and the raw wire text.
+function expectStorageDenialIsSanitized(
+  bodyText: string,
+  body: Record<string, unknown>,
+): void {
+  // No raw_reasons key at all on the public body (omitted, not empty).
+  expect(body.raw_reasons).toBeUndefined();
+  expect(Object.prototype.hasOwnProperty.call(body, 'raw_reasons')).toBe(false);
+  // The public message is classification-only — not the bounded-store throw.
+  expect(typeof body.message).toBe('string');
+  // Wire-text scan: none of the internal/store/tenant fingerprints survive.
+  for (const tok of DENIAL_NO_LEAK_TOKENS) {
+    expect(bodyText).not.toContain(tok);
+  }
+  // No JWT/token material and no stack-ish frames.
+  expect(bodyText).not.toMatch(/eyJ[A-Za-z0-9_-]+\./);
+}
+
+describe('Phase 32K — dev/operator seeded live estate (real route + real seam)', () => {
+  it('seeded tenant returns HTTP 200 served/allow recall through the real route', async () => {
+    const app = buildSeededApp();
+    const jwt = await mintJwt(SEEDED_TENANT);
+    const body = buildSignedBody({
+      wallet: SEEDED_TENANT,
+      requestId: 'rreq_phase32k_served',
+      task: 'phase-32k-dev-seed-smoke',
+    });
+    const res = await postRecall(app, jwt, body, 'phase-32k-served-1');
+
+    expect(res.status).toBe(200);
+    const j = (await res.json()) as {
+      outcome: string;
+      pack?: RecallPack;
+      receipt?: RecallReceipt;
+    };
+    // Served / governed recall through the REAL Straylight runtime.
+    expect(j.outcome).toBe('served');
+    expect(j.pack).toBeDefined();
+    expect(j.receipt).toBeDefined();
+    expect(j.pack?.policy_decision.decision).toBe('allow');
+    expect(j.pack?.actor_id).toBe(SEEDED_TENANT);
+    expect(j.pack?.estate_id).toBe(SEEDED_TENANT);
+    // Empty seeded estate → nothing included/marked.
+    expect(j.pack?.included).toEqual([]);
+    expect(j.pack?.marked).toEqual([]);
+    expect(j.pack?.pack_hash?.startsWith('sha256:')).toBe(true);
+    expect(j.receipt?.pack_hash).toBe(j.pack?.pack_hash);
+    expect(j.receipt?.receipt_hash?.startsWith('sha256:')).toBe(true);
+  });
+
+  it('seed is idempotent / safe to initialize more than once', async () => {
+    // Two independent app instances seed the same synthetic tenant on
+    // construction; both must serve identically. This models re-seeding on
+    // process restart (the seed replaces the slot — no duplication, no throw).
+    const a = buildSeededApp();
+    const b = buildSeededApp();
+    const jwt = await mintJwt(SEEDED_TENANT);
+    const body = buildSignedBody({
+      wallet: SEEDED_TENANT,
+      requestId: 'rreq_phase32k_idem',
+      task: 'phase-32k-idempotent',
+    });
+    const r1 = await postRecall(a, jwt, body, 'phase-32k-idem-a');
+    const r2 = await postRecall(b, jwt, body, 'phase-32k-idem-b');
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    const j1 = (await r1.json()) as { outcome: string; pack?: RecallPack };
+    const j2 = (await r2.json()) as { outcome: string; pack?: RecallPack };
+    // Re-seeding the same synthetic tenant on a second startup is safe: no
+    // throw, no duplication, and the seeded estate serves an identical
+    // governed-recall SHAPE. (pack_hash itself is content-addressed over the
+    // request-time `now`, which the production server path does not pin, so
+    // hashes legitimately differ across instants — the seed identity, not the
+    // wall clock, is what must be stable.)
+    expect(j1.outcome).toBe('served');
+    expect(j2.outcome).toBe('served');
+    expect(j1.pack?.policy_decision.decision).toBe('allow');
+    expect(j2.pack?.policy_decision.decision).toBe('allow');
+    expect(j1.pack?.actor_id).toBe(SEEDED_TENANT);
+    expect(j2.pack?.actor_id).toBe(SEEDED_TENANT);
+    expect(j1.pack?.estate_id).toBe(SEEDED_TENANT);
+    expect(j2.pack?.estate_id).toBe(SEEDED_TENANT);
+    expect(j1.pack?.included).toEqual([]);
+    expect(j2.pack?.included).toEqual([]);
+    expect(j1.pack?.marked).toEqual([]);
+    expect(j2.pack?.marked).toEqual([]);
+  });
+
+  it('re-seeding the SAME store instance is a safe no-op-equivalent overwrite', async () => {
+    // Direct seed-helper idempotency: seeding the same tenant twice on one
+    // store must not throw and must leave a single empty estate (zero
+    // assertions), confirming seedTenant replaces (not appends to) the slot.
+    const { createBoundedEstateStore, seedDevOperatorEstate } = await import(
+      '../../../src/services/straylight-recall-intake/index.js'
+    );
+    const store = createBoundedEstateStore({
+      maxAssertionsPerTenant: 512,
+      maxAssertionBytesPerTenant: 1_048_576,
+    });
+    seedDevOperatorEstate(store, SEEDED_TENANT);
+    seedDevOperatorEstate(store, SEEDED_TENANT);
+    const footprint = store.inspectTenant(SEEDED_TENANT);
+    expect(footprint.assertions).toBe(0);
+    expect(footprint.bytes).toBe(0);
+  });
+
+  it('served wire body leaks no secrets/internals/tenant-debug material', async () => {
+    const app = buildSeededApp();
+    const jwt = await mintJwt(SEEDED_TENANT);
+    const body = buildSignedBody({
+      wallet: SEEDED_TENANT,
+      requestId: 'rreq_phase32k_noleak',
+      task: 'phase-32k-no-leak',
+    });
+    const res = await postRecall(app, jwt, body, 'phase-32k-noleak-1');
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    for (const tok of NO_LEAK_TOKENS) {
+      expect(text).not.toContain(tok);
+    }
+    // No JWT/token material, no raw assertion-store internals, no stack
+    // traces. (Note: the served receipt's `filters_applied` legitimately
+    // contains the frame token "private_chat" — that is public wedge
+    // vocabulary, not private payload — so we do NOT blanket-ban "private".)
+    expect(text).not.toMatch(/eyJ[A-Za-z0-9_-]+\./); // no JWT
+    expect(text).not.toContain('at Object.');
+    expect(text).not.toContain('.ts:');
+  });
+
+  it('UNSEEDED tenant still returns safe seam.storage_unavailable (503)', async () => {
+    const app = buildSeededApp();
+    const jwt = await mintJwt(UNSEEDED_TENANT);
+    const body = buildSignedBody({
+      wallet: UNSEEDED_TENANT,
+      requestId: 'rreq_phase32k_unseeded',
+      task: 'phase-32k-unseeded',
+    });
+    const res = await postRecall(app, jwt, body, 'phase-32k-unseeded-1');
+    // Producer (A) from Phase 32J §2: unseeded slot → getKeyring throws →
+    // host coerces to storage_unavailable → 503 refusal. Preserved exactly.
+    expect(res.status).toBe(503);
+    const bodyText = await res.text();
+    const j = JSON.parse(bodyText) as { outcome: string; error: string };
+    expect(j.outcome).toBe('denied');
+    expect(j.error).toBe('seam.storage_unavailable');
+    // Critically: a served pack/receipt MUST NOT appear for an unseeded
+    // tenant even though another tenant is seeded in the same store.
+    expect((j as { pack?: unknown }).pack).toBeUndefined();
+    expect((j as { receipt?: unknown }).receipt).toBeUndefined();
+    // Phase 32K — the public denial body must NOT forward the host's
+    // bounded-store throw text (which embeds the raw tenant id) nor any
+    // internal seam/debug material. raw_reasons is sanitized out entirely.
+    expectStorageDenialIsSanitized(bodyText, j as Record<string, unknown>);
+  });
+
+  it('unauthenticated recall-intake still fails closed (401)', async () => {
+    const app = buildSeededApp();
+    const body = buildSignedBody({
+      wallet: SEEDED_TENANT,
+      requestId: 'rreq_phase32k_noauth',
+      task: 'phase-32k-noauth',
+    });
+    const res = await postRecall(app, null, body, 'phase-32k-noauth-1');
+    // No JWT → JWT middleware sets no wallet → allowlist gate returns 401
+    // before the route runs. Fail-closed; no served body.
+    expect(res.status).toBe(401);
+  });
+
+  it('expired token still fails closed (401, unchanged)', async () => {
+    const app = buildSeededApp();
+    const jwt = await mintExpiredJwt(SEEDED_TENANT);
+    const body = buildSignedBody({
+      wallet: SEEDED_TENANT,
+      requestId: 'rreq_phase32k_expired',
+      task: 'phase-32k-expired',
+    });
+    const res = await postRecall(app, jwt, body, 'phase-32k-expired-1');
+    // Expired JWT → no wallet set → allowlist gate 401. No served body.
+    expect(res.status).toBe(401);
+  });
+
+  it('cross-tenant body mismatch still returns 403 (authoritative override)', async () => {
+    const app = buildSeededApp();
+    // Authenticate as CROSS_TENANT but address the seeded tenant in the body.
+    const jwt = await mintJwt(CROSS_TENANT);
+    const body = buildSignedBody({
+      wallet: SEEDED_TENANT, // body claims the seeded tenant
+      requestId: 'rreq_phase32k_cross',
+      task: 'phase-32k-cross-tenant',
+    });
+    const res = await postRecall(app, jwt, body, 'phase-32k-cross-1');
+    expect(res.status).toBe(403);
+    const j = (await res.json()) as { error: string };
+    expect(j.error).toBe('ingress.cross_tenant_body_mismatch');
+    // The mismatch must be rejected at ingress BEFORE any seam/seed work —
+    // the attacker must not borrow the seeded tenant's served estate.
+    expect((j as { pack?: unknown }).pack).toBeUndefined();
+  });
+});
+
+describe('Phase 32K — default-off preserves the current unseeded failure path', () => {
+  function buildUnseededApp(): DixieApp {
+    // Dev seed DISABLED (default). Recall route still mounted.
+    const app = createDixieApp(baseConfig(MOCK_FINN_PORT));
+    app.allowlistStore.addEntry('wallet', SEEDED_TENANT);
+    return app;
+  }
+
+  it('with the dev seed OFF, the SAME tenant returns seam.storage_unavailable', async () => {
+    const app = buildUnseededApp();
+    const jwt = await mintJwt(SEEDED_TENANT);
+    const body = buildSignedBody({
+      wallet: SEEDED_TENANT,
+      requestId: 'rreq_phase32k_off',
+      task: 'phase-32k-default-off',
+    });
+    const res = await postRecall(app, jwt, body, 'phase-32k-off-1');
+    // No seed → exact pre-Phase-32K behavior: 503 storage_unavailable.
+    expect(res.status).toBe(503);
+    const bodyText = await res.text();
+    const j = JSON.parse(bodyText) as { outcome: string; error: string };
+    expect(j.outcome).toBe('denied');
+    expect(j.error).toBe('seam.storage_unavailable');
+    expect((j as { pack?: unknown }).pack).toBeUndefined();
+    // Phase 32K — default-off denial body is sanitized identically: no raw
+    // reasons, no bounded-store detail, no tenant material, no internal seam
+    // text. The safe status + classification are preserved.
+    expectStorageDenialIsSanitized(bodyText, j as Record<string, unknown>);
+  });
+});

--- a/app/tests/unit/recall-intake/dev-seeded-estate-config.test.ts
+++ b/app/tests/unit/recall-intake/dev-seeded-estate-config.test.ts
@@ -1,0 +1,112 @@
+// Phase 32K — dev/operator seeded live estate config gate.
+//
+// Mirrors the fail-closed posture of config-fail-closed.test.ts for the
+// recall route key. The dev-seed gate is default-OFF; when enabled it
+// requires DIXIE_RECALL_INTAKE_ENABLED=true and a valid synthetic
+// 0x-prefixed 40-hex tenant id, and fails closed (throws at loadConfig)
+// otherwise — it must never silently seed nothing.
+//
+// dev/operator-only smoke mechanism. NOT production memory admission. No
+// live ids/secrets appear in this test; the tenant id below is a synthetic,
+// public-safe address.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../../../src/config.js';
+
+const REQUIRED = {
+  FINN_URL: 'http://localhost:3000',
+  DIXIE_JWT_PRIVATE_KEY: 'a'.repeat(64),
+  NODE_ENV: 'test',
+};
+
+// Synthetic, public-safe dev/operator address (not a live wallet).
+const SYNTH_TENANT = '0xabcdef0000000000000000000000000000000032';
+
+describe('config — Phase 32K dev-seeded estate gate (default off, fail-closed)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const TOUCH = [
+    ...Object.keys(REQUIRED),
+    'DIXIE_RECALL_INTAKE_ENABLED',
+    'STRAYLIGHT_RUNTIME_DIXIE_KEY',
+    'DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED',
+    'DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID',
+  ];
+
+  beforeEach(() => {
+    for (const k of TOUCH) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    Object.assign(process.env, REQUIRED);
+  });
+  afterEach(() => {
+    for (const k of TOUCH) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('default-off: dev seed disabled and tenant id empty when unset', () => {
+    const c = loadConfig();
+    expect(c.recallIntakeDevSeedEnabled).toBe(false);
+    expect(c.recallIntakeDevSeedTenantId).toBe('');
+  });
+
+  it('default-off: a configured tenant id alone does NOT enable the seed', () => {
+    // Presence of the tenant id without the enable flag must not turn the
+    // seed on — the gate is the explicit enable flag, default off.
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID = SYNTH_TENANT;
+    const c = loadConfig();
+    expect(c.recallIntakeDevSeedEnabled).toBe(false);
+    expect(c.recallIntakeDevSeedTenantId).toBe('');
+  });
+
+  it('enabled without the recall route enabled → throws (fail-closed)', () => {
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED = 'true';
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID = SYNTH_TENANT;
+    // DIXIE_RECALL_INTAKE_ENABLED intentionally unset.
+    expect(() => loadConfig()).toThrow(/DIXIE_RECALL_INTAKE_ENABLED/);
+  });
+
+  it('enabled + missing tenant id → throws (fail-closed, no silent no-op)', () => {
+    process.env.DIXIE_RECALL_INTAKE_ENABLED = 'true';
+    process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY = 'k'.repeat(32);
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED = 'true';
+    // tenant id intentionally unset.
+    expect(() => loadConfig()).toThrow(/DEV_SEED_TENANT_ID/);
+  });
+
+  it('enabled + invalid tenant id → throws (fail-closed)', () => {
+    process.env.DIXIE_RECALL_INTAKE_ENABLED = 'true';
+    process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY = 'k'.repeat(32);
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED = 'true';
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID = 'not-an-address';
+    expect(() => loadConfig()).toThrow(/DEV_SEED_TENANT_ID/);
+  });
+
+  it('enabled + valid tenant id → loads with seed enabled and tenant captured', () => {
+    process.env.DIXIE_RECALL_INTAKE_ENABLED = 'true';
+    process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY = 'k'.repeat(32);
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED = 'true';
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID = SYNTH_TENANT;
+    const c = loadConfig();
+    expect(c.recallIntakeDevSeedEnabled).toBe(true);
+    expect(c.recallIntakeDevSeedTenantId).toBe(SYNTH_TENANT);
+  });
+
+  it('fail-closed error message does NOT echo the raw invalid tenant id', () => {
+    process.env.DIXIE_RECALL_INTAKE_ENABLED = 'true';
+    process.env.STRAYLIGHT_RUNTIME_DIXIE_KEY = 'k'.repeat(32);
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED = 'true';
+    const leaky = '0xLEAKYBADVALUE-do-not-echo-me';
+    process.env.DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID = leaky;
+    try {
+      loadConfig();
+      throw new Error('expected loadConfig to throw');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).not.toContain(leaky);
+      expect(msg).toMatch(/DEV_SEED_TENANT_ID/);
+    }
+  });
+});

--- a/app/tests/unit/recall-intake/refusal-mapping.test.ts
+++ b/app/tests/unit/recall-intake/refusal-mapping.test.ts
@@ -100,6 +100,105 @@ describe('mapSeamResponseToRefusal — host denial reasons', () => {
   });
 });
 
+describe('mapSeamResponseToRefusal — Phase 32K storage/internal-seam sanitization', () => {
+  // Producer (A): unseeded tenant. The Straylight host try/catch coerces the
+  // bounded store's getKeyring() throw into reason:'storage_unavailable'
+  // with raw_reasons:[err.message], where err.message carries the bounded-
+  // store implementation text AND the raw tenant id. The PUBLIC body must
+  // not forward it; the internal audit object must retain it.
+  it('storage_unavailable: omits raw_reasons from the PUBLIC body but retains them on audit', () => {
+    const leakyMessage =
+      'bounded-estate-store: no slot for tenant 0xabcdef0000000000000000000000000000000099';
+    const resp: RecallIntakeResponse = {
+      outcome: 'denied',
+      reason: 'storage_unavailable',
+      raw_reasons: [leakyMessage],
+      intake_log_entry_id: 'idlog_x',
+    };
+    const r = mapSeamResponseToRefusal(resp, { tenant_id: 'w', caller_actor_id: 'w' })!;
+    expect(r.http_status).toBe(503);
+    expect(r.body.error).toBe('seam.storage_unavailable');
+    expect(r.body.outcome).toBe('denied');
+
+    // PUBLIC body: no raw_reasons key, no leaky message text anywhere.
+    expect(r.body.raw_reasons).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(r.body, 'raw_reasons')).toBe(false);
+    expect(JSON.stringify(r.body)).not.toContain('bounded-estate-store');
+    expect(JSON.stringify(r.body)).not.toContain('no slot for tenant');
+    expect(JSON.stringify(r.body)).not.toContain(
+      '0xabcdef0000000000000000000000000000000099',
+    );
+    // Message is a fixed, classification-only string (not the throw text).
+    expect(typeof r.body.message).toBe('string');
+    expect(r.body.message).not.toContain(leakyMessage);
+
+    // INTERNAL audit: raw reason is preserved for the safe internal trail.
+    expect(r.audit.raw_reasons).toEqual([leakyMessage]);
+    expect(r.audit.refusal_class).toBe('seam.storage_unavailable');
+  });
+
+  // Producer (C): route internal-error fallback synthesizes a
+  // runtime_seam:internal:* raw reason on a storage_unavailable response.
+  it('storage_unavailable: drops a runtime_seam:internal:* raw reason from the public body', () => {
+    const resp: RecallIntakeResponse = {
+      outcome: 'denied',
+      reason: 'storage_unavailable',
+      raw_reasons: ['runtime_seam:internal:Cannot read properties of undefined'],
+    };
+    const r = mapSeamResponseToRefusal(resp, { tenant_id: 'w' })!;
+    expect(r.body.error).toBe('seam.storage_unavailable');
+    expect(r.body.raw_reasons).toBeUndefined();
+    expect(JSON.stringify(r.body)).not.toContain('runtime_seam:internal');
+    // Internal audit still carries it.
+    expect(r.audit.raw_reasons).toEqual([
+      'runtime_seam:internal:Cannot read properties of undefined',
+    ]);
+  });
+
+  // A denied response with an UNKNOWN reason string falls through to the
+  // storage_unavailable class and must be sanitized identically (it would
+  // otherwise be the broadest leak surface for any future seam reason).
+  it('unknown denial reason → storage_unavailable class, public body sanitized', () => {
+    const resp = {
+      outcome: 'denied',
+      reason: 'some_future_reason_not_in_map',
+      raw_reasons: ['internal:leak:do-not-expose'],
+    } as unknown as RecallIntakeResponse;
+    const r = mapSeamResponseToRefusal(resp, {})!;
+    expect(r.body.error).toBe('seam.storage_unavailable');
+    expect(r.body.raw_reasons).toBeUndefined();
+    expect(JSON.stringify(r.body)).not.toContain('internal:leak:do-not-expose');
+    expect(r.audit.raw_reasons).toEqual(['internal:leak:do-not-expose']);
+  });
+
+  // Phase 32D contract preserved: a real, public-vocabulary denial reason
+  // (privacy_scope_refusal) STILL forwards its raw_reasons on the public
+  // body. The sanitization is scoped to the internal-seam class only.
+  it('privacy_scope_refusal still forwards public raw_reasons (Phase 32D contract intact)', () => {
+    const resp: RecallIntakeResponse = {
+      outcome: 'denied',
+      reason: 'privacy_scope_refusal',
+      raw_reasons: ['privacy_scope:public_frame_blocked'],
+    };
+    const r = mapSeamResponseToRefusal(resp, {})!;
+    expect(r.http_status).toBe(403);
+    expect(r.body.error).toBe('seam.privacy_scope_refusal');
+    expect(r.body.raw_reasons).toEqual(['privacy_scope:public_frame_blocked']);
+  });
+
+  it('blocked_by_policy still forwards public raw_reasons', () => {
+    const resp: RecallIntakeResponse = {
+      outcome: 'denied',
+      reason: 'blocked_by_policy',
+      raw_reasons: ['competence:signer_role_not_admitted'],
+    };
+    const r = mapSeamResponseToRefusal(resp, {})!;
+    expect(r.http_status).toBe(403);
+    expect(r.body.error).toBe('seam.blocked_by_policy');
+    expect(r.body.raw_reasons).toEqual(['competence:signer_role_not_admitted']);
+  });
+});
+
 describe('mapSeamResponseToRefusal — pass-through', () => {
   it('served → undefined (caller emits 200 directly)', () => {
     const resp: RecallIntakeResponse = {

--- a/docs/RECALL-WEDGE-SEEDED-LIVE-ESTATE-STORAGE-DESIGN.md
+++ b/docs/RECALL-WEDGE-SEEDED-LIVE-ESTATE-STORAGE-DESIGN.md
@@ -9,8 +9,10 @@
 > (readiness checkpoint), ADR-026C, ADR-026D
 > **Related (freeside-characters)**: Phase 41D (controlled live
 > `/recall-wedge-live-demo` smoke), Phase 42A (next-MVP decision)
-> **Status**: **docs-only design gate** — code-inspection-grounded. **No
-> implementation. No seeding. No source change.**
+> **Status**: **docs-only design gate** (32J) — code-inspection-grounded. **No
+> implementation. No seeding. No source change.** _Superseded for
+> implementation by the Phase 32K addendum in §11, which ships Option 1 as a
+> default-off dev/operator seed._
 
 This document is a **design gate**, not an implementation. It identifies the
 narrowest safe future path to seed a dev/operator estate so that a later live
@@ -373,3 +375,110 @@ This phase explicitly does **not**:
   seeding step exists today; intentionally **not** modified by this docs-only
   gate (no good anchor — the runbook covers infra deploy/rollback, not the
   in-process recall store).
+
+---
+
+## 11. Phase 32K addendum — implemented dev/operator seed (default-off)
+
+> **Phase**: 32K · **Status**: **implemented** (Option 1 from §4/§5). This
+> section documents the env gate and non-goals of the shipped code; the
+> design rationale above is unchanged.
+
+Phase 32K implements the §5-recommended Option 1: a deterministic,
+**dev/operator-only**, **default-off**, idempotent in-process `seedTenant`
+seed wired immediately after `createBoundedEstateStore(...)` in
+`app/src/server.ts`, behind a dedicated env gate distinct from
+`DIXIE_RECALL_INTAKE_ENABLED`.
+
+### Env gate
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED` | `false` | When `true`, seed exactly **one** synthetic dev/operator tenant slot into the process-local bounded estate store. Requires `DIXIE_RECALL_INTAKE_ENABLED=true`. |
+| `DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID` | _(empty)_ | Synthetic `0x`+40-hex dev/operator wallet/address to seed. **Required** when the seed is enabled; must match the recall-intake tenant/session identity format. Provide via env/secret — **never commit a live id**. |
+
+**Fail-closed behavior** (`app/src/config.ts`, mirrors the ADR-026D §4.a
+key gate): enabled is default-off; enabled without
+`DIXIE_RECALL_INTAKE_ENABLED=true` throws at `loadConfig()`; enabled with a
+missing or non-`0x40hex` tenant id throws at `loadConfig()` (never silently
+seeds nothing). The fail-closed error message reports the expected shape
+only and does **not** echo the raw operator-provided value. The raw tenant
+id is **not** logged at startup — only a `recall_intake_dev_seed_active`
+warning that the seed ran.
+
+### What the seed is / is not
+
+- The seed stores only **synthetic signer/keyring metadata** (`signer_id`,
+  `signer_type`, a public `key_ref` label, a `recall_estate_context`
+  competence rule) plus an empty (zero-assertion) estate. The served recall
+  over that estate returns an `allow` pack with `included: []`.
+- The `dev_signature` a caller presents is **caller-computed at request
+  time** (HMAC over the canonical recall payload keyed by the public
+  `key_ref`); it is **never stored**. `dev_signature` carries no
+  cryptographic authority (it is marked DEVELOPMENT-ONLY upstream). **No
+  secret, private key, live id, token, URL, or signature is committed.**
+- The seed is **idempotent** (`seedTenant` replaces the slot) and **safe to
+  rerun** on every process startup. It is **non-durable** (lost on restart;
+  re-seeded next startup) — acceptable for a dev/operator smoke.
+
+### Public storage / internal-seam denial sanitization
+
+Phase 32K now **sanitizes public storage/internal-seam denial bodies**. The
+`storage_unavailable` denial class is the only one whose seam `raw_reasons`
+is an uncontrolled exception message rather than public Straylight
+vocabulary: producer A (unseeded tenant) coerces the bounded store's
+`getKeyring()` throw — whose message embeds bounded-store implementation text
+and the raw tenant id — into `raw_reasons`, and producer C (route
+internal-error fallback) synthesizes a `runtime_seam:internal:*` raw reason.
+`mapSeamResponseToRefusal` now **omits `raw_reasons` from the public HTTP
+body** for the `seam.storage_unavailable` class (key omitted, not emptied)
+and returns a fixed classification-only `message`. The raw reason is retained
+**only** on the internal `audit` object (the existing intake-deny / emitAudit
+trail — no new logging surface is introduced). The safe `503` status and
+`seam.storage_unavailable` classification are unchanged, and every other
+denial class (e.g. `privacy_scope_refusal`, `blocked_by_policy`) still
+forwards its public-vocabulary `raw_reasons` per the Phase 32D denied-no-leak
+contract.
+
+### Non-goals (carried from §6/§8, unchanged)
+
+This seed is a **dev/operator smoke mechanism only**. It is **NOT**:
+
+- production memory admission;
+- a user-facing or public write path;
+- a Discord/Telegram message-history ingestion path;
+- a "remember this" / candidate-memory admission path;
+- a public rollout or public-channel recall;
+- a cross-user auth/consent implementation.
+
+It introduces no Freeside Characters change, no Discord command
+registration, no Railway env change, no production DB migration, and no
+Postgres seed rows.
+
+### Acceptance status
+
+The §7 acceptance criteria are proven **in-repo** by:
+
+- `app/tests/unit/recall-intake/dev-seeded-estate-config.test.ts` —
+  default-off; fail-closed on enabled-but-missing/invalid tenant id; no raw
+  value echo.
+- `app/tests/integration/recall-intake/dev-seeded-live-estate.test.ts` —
+  drives the **real** Dixie app + **real** Straylight runtime (no mocked
+  `handleRecallIntake`): seeded tenant → `200` served / `allow`; unseeded
+  tenant → safe `seam.storage_unavailable` / `503`; no-auth → `401`; expired
+  token → `401`; cross-tenant body mismatch → `403`; default-off preserves
+  the unseeded `503`; idempotent re-seed; served wire body carries no
+  secrets/internals/tenant-debug/JWT material; and both the unseeded and
+  default-off `503` denial bodies carry no `raw_reasons`, bounded-store
+  detail, raw tenant ids, or internal seam/debug text.
+- `app/tests/unit/recall-intake/refusal-mapping.test.ts` — unit proof that
+  the `seam.storage_unavailable` class omits `raw_reasons` from the public
+  body (producers A and C) while retaining them on the internal audit
+  object, and that other denial classes still forward public `raw_reasons`.
+
+**A live smoke after deploy is still required** to accept served recall
+*in the deployed environment*. The in-repo integration test is the
+live-equivalent proof against the real runtime, but it does not substitute
+for a controlled post-deploy `POST /api/recall/intake` smoke against the
+configured dev/operator tenant (see §7 "Direct Dixie smoke" and the
+freeside-characters Phase 41D live demo).


### PR DESCRIPTION
## Summary

Phase 32K implements the dev/operator seeded live estate path for Dixie.

This follows Phase 32J, which established that live Dixie recall-intake reached the Straylight seam but returned seam.storage_unavailable because the process-local bounded estate store had no seeded tenant slot.

This PR adds a default-off dev/operator seed gate, deterministic synthetic seed material, server wiring after createBoundedEstateStore, and regression tests proving that a configured seeded tenant can return a served recall result through the real Dixie route and real Straylight runtime.

It also resolves the Codex PATCH by sanitizing public seam.storage_unavailable denial bodies so internal storage/runtime raw reasons are not exposed publicly.

## Files

Changed source:

- app/src/config.ts
- app/src/server.ts
- app/src/services/straylight-recall-intake/index.ts
- app/src/services/straylight-recall-intake/refusal-mapping.ts
- app/src/services/straylight-recall-intake/dev-seeded-estate.ts

Changed tests:

- app/tests/integration/recall-intake/dev-seeded-live-estate.test.ts
- app/tests/unit/recall-intake/dev-seeded-estate-config.test.ts
- app/tests/unit/recall-intake/refusal-mapping.test.ts

Changed docs:

- docs/RECALL-WEDGE-SEEDED-LIVE-ESTATE-STORAGE-DESIGN.md

## Implementation

This PR adds:

- default-off config gate:
  - DIXIE_RECALL_INTAKE_DEV_SEED_ENABLED
  - DIXIE_RECALL_INTAKE_DEV_SEED_TENANT_ID
- fail-closed config behavior:
  - enabled seed requires recall-intake to be enabled;
  - enabled seed requires a valid 0x + 40 hex tenant id;
  - invalid values are not echoed in errors;
- deterministic synthetic seed helper:
  - builds synthetic dev/operator seed material;
  - calls the real bounded-store seedTenant path;
  - imports no test helpers into production source;
- server wiring:
  - seed runs after createBoundedEstateStore and before createRecallIntakeRoutes;
  - seed applies only to the explicitly configured tenant;
  - no request-driven seeding;
- public denial sanitization:
  - seam.storage_unavailable public bodies omit raw_reasons;
  - fixed public message is used for storage/internal seam failures;
  - outcome, error, audit_event_id, intake_log_entry_id, and HTTP 503 are preserved;
  - internal audit still retains raw reasons.

## Behavior proven

Tests prove:

- default-off route behavior remains unseeded and safe;
- enabled seeded tenant returns HTTP 200 served / allow through the real route and real Straylight runtime;
- unseeded tenant still returns safe 503 seam.storage_unavailable;
- no-auth remains 401;
- expired token remains 401;
- cross-tenant mismatch remains 403;
- public unseeded/default-off denial bodies do not expose raw_reasons, bounded-store detail, raw tenant material, runtime_seam:internal, stack-ish/debug detail, token material, private IDs, or raw assertion IDs;
- non-storage refusal classes that are intentionally public keep their existing behavior.

## Results

Validation:

- git diff --check: pass
- npm run typecheck: pass
- npm run build: pass
- focused Vitest: pass
- broader recall-intake / Straylight-host suites: pass
- secret/live-value scan: clean except deterministic synthetic test addresses
- no package/lockfile/generated/migration changes

Codex audit:

- Initial verdict: PATCH
- Required patch: sanitize public storage/internal seam denial bodies and add unseeded/default-off no-leak regressions
- Patch applied
- Re-audit verdict: ACCEPT

## Non-goals

This PR does not:

- add production memory admission
- add user-facing writes
- add Discord or Telegram ingestion
- add remember-this or candidate-memory writes
- add public rollout
- add public-channel recall
- add cross-user auth or consent
- add LLM rewriting
- add character voice rewriting
- add Finn integration
- add migrations
- add scripts or CLI commands
- change Freeside Characters
- change Straylight
- change package or lockfiles
- commit live IDs, live URLs, tokens, JWTs, service tokens, admin keys, Postgres URLs, or secrets
