### PR TITLE
Phase 33C docs: add Admission Wedge contract probes

### DIFF
--- a/docs/ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md
+++ b/docs/ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md
@@ -499,6 +499,14 @@ This Phase 33B succeeds if **all** of the following hold:
 
 ## 15. Cross-references
 
+> **Phase 33C status note (added later).** Phase 33C acted on this decision and
+> authored the first **draft v0** Admission Wedge contract probes at
+> `docs/admission-wedge/fixtures/` (five probe JSONs + an isolated, dependency-free
+> validator + a README). It remains **non-runtime**: it implements **no** live
+> route, storage, auth, or admission behavior, and it does **not** freeze a
+> schema. Future Freeside Characters reconciliation against these probes remains a
+> separate, separately-gated effort.
+
 - `docs/ADMISSION-WEDGE-CONTRACT-RESPONSE.md` — Dixie Phase 33A contract response
   / acceptance gate (PR #118). Its §10 pre-listed this Phase 33B as "contract
   fixture / probe alignment"; this doc is that decision. Gains a single minimal

--- a/docs/admission-wedge/fixtures/README.md
+++ b/docs/admission-wedge/fixtures/README.md
@@ -1,0 +1,125 @@
+# Admission Wedge — Draft Contract Probes (Phase 33C)
+
+> **Phase**: 33C — Admission Wedge canonical fixture/probe draft
+> **Status**: **docs + non-runtime fixture/probe only.** No live route, no
+> storage, no auth, no admission writes, no runtime behavior.
+> **Schema status**: **draft v0 — NOT frozen.** These probes are a *proposal*
+> for cross-repo review, not a production schema.
+
+This directory holds the first Dixie-owned **draft v0** Admission Wedge contract
+probes. They are deterministic, fully synthetic, public-safe JSON files plus an
+isolated, dependency-free validator. They exist to pin a *shape* for cross-repo
+review — they do **not** implement admission.
+
+## What this is (and is not)
+
+- **Is**: a set of static JSON contract probes and an offline validator that
+  checks their shape and no-leak properties.
+- **Is not**: a live route, an API handler, storage, auth/consent, an admission
+  implementation, a package export, or a frozen schema.
+
+Per the [Phase 33B alignment decision](../../ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md),
+**Dixie owns this first canonical probe proposal** for cross-repo review.
+**Straylight (`@loa/straylight`) remains the canonical primitive / substrate
+owner** of the assertion-lifecycle vocabulary; Dixie consumes and mirrors those
+names rather than coining its own. **Freeside Characters should wait** for this
+Dixie-authored probe set before mutating its local proof labels (fixtures,
+reducer, runner) — the probes give it a canonical shape to reconcile against
+rather than a guess. This work does **not** edit Freeside Characters and does
+not mutate its local labels.
+
+## Not authorized by Phase 33C
+
+No live Dixie admission route, no production admission, no production storage, no
+production auth/consent, no public `remember-this`, no Discord command, no
+Discord history ingestion, no user chat becoming memory, no Freeside Characters
+runtime change, no package export, no LLM/voice behavior, no Finn production
+wiring, no forget/revoke/correction UI, and **no final schema freeze**.
+
+To be unambiguous about current reality: Dixie today exposes a read-only,
+default-off, fail-closed **recall** route (`POST /api/recall/intake`). It has
+**no admission route, no admission concept in route code, and no production
+storage**; admission semantics live upstream in `@loa/straylight`. Phase 33C
+implements no runtime behavior and changes no Dixie application/source/route/
+config code.
+
+## The five probes
+
+Each probe is a single JSON object with a shared envelope: synthetic `input`
+(may carry a private `unsafe_marker:` token), a modeled transition / assertion /
+recall projection, a private `audit` object, and a clean `public_response`. The
+`public_response` is the only surface a caller would see, and the validator
+proves it never leaks private material.
+
+| File | Scenario | What it proves |
+|------|----------|----------------|
+| `candidate-pending-not-recallable.json` | A | A candidate exists as canonical `proposed`; no admission transition; no admitted assertion; `recall_eligible` is false; the payload is not echoed in the public projection. |
+| `accept-candidate-to-admitted-assertion.json` | B | A candidate is accepted via an `admit_assertion` transition linking candidate → admitted assertion (canonical status `active`); it becomes recall-eligible under policy; a receipt/audit split exists; the raw payload is not echoed. |
+| `reject-candidate-no-assertion.json` | C | A candidate is denied (canonical `transition_denied` audit event); **no** admitted assertion is minted; the candidate stays non-recallable; a rejection receipt exists on the audit boundary; the public response is safe. |
+| `supersede-with-corrected-assertion.json` | D | A prior assertion moves to canonical `superseded`; a corrected assertion is `active`; ordinary recall includes the corrected active assertion **only**; the superseded prior remains audit/provenance only; the public response is safe. |
+| `malformed-or-unsafe-payload-fail-closed.json` | E | A malformed/unsafe input fails closed with a stable reason code from the existing Dixie refusal family; **no** admitted assertion is minted; no raw payload, unsafe marker, source material, or stack trace appears in the public response. |
+
+## Vocabulary: canonical (aligned) vs draft (proposed)
+
+The probes **align** to canonical Straylight-owned vocabulary where it exists,
+and clearly mark Dixie-proposed names as **draft**. Final naming reconciles at a
+later, separately-gated phase; nothing here is frozen.
+
+| Concept | Term used | Ownership / status |
+|---------|-----------|--------------------|
+| Pre-admission candidate state | `proposed` | Canonical `AssertionStatus` (Straylight-owned) — aligned. Not the Freeside-local `candidate_pending`. |
+| Admitted assertion status | `active` | Canonical `AssertionStatus` (Straylight-owned) — aligned. There is no bare `admitted` status. |
+| Act of admission | transition `admit_assertion` + audit event `assertion_admitted` | Canonical (Straylight-owned) — aligned. |
+| Denied admission | audit event `transition_denied` | Canonical (Straylight-owned) — aligned. Not a coined `rejected` status. |
+| Correction | `(superseded, active)` pair + supersede link | Canonical statuses (Straylight-owned) — aligned. No coined `corrected_active` status. |
+| Recallability signal | `RecallUseInstruction` (`usable` … `do_not_use_for_action`) | Canonical (Straylight-owned) — aligned. |
+| Shape-failure reason code | `ingress.invalid_request` | Dixie-local refusal family (Dixie-owned) — aligned to existing code. |
+| Class-failure reason code | `seam.class_validation_failed` | Dixie-local refusal family (Dixie-owned) — aligned to existing code. |
+| Link / receipt field names | `source_candidate_id`, `admission_transition_id`, `admitted_assertion_id`, `supersedes_assertion_id`, `superseded_by_assertion_id`, `recall_use_instruction`, `rendered_candidate_payload`, `receipt_public_ref` | **DRAFT** — Dixie-proposed, subject to reconciliation. |
+
+The pending-vs-denied distinction is preserved deliberately: a candidate with no
+transition is simply `proposed` (probe A), which is **not** the same as an
+explicit `transition_denied` (probe C). The probes keep these on separate
+scenarios so the distinction is provable rather than collapsed.
+
+## No-leak rules (enforced by the validator)
+
+The validator deep-walks each `public_response` and fails if it finds any of:
+
+- the generic synthetic `unsafe_marker:` token, or any raw candidate payload /
+  source material;
+- known internal/foreign sentinel forms (e.g. `BODY_OVER_CAP`,
+  `runtime_seam:internal:`, `*_PRIVATE_SENTINEL`);
+- stack traces, `Error:`-style prefixes, or `file.ts:line` source references;
+- URLs (`http(s)://`, `ws(s)://`), bearer tokens, JWTs, `sk-` keys, or
+  `-----BEGIN` PEM material;
+- long opaque IDs (`0x`-hex addresses, 40+ char hex runs);
+- audit-only keys (`tenant_id`, `estate_id`, `candidate_id`, `candidate_payload`,
+  `raw_reasons`, `policy_reason`, `receipt_id`, …).
+
+> **On sentinels.** No Dixie-side public leak-canary string exists in code (the
+> only over-cap sentinel is an internal `Symbol`, never serialized). These probes
+> therefore use a **generic synthetic `unsafe_marker:` token**, held only in the
+> `input` and `audit` sections, and the validator proves it can never appear in a
+> `public_response`. The Freeside-local sentinel string is **not** used here.
+
+## Running the validator
+
+```bash
+node docs/admission-wedge/fixtures/validate-fixtures.mjs
+```
+
+The validator uses **Node built-ins only** (no package install, no network, no
+storage, no env, no app/route imports). It checks that all five scenario files
+exist and parse, that the shared metadata is correct (`probe_kind`,
+`probe_version`, `schema_final=false`, `runtime_enabled=false`,
+`production_admission=false`, `public_safe=true`), that each scenario satisfies
+its invariant, and that no `public_response` leaks. It prints a deterministic
+PASS/FAIL summary and exits non-zero on any failure.
+
+## Provenance
+
+- [`docs/ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md`](../../ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md) — Phase 33B Dixie-first ownership decision and minimum probe set (§6) / schema surfaces (§7) / vocabulary directions (§8).
+- [`docs/ADMISSION-WEDGE-CONTRACT-RESPONSE.md`](../../ADMISSION-WEDGE-CONTRACT-RESPONSE.md) — Phase 33A contract response: the core invariant, draft v0 vocabulary, and reconciliation directions.
+- [`docs/integration/phase-32e-recall-wedge-route-contract.md`](../../integration/phase-32e-recall-wedge-route-contract.md) — the Recall Wedge route contract and BFF/Straylight ownership split this probe set assumes (but does not mutate).
+- `@loa/straylight` — semantic owner of the assertion lifecycle and the canonical vocabulary the probes align to.

--- a/docs/admission-wedge/fixtures/accept-candidate-to-admitted-assertion.json
+++ b/docs/admission-wedge/fixtures/accept-candidate-to-admitted-assertion.json
@@ -1,0 +1,99 @@
+{
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "accept_candidate_to_admitted_assertion",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A proposed candidate is accepted; an admission transition links it to an admitted, active assertion that becomes recall-eligible under policy, without echoing the raw candidate payload.",
+  "invariant_refs": [
+    "inv3_accepted_transition_creates_or_references_admitted_assertion",
+    "inv2_candidate_not_recallable_before_admission",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.proposed",
+    "AssertionStatus.active",
+    "Transition.admit_assertion",
+    "AuditEvent.assertion_admitted",
+    "RecallUseInstruction.usable"
+  ],
+  "draft_vocab_used": [
+    "source_candidate_id",
+    "admission_transition_id",
+    "admitted_assertion_id",
+    "recall_eligible",
+    "recall_use_instruction",
+    "rendered_candidate_payload",
+    "receipt_public_ref"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: the ACT of admission is the canonical Straylight transition 'admit_assertion' and audit event 'assertion_admitted'; the resulting STATUS is canonical 'active'. There is NO bare 'admitted' status upstream, so the probe deliberately avoids 'admitted'/'admitted_active_assertion' as a status value.",
+    "Recall eligibility is expressed as 'under policy': a boolean recall_eligible plus the canonical RecallUseInstruction signal ('usable'), not an unconditional grant. The boolean and the canonical signal are kept side by side so future reconciliation is cheap.",
+    "Receipt/audit split: the public_response carries only a public-safe receipt reference and summary; the full admission receipt (policy reasoning, candidate ref, ids) lives on the audit object.",
+    "Link field names (source_candidate_id, admission_transition_id, admitted_assertion_id) are DRAFT and subject to reconciliation against Straylight-owned assertion types."
+  ],
+  "input": {
+    "candidate_id": "cand_demo_002",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "proposed_assertion_class": "preference",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-002",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-002"
+  },
+  "admission_transition": {
+    "admission_transition_id": "trans_demo_001",
+    "transition_kind": "admit_assertion",
+    "outcome": "accepted",
+    "source_candidate_id": "cand_demo_002",
+    "admitted_assertion_id": "assn_demo_001",
+    "authority_signer_type_draft": "policy_service",
+    "policy_decision": "accepted_under_policy"
+  },
+  "admitted_assertion": {
+    "admitted_assertion_id": "assn_demo_001",
+    "assertion_status": "active",
+    "assertion_class": "preference",
+    "source_candidate_id": "cand_demo_002",
+    "admission_transition_id": "trans_demo_001",
+    "recall_eligible": true,
+    "recall_use_instruction": "usable"
+  },
+  "recall_projection": {
+    "ordinary_recall_members": [
+      "assn_demo_001"
+    ],
+    "explanation": "The admitted assertion is active and recall-eligible under policy, so it appears in ordinary recall."
+  },
+  "public_response": {
+    "outcome": "admitted",
+    "assertion_status": "active",
+    "recall_eligible": true,
+    "recall_use_instruction": "usable",
+    "rendered_candidate_payload": false,
+    "receipt_public_ref": "rcpt_demo_002",
+    "public_summary": "Candidate admitted under policy. The resulting assertion is active and recall-eligible. The candidate payload is not echoed."
+  },
+  "audit": {
+    "admission_receipt": {
+      "receipt_id": "rcpt_demo_002",
+      "decision_time_label": "demo_decision_time",
+      "service_actor": "actor_demo",
+      "policy_reason": "accepted_under_policy",
+      "source_candidate_id": "cand_demo_002",
+      "admitted_assertion_id": "assn_demo_001",
+      "recall_eligibility_result": "eligible_under_policy",
+      "audit_event": "assertion_admitted"
+    },
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-002",
+    "source_ref": "unsafe_marker:source-ref-demo-002",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/fixtures/candidate-pending-not-recallable.json
+++ b/docs/admission-wedge/fixtures/candidate-pending-not-recallable.json
@@ -1,0 +1,65 @@
+{
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "candidate_pending_not_recallable",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A candidate proposal exists but no admission transition has occurred; it is not recallable and its payload is never echoed in the public projection.",
+  "invariant_refs": [
+    "inv1_candidate_is_not_admitted",
+    "inv2_candidate_not_recallable_before_admission",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.proposed"
+  ],
+  "draft_vocab_used": [
+    "candidate_state",
+    "recall_eligible",
+    "rendered_candidate_payload",
+    "admission_transition"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: the pre-admission state uses the canonical Straylight AssertionStatus 'proposed' (Straylight-owned), NOT the Freeside-local proof label 'candidate_pending'. The scenario_id keeps the descriptive name 'candidate_pending_not_recallable' purely as a scenario label, never as a status value.",
+    "Pending-vs-denied distinction: a candidate with NO admission_transition is simply 'proposed'. This is deliberately distinct from a denied candidate (see reject-candidate-no-assertion.json, which carries a 'transition_denied' audit event). The two must not be collapsed.",
+    "Field names under draft_vocab_used are directional proposals subject to cross-repo reconciliation; only the canonical_vocab_used terms are treated as upstream-owned."
+  ],
+  "input": {
+    "candidate_id": "cand_demo_001",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "proposed_assertion_class": "observation",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-001",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-001"
+  },
+  "admission_transition": null,
+  "admitted_assertion": null,
+  "recall_projection": {
+    "ordinary_recall_members": [],
+    "explanation": "No admitted, active assertion exists; the proposed candidate is excluded from ordinary recall."
+  },
+  "public_response": {
+    "outcome": "accepted_as_proposed",
+    "candidate_state": "proposed",
+    "recall_eligible": false,
+    "rendered_candidate_payload": false,
+    "public_summary": "Candidate recorded as proposed. Not admitted and not recallable until an explicit admission transition accepts it."
+  },
+  "audit": {
+    "receipt_id": "rcpt_demo_001",
+    "candidate_id": "cand_demo_001",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-001",
+    "source_ref": "unsafe_marker:source-ref-demo-001",
+    "decision": "none_yet",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/fixtures/malformed-or-unsafe-payload-fail-closed.json
+++ b/docs/admission-wedge/fixtures/malformed-or-unsafe-payload-fail-closed.json
@@ -1,0 +1,63 @@
+{
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "malformed_or_unsafe_payload_fail_closed",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A malformed or unsafe candidate input is presented; the path fails closed with a stable reason code, mints no admitted assertion, and leaks no raw payload, unsafe marker, source material, or stack trace into the public response.",
+  "invariant_refs": [
+    "inv6_fail_closed_no_leak",
+    "inv3_accepted_transition_creates_or_references_admitted_assertion",
+    "inv2_candidate_not_recallable_before_admission"
+  ],
+  "canonical_vocab_used": [],
+  "draft_vocab_used": [
+    "reason_code",
+    "recall_eligible",
+    "rendered_candidate_payload"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Reason-code alignment: the public reason_code is grounded in the existing Dixie-local refusal family, NOT a coined 'unsupported_admission_shape' or 'unsafe_*' public code. A malformed envelope maps to 'ingress.invalid_request' (HTTP-400-shaped at ingress); an unsupported assertion class would instead map to 'seam.class_validation_failed'. These exact strings exist today in app/src/services/straylight-recall-intake/refusal-mapping.ts and are Dixie-owned (not Straylight-owned).",
+    "No-leak seal: the unsafe input lives only in the 'input' and 'audit' sections and carries a generic synthetic 'unsafe_marker:' token (NOT the Freeside-local sentinel string). The public_response must contain no unsafe_marker, no raw payload, no source material, and no stack trace. The validator proves this by deep-walking public_response.",
+    "Public/audit split: admission decides its own split explicitly and does NOT inherit the recall default. raw_reasons that could carry internal/unsafe material are OMITTED from the public body and retained only on the audit object — mirroring the Phase 32K storage_unavailable posture, applied here by deliberate choice.",
+    "No admitted assertion is minted on the fail-closed path."
+  ],
+  "input": {
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "malformed": true,
+    "proposed_assertion_class": "not_a_valid_class_demo",
+    "candidate_payload": "unsafe_marker:malformed-body-demo-005",
+    "source_ref": "unsafe_marker:source-ref-demo-005"
+  },
+  "admission_transition": null,
+  "admitted_assertion": null,
+  "recall_projection": {
+    "ordinary_recall_members": [],
+    "explanation": "Input failed closed before any admission; no assertion exists and nothing enters ordinary recall."
+  },
+  "public_response": {
+    "outcome": "refused",
+    "reason_code": "ingress.invalid_request",
+    "recall_eligible": false,
+    "rendered_candidate_payload": false,
+    "public_summary": "The admission request was malformed and was refused. No candidate detail is echoed."
+  },
+  "audit": {
+    "refusal_class": "ingress.invalid_request",
+    "raw_reasons": [
+      "unsafe_marker:malformed-body-demo-005",
+      "draft_probe_validation: proposed_assertion_class not in canonical AssertionClass union"
+    ],
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "candidate_payload": "unsafe_marker:malformed-body-demo-005",
+    "source_ref": "unsafe_marker:source-ref-demo-005",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/fixtures/reject-candidate-no-assertion.json
+++ b/docs/admission-wedge/fixtures/reject-candidate-no-assertion.json
@@ -1,0 +1,81 @@
+{
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "reject_candidate_no_assertion",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "A proposed candidate is denied admission; no admitted assertion is minted, the candidate remains non-recallable, and a rejection receipt exists on the audit boundary.",
+  "invariant_refs": [
+    "inv4_rejected_candidate_never_recallable",
+    "inv3_accepted_transition_creates_or_references_admitted_assertion",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.proposed",
+    "Transition.admit_assertion",
+    "AuditEvent.transition_denied"
+  ],
+  "draft_vocab_used": [
+    "source_candidate_id",
+    "recall_eligible",
+    "rendered_candidate_payload",
+    "receipt_public_ref"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: rejection is anchored on the canonical Straylight audit event 'transition_denied' (a denied 'admit_assertion' transition). The probe deliberately does NOT coin a parallel 'rejected' status.",
+    "Synonym-collision flag: the Freeside-local proof labels 'rejected', 'candidate_rejected', and 'candidate_not_admitted' are a three-way synonym collision and are referenced here as proof labels only, all reconciling onto 'transition_denied'. Note 'candidate_not_admitted' (pending, never decided) is semantically distinct from an explicit denial; this probe is the explicit-denial case.",
+    "Rejection is terminal for recall eligibility; any future appeal/correction path is separately gated and not implied here.",
+    "Receipt/audit split: the public_response carries only a stable outcome and public summary; the denial receipt (policy reason, candidate ref, audit event) lives on the audit object."
+  ],
+  "input": {
+    "candidate_id": "cand_demo_003",
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "proposing_actor_id": "actor_demo",
+    "proposed_assertion_class": "claim",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-003",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-003"
+  },
+  "admission_transition": {
+    "admission_transition_id": "trans_demo_002",
+    "transition_kind": "admit_assertion",
+    "outcome": "denied",
+    "source_candidate_id": "cand_demo_003",
+    "admitted_assertion_id": null,
+    "authority_signer_type_draft": "policy_service",
+    "policy_decision": "denied_by_policy"
+  },
+  "admitted_assertion": null,
+  "recall_projection": {
+    "ordinary_recall_members": [],
+    "explanation": "No admitted assertion was minted; the denied candidate is excluded from ordinary recall and remains non-recallable."
+  },
+  "public_response": {
+    "outcome": "denied",
+    "recall_eligible": false,
+    "rendered_candidate_payload": false,
+    "public_summary": "Candidate admission was denied. No assertion was created and the candidate is not recallable."
+  },
+  "audit": {
+    "admission_receipt": {
+      "receipt_id": "rcpt_demo_003",
+      "decision_time_label": "demo_decision_time",
+      "service_actor": "actor_demo",
+      "policy_reason": "denied_by_policy",
+      "source_candidate_id": "cand_demo_003",
+      "admitted_assertion_id": null,
+      "recall_eligibility_result": "not_eligible",
+      "audit_event": "transition_denied"
+    },
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "candidate_payload": "unsafe_marker:candidate-body-demo-003",
+    "source_ref": "unsafe_marker:source-ref-demo-003",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/fixtures/supersede-with-corrected-assertion.json
+++ b/docs/admission-wedge/fixtures/supersede-with-corrected-assertion.json
@@ -1,0 +1,116 @@
+{
+  "probe_kind": "admission_wedge_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v0",
+  "scenario": "draft_contract_probe",
+  "scenario_id": "supersede_with_corrected_assertion",
+  "schema_final": false,
+  "runtime_enabled": false,
+  "production_admission": false,
+  "public_safe": true,
+  "intent": "An existing active assertion is superseded by a corrected active assertion; ordinary recall includes only the corrected active assertion while the superseded prior state remains audit/provenance only.",
+  "invariant_refs": [
+    "inv5_supersession_auditable_recall_active_only",
+    "inv2_candidate_not_recallable_before_admission",
+    "inv6_fail_closed_no_leak"
+  ],
+  "canonical_vocab_used": [
+    "AssertionStatus.active",
+    "AssertionStatus.superseded",
+    "RecallUseInstruction.usable",
+    "RecallUseInstruction.do_not_use_for_action"
+  ],
+  "draft_vocab_used": [
+    "supersedes_assertion_id",
+    "superseded_by_assertion_id",
+    "supersession_transition_id",
+    "recall_eligible",
+    "recall_use_instruction",
+    "rendered_candidate_payload",
+    "receipt_public_ref"
+  ],
+  "notes": [
+    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "Canonical alignment: correction is expressed as the canonical (superseded, active) PAIR — the prior assertion moves to canonical status 'superseded' and the corrected assertion is canonical status 'active' with a supersede link. The probe deliberately does NOT coin a 'corrected'/'corrected_active' status; 'corrected active' is direction, not a new status value.",
+    "The superseded prior remains audit/provenance only: recall_eligible is false on the superseded record (signalled with RecallUseInstruction 'do_not_use_for_action'), and it is excluded from ordinary recall.",
+    "Supersession is a follow-on transition over an already-admitted assertion, not a first-pass admission outcome.",
+    "Forget/revoke/correction UI remains out of scope; this probe defines no user-facing correction surface.",
+    "Link field names (supersedes_assertion_id, superseded_by_assertion_id, supersession_transition_id) are DRAFT and subject to reconciliation against Straylight-owned assertion types."
+  ],
+  "input": {
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "correcting_actor_id": "actor_demo",
+    "prior_assertion_id": "assn_demo_002",
+    "corrected_candidate_payload": "unsafe_marker:candidate-body-demo-004",
+    "source_kind": "synthetic_probe",
+    "source_ref": "unsafe_marker:source-ref-demo-004"
+  },
+  "supersession_transition": {
+    "supersession_transition_id": "trans_demo_003",
+    "transition_kind": "admit_assertion",
+    "outcome": "accepted",
+    "supersedes_assertion_id": "assn_demo_002",
+    "corrected_assertion_id": "assn_demo_003",
+    "authority_signer_type_draft": "policy_service",
+    "policy_decision": "correction_accepted_under_policy"
+  },
+  "assertions": [
+    {
+      "assertion_id": "assn_demo_002",
+      "assertion_status": "superseded",
+      "assertion_class": "claim",
+      "superseded_by_assertion_id": "assn_demo_003",
+      "recall_eligible": false,
+      "recall_use_instruction": "do_not_use_for_action",
+      "audit_provenance_only": true
+    },
+    {
+      "assertion_id": "assn_demo_003",
+      "assertion_status": "active",
+      "assertion_class": "claim",
+      "supersedes_assertion_id": "assn_demo_002",
+      "recall_eligible": true,
+      "recall_use_instruction": "usable"
+    }
+  ],
+  "recall_projection": {
+    "ordinary_recall_members": [
+      "assn_demo_003"
+    ],
+    "excluded_from_ordinary_recall": [
+      "assn_demo_002"
+    ],
+    "explanation": "Ordinary recall includes the corrected active assertion only. The superseded prior assertion is retained for audit/provenance and excluded from ordinary recall."
+  },
+  "public_response": {
+    "outcome": "superseded_with_correction",
+    "active_assertion_status": "active",
+    "recall_eligible": true,
+    "recall_use_instruction": "usable",
+    "rendered_candidate_payload": false,
+    "receipt_public_ref": "rcpt_demo_004",
+    "public_summary": "A corrected active assertion now supersedes the prior assertion. Ordinary recall reflects only the corrected active assertion."
+  },
+  "audit": {
+    "supersession_receipt": {
+      "receipt_id": "rcpt_demo_004",
+      "decision_time_label": "demo_decision_time",
+      "service_actor": "actor_demo",
+      "policy_reason": "correction_accepted_under_policy",
+      "supersedes_assertion_id": "assn_demo_002",
+      "corrected_assertion_id": "assn_demo_003",
+      "recall_eligibility_result": "corrected_active_eligible",
+      "audit_event": "assertion_admitted"
+    },
+    "superseded_prior": {
+      "assertion_id": "assn_demo_002",
+      "assertion_status": "superseded",
+      "candidate_payload": "unsafe_marker:prior-body-demo-004"
+    },
+    "tenant_id": "tenant_demo",
+    "estate_id": "estate_demo",
+    "corrected_candidate_payload": "unsafe_marker:candidate-body-demo-004",
+    "source_ref": "unsafe_marker:source-ref-demo-004",
+    "audit_only": true
+  }
+}

--- a/docs/admission-wedge/fixtures/validate-fixtures.mjs
+++ b/docs/admission-wedge/fixtures/validate-fixtures.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+// Phase 33C — Admission Wedge draft contract-probe validator.
+//
+// DOCS-ONLY / NON-RUNTIME. This script is an isolated, dependency-free shape /
+// no-leak validator over the JSON probe fixtures in this directory. It is NOT
+// wired into the application, NOT imported by any route, and exercises NO live
+// admission behavior.
+//
+// Hard isolation rules (enforced by construction):
+//   * Node built-ins ONLY (node:fs, node:path, node:url). No third-party deps.
+//   * No package.json change, no lockfile change.
+//   * No import of @loa/straylight, no import of any app/src route/service.
+//   * No database, storage, network, or environment access.
+//   * Validates ONLY files under docs/admission-wedge/fixtures.
+//
+// What it proves:
+//   1. All five required scenario files exist and parse as JSON.
+//   2. Shared metadata is present and correct (probe_kind / probe_version /
+//      schema_final=false / runtime_enabled=false / production_admission=false /
+//      public_safe=true).
+//   3. No public_response leaks raw candidate payload, unsafe markers, sentinel
+//      strings, stack traces, URLs, tokens, PEM keys, long IDs, or audit-only
+//      fields.
+//   4. Each scenario satisfies its load-bearing invariant (pending / accept /
+//      reject / supersede / fail-closed).
+//
+// It emits a deterministic pass/fail summary and exits non-zero on any failure.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURES_DIR = dirname(fileURLToPath(import.meta.url));
+
+// scenario_id -> on-disk filename. The five required scenarios.
+const REQUIRED = {
+  candidate_pending_not_recallable: 'candidate-pending-not-recallable.json',
+  accept_candidate_to_admitted_assertion: 'accept-candidate-to-admitted-assertion.json',
+  reject_candidate_no_assertion: 'reject-candidate-no-assertion.json',
+  supersede_with_corrected_assertion: 'supersede-with-corrected-assertion.json',
+  malformed_or_unsafe_payload_fail_closed: 'malformed-or-unsafe-payload-fail-closed.json',
+};
+
+const PROBE_KIND = 'admission_wedge_contract_probe';
+const PROBE_VERSION = 'dixie_admission_wedge_probe_v0';
+
+// Reason codes the fail-closed public path may carry. Grounded in the existing
+// Dixie-local refusal family (app/src/services/straylight-recall-intake/
+// refusal-mapping.ts) — NOT coined here. Kept inline so the validator imports
+// nothing from the app.
+const STABLE_PUBLIC_REASON_CODES = new Set([
+  'ingress.invalid_request',
+  'seam.class_validation_failed',
+]);
+
+// Substrings that must never appear anywhere in a public_response (keys or
+// string values). Includes this probe set's generic synthetic marker plus
+// known internal/foreign sentinel forms guarded defensively.
+const FORBIDDEN_SUBSTRINGS = [
+  'unsafe_marker',
+  'BODY_OVER_CAP',
+  'body-over-cap',
+  'runtime_seam:internal:',
+  'CANDIDATE_PRIVATE_SENTINEL',
+  'SOURCE_SENTINEL',
+  'SUPERSEDED_PRIVATE_SENTINEL',
+  'ADMITTED_PRIVATE_SENTINEL',
+  'STRAYLIGHT_RUNTIME_DIXIE_KEY',
+  'ADMIN_KEY',
+  'Traceback',
+  'node_modules/',
+  '-----BEGIN ',
+];
+
+// Regex leak patterns checked against every string value in a public_response.
+const FORBIDDEN_PATTERNS = [
+  { name: 'url', re: /\bhttps?:\/\//i },
+  { name: 'ws-url', re: /\bwss?:\/\//i },
+  { name: 'jwt', re: /\beyJ[A-Za-z0-9_-]{8,}/ },
+  { name: 'openai-style-key', re: /\bsk-[A-Za-z0-9]{16,}/ },
+  { name: 'bearer-token', re: /\bBearer\s+\S+/ },
+  { name: '0x-hex-address', re: /0x[0-9a-fA-F]{16,}/ },
+  { name: 'long-hex-id', re: /\b[0-9a-fA-F]{40,}\b/ },
+  { name: 'stack-frame', re: /\bat\s+\/?\S+:\d+:\d+/ },
+  { name: 'source-line-ref', re: /\.[jt]s:\d+/ },
+  { name: 'error-prefix', re: /\b(?:Error|TypeError|RangeError|SyntaxError):\s/ },
+];
+
+// Keys that are audit-only / private and must never appear in a public_response
+// (deep). The public projection carries only public-safe references/summaries.
+const FORBIDDEN_PUBLIC_KEYS = new Set([
+  'tenant_id',
+  'estate_id',
+  'candidate_id',
+  'source_candidate_id',
+  'proposing_actor_id',
+  'correcting_actor_id',
+  'caller_actor_id',
+  'actor_id',
+  'service_actor',
+  'candidate_payload',
+  'corrected_candidate_payload',
+  'source_ref',
+  'source_kind',
+  'raw_reasons',
+  'policy_reason',
+  'policy_decision',
+  'receipt_id',
+  'audit_only',
+  'decision_time_label',
+  'audit_event',
+  'admitted_assertion_id',
+]);
+
+// ---------------------------------------------------------------------------
+// Reporting helpers
+// ---------------------------------------------------------------------------
+
+/** Walk every (key, string-value) pair in a JSON value. */
+function* walk(node, path = '$') {
+  if (node === null || node === undefined) return;
+  if (typeof node === 'string') {
+    yield { kind: 'value', path, value: node };
+    return;
+  }
+  if (typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      yield* walk(node[i], `${path}[${i}]`);
+    }
+    return;
+  }
+  for (const [k, v] of Object.entries(node)) {
+    yield { kind: 'key', path: `${path}.${k}`, value: k };
+    yield* walk(v, `${path}.${k}`);
+  }
+}
+
+function noLeakFailures(publicResponse) {
+  const failures = [];
+  for (const node of walk(publicResponse, '$.public_response')) {
+    // Forbidden audit-only keys.
+    if (node.kind === 'key' && FORBIDDEN_PUBLIC_KEYS.has(node.value)) {
+      failures.push(`audit-only key "${node.value}" present in public_response at ${node.path}`);
+    }
+    // Forbidden substrings (checked on keys AND values).
+    for (const s of FORBIDDEN_SUBSTRINGS) {
+      if (node.value.includes(s)) {
+        failures.push(`forbidden substring "${s}" found in public_response at ${node.path}`);
+      }
+    }
+    // Forbidden regex patterns (string values and keys).
+    for (const p of FORBIDDEN_PATTERNS) {
+      if (p.re.test(node.value)) {
+        failures.push(`forbidden ${p.name} pattern matched in public_response at ${node.path}`);
+      }
+    }
+  }
+  return failures;
+}
+
+// ---------------------------------------------------------------------------
+// Per-probe semantic checks
+// ---------------------------------------------------------------------------
+
+function checkMetadata(probe, push) {
+  if (probe.probe_kind !== PROBE_KIND) push(`probe_kind must be "${PROBE_KIND}" (got ${JSON.stringify(probe.probe_kind)})`);
+  if (probe.probe_version !== PROBE_VERSION) push(`probe_version must be "${PROBE_VERSION}" (got ${JSON.stringify(probe.probe_version)})`);
+  if (probe.schema_final !== false) push('schema_final must be false');
+  if (probe.runtime_enabled !== false) push('runtime_enabled must be false');
+  if (probe.production_admission !== false) push('production_admission must be false');
+  if (probe.public_safe !== true) push('public_safe must be true');
+  if (!probe.public_response || typeof probe.public_response !== 'object') push('public_response object is required');
+}
+
+function checkPending(probe, push) {
+  if (probe.admission_transition !== null) push('candidate_pending: admission_transition must be null (no transition yet)');
+  if (probe.admitted_assertion !== null) push('candidate_pending: admitted_assertion must be null (no admitted assertion)');
+  if (probe.public_response?.recall_eligible !== false) push('candidate_pending: public_response.recall_eligible must be false');
+  if (probe.public_response?.candidate_state !== 'proposed') push('candidate_pending: public_response.candidate_state must be canonical "proposed"');
+  if (probe.public_response?.rendered_candidate_payload !== false) push('candidate_pending: rendered_candidate_payload must be false');
+}
+
+function checkAccept(probe, push) {
+  const t = probe.admission_transition;
+  const a = probe.admitted_assertion;
+  const candId = probe.input?.candidate_id;
+  if (!t || typeof t !== 'object') { push('accept: admission_transition object is required'); return; }
+  if (!a || typeof a !== 'object') { push('accept: admitted_assertion object is required'); return; }
+  if (t.transition_kind !== 'admit_assertion') push('accept: transition_kind must be canonical "admit_assertion"');
+  if (t.outcome !== 'accepted') push('accept: transition outcome must be "accepted"');
+  // candidate -> transition -> admitted assertion chain.
+  if (!candId || t.source_candidate_id !== candId) push('accept: transition.source_candidate_id must link to input.candidate_id');
+  if (a.source_candidate_id !== candId) push('accept: admitted_assertion.source_candidate_id must link to input.candidate_id');
+  if (!t.admitted_assertion_id || t.admitted_assertion_id !== a.admitted_assertion_id) push('accept: transition.admitted_assertion_id must reference the admitted assertion');
+  if (a.admission_transition_id !== t.admission_transition_id) push('accept: admitted_assertion.admission_transition_id must reference the transition');
+  if (a.assertion_status !== 'active') push('accept: admitted assertion status must be canonical "active" (no bare "admitted" status)');
+  if (a.recall_eligible !== true) push('accept: admitted_assertion.recall_eligible must be true (under policy)');
+  if (probe.public_response?.recall_eligible !== true) push('accept: public_response.recall_eligible must be true');
+  if (probe.public_response?.rendered_candidate_payload !== false) push('accept: rendered_candidate_payload must be false');
+}
+
+function checkReject(probe, push) {
+  const t = probe.admission_transition;
+  if (probe.admitted_assertion !== null) push('reject: admitted_assertion must be null (no assertion minted)');
+  if (t && t.admitted_assertion_id !== null) push('reject: transition.admitted_assertion_id must be null');
+  if (t && t.outcome !== 'denied') push('reject: transition outcome must be "denied"');
+  if (probe.audit?.admission_receipt?.audit_event !== 'transition_denied') push('reject: audit event must be canonical "transition_denied"');
+  if (probe.public_response?.recall_eligible !== false) push('reject: public_response.recall_eligible must be false');
+  if (probe.public_response?.outcome !== 'denied') push('reject: public_response.outcome must be "denied"');
+}
+
+function checkSupersede(probe, push) {
+  const assertions = Array.isArray(probe.assertions) ? probe.assertions : [];
+  const superseded = assertions.find((x) => x.assertion_status === 'superseded');
+  const active = assertions.find((x) => x.assertion_status === 'active');
+  if (!superseded) { push('supersede: an assertion with canonical status "superseded" is required'); }
+  if (!active) { push('supersede: an assertion with canonical status "active" (corrected) is required'); }
+  if (superseded && superseded.recall_eligible !== false) push('supersede: superseded assertion must not be recall-eligible');
+  if (active && active.recall_eligible !== true) push('supersede: corrected active assertion must be recall-eligible');
+  if (superseded && active) {
+    if (active.supersedes_assertion_id !== superseded.assertion_id) push('supersede: corrected active must link supersedes_assertion_id -> prior');
+    if (superseded.superseded_by_assertion_id !== active.assertion_id) push('supersede: superseded prior must link superseded_by_assertion_id -> corrected');
+  }
+  const ordinary = probe.recall_projection?.ordinary_recall_members ?? [];
+  if (active && !ordinary.includes(active.assertion_id)) push('supersede: ordinary recall must include the corrected active assertion');
+  if (superseded && ordinary.includes(superseded.assertion_id)) push('supersede: ordinary recall must EXCLUDE the superseded assertion');
+}
+
+function checkMalformed(probe, push) {
+  if (probe.admitted_assertion !== null) push('malformed: admitted_assertion must be null (fail-closed mints nothing)');
+  if (probe.admission_transition !== null) push('malformed: admission_transition must be null (fail-closed before any transition)');
+  if (probe.public_response?.outcome !== 'refused') push('malformed: public_response.outcome must be "refused"');
+  const code = probe.public_response?.reason_code;
+  if (!code || !STABLE_PUBLIC_REASON_CODES.has(code)) push(`malformed: public reason_code must be a stable Dixie-family code (${[...STABLE_PUBLIC_REASON_CODES].join(' | ')}), got ${JSON.stringify(code)}`);
+  if (probe.public_response?.recall_eligible !== false) push('malformed: public_response.recall_eligible must be false');
+  if (probe.public_response?.rendered_candidate_payload !== false) push('malformed: rendered_candidate_payload must be false');
+}
+
+const SEMANTIC_CHECKS = {
+  candidate_pending_not_recallable: checkPending,
+  accept_candidate_to_admitted_assertion: checkAccept,
+  reject_candidate_no_assertion: checkReject,
+  supersede_with_corrected_assertion: checkSupersede,
+  malformed_or_unsafe_payload_fail_closed: checkMalformed,
+};
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function validate() {
+  const results = [];
+
+  for (const [scenarioId, filename] of Object.entries(REQUIRED)) {
+    const failures = [];
+    const push = (m) => failures.push(m);
+    const path = join(FIXTURES_DIR, filename);
+
+    if (!existsSync(path)) {
+      results.push({ scenarioId, filename, failures: ['file does not exist'] });
+      continue;
+    }
+
+    let probe;
+    try {
+      probe = JSON.parse(readFileSync(path, 'utf8'));
+    } catch (err) {
+      results.push({ scenarioId, filename, failures: [`JSON parse error: ${err.message}`] });
+      continue;
+    }
+
+    // scenario_id must match the file's slot.
+    if (probe.scenario_id !== scenarioId) push(`scenario_id must be "${scenarioId}" (got ${JSON.stringify(probe.scenario_id)})`);
+
+    checkMetadata(probe, push);
+
+    // No-leak sweep over the public response.
+    for (const f of noLeakFailures(probe.public_response ?? {})) push(f);
+
+    // Per-scenario semantic invariant.
+    const semantic = SEMANTIC_CHECKS[scenarioId];
+    if (semantic) semantic(probe, push);
+
+    results.push({ scenarioId, filename, failures });
+  }
+
+  return results;
+}
+
+function report(results) {
+  const lines = [];
+  lines.push('Phase 33C — Admission Wedge draft contract-probe validation');
+  lines.push('===========================================================');
+  lines.push(`fixtures dir: ${FIXTURES_DIR}`);
+  lines.push(`required probes: ${Object.keys(REQUIRED).length}`);
+  lines.push('');
+
+  let failedProbes = 0;
+  let totalFailures = 0;
+
+  // Stable ordering: REQUIRED is iterated in declaration order above.
+  for (const r of results) {
+    if (r.failures.length === 0) {
+      lines.push(`PASS  ${r.scenarioId}  (${basename(r.filename)})`);
+    } else {
+      failedProbes++;
+      totalFailures += r.failures.length;
+      lines.push(`FAIL  ${r.scenarioId}  (${basename(r.filename)})`);
+      for (const f of r.failures) lines.push(`        - ${f}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('-----------------------------------------------------------');
+  if (failedProbes === 0) {
+    lines.push(`RESULT: PASS — ${results.length}/${results.length} probes valid, 0 failures.`);
+  } else {
+    lines.push(`RESULT: FAIL — ${failedProbes}/${results.length} probes failed, ${totalFailures} failure(s).`);
+  }
+
+  process.stdout.write(lines.join('\n') + '\n');
+  return failedProbes === 0;
+}
+
+const ok = report(validate());
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary

Phase 33C adds the first Dixie-owned draft canonical Admission Wedge contract probe set.

This is docs + non-runtime fixture/probe only. It creates five draft v0 contract probes, a README, and an isolated validator under `docs/admission-wedge/fixtures/`.

It does not implement a live route, storage, auth, admission writes, runtime behavior, package exports, or final production schema.

## Files

New:

- docs/admission-wedge/fixtures/README.md
- docs/admission-wedge/fixtures/validate-fixtures.mjs
- docs/admission-wedge/fixtures/candidate-pending-not-recallable.json
- docs/admission-wedge/fixtures/accept-candidate-to-admitted-assertion.json
- docs/admission-wedge/fixtures/reject-candidate-no-assertion.json
- docs/admission-wedge/fixtures/supersede-with-corrected-assertion.json
- docs/admission-wedge/fixtures/malformed-or-unsafe-payload-fail-closed.json

Modified:

- docs/ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md

The tracked edit is a minimal Phase 33C status note.

## Probe cases

The five draft v0 probes are:

- `candidate_pending_not_recallable`
- `accept_candidate_to_admitted_assertion`
- `reject_candidate_no_assertion`
- `supersede_with_corrected_assertion`
- `malformed_or_unsafe_payload_fail_closed`

Each probe uses shared metadata:

- `probe_kind: "admission_wedge_contract_probe"`
- `probe_version: "dixie_admission_wedge_probe_v0"`
- `status: "draft_contract_probe"`
- `schema_final: false`
- `runtime_enabled: false`
- `production_admission: false`
- `public_safe: true`

The probes use synthetic short IDs only.

## Validator

The validator is isolated and docs-only:

- Node built-ins only
- no package changes
- no runtime imports
- no route imports
- no DB/storage/network/env access
- validates only `docs/admission-wedge/fixtures`
- emits deterministic PASS/FAIL output
- exits nonzero on failure

It checks:

- all five required scenario files exist
- JSON parses
- required metadata
- public response no-leak rules
- pending candidate is not recallable
- accepted candidate links candidate → transition → admitted assertion and becomes recall eligible
- rejected candidate mints no admitted assertion and remains non-recallable
- supersession includes only the corrected active assertion in ordinary recall
- malformed input fails closed and mints no admitted assertion

## Draft / non-runtime status

All probes are draft v0 contract probes, not final schema.

The probe vocabulary is Dixie/Straylight-aligned where possible:

- proposed / candidate state direction
- active admitted assertion direction
- transition_denied-family direction while preserving pending-vs-denied distinction
- superseded as audit/provenance prior state
- corrected active as active assertion direction, not necessarily a new status
- invalid_request / class_validation_failed family for shape failures
- no-leak / unsafe projection family for public projection refusal

Freeside Characters should wait before mutating local proof labels. Future Freeside reconciliation remains separately gated.

## Codex audit

Codex returned:

- VERDICT: ACCEPT
- no required patches

Codex confirmed:

- scope is docs + non-runtime fixture/probe only
- changed files are exactly one tracked Phase 33B back-reference plus the seven new `docs/admission-wedge/fixtures` files
- no app source, route/API handler, storage/migration, auth implementation, package/lockfile, config, CI, generated, or Freeside Characters files changed
- all five required probes exist and carry the required metadata
- probe content satisfies the required invariants
- README correctly states draft/non-runtime status and blocked lanes
- validator is isolated and docs-only
- validation passed

## Validation

Validated locally:

- git diff --check: clean
- no-index whitespace checks over README, validator, and all five JSON probes: no whitespace diagnostics
- node docs/admission-wedge/fixtures/validate-fixtures.mjs: PASS, 5/5 probes valid, 0 failures

No obvious docs/markdown lint target was found.

## Non-goals

This PR does not authorize or add:

- live Dixie admission route
- production admission
- production storage
- production auth/consent
- public remember-this
- Discord command
- Discord history ingestion
- user chat becoming memory
- Freeside Characters runtime changes
- package exports
- LLM/voice
- Finn production wiring
- forget/revoke/correction UI
- final schema freeze
- route/API handler changes
- storage/migration changes
- auth implementation
- package or lockfile changes
- config, CI, or generated changes
