### PR TITLE
Phase 33E docs: harden Admission Wedge probe draft

### DIFF
--- a/docs/ADMISSION-WEDGE-PROBE-HARDENING-GATE.md
+++ b/docs/ADMISSION-WEDGE-PROBE-HARDENING-GATE.md
@@ -432,3 +432,45 @@ This Phase 33D succeeds if **all** of the following hold:
 - ADR-022E (durable-store gate, still held), ADR-026C / ADR-026D
   (capability/route guardrails) — any future admission storage/route must clear
   these.
+
+---
+
+## 12. Phase 33E status note (implemented)
+
+> **Phase 33E — Admission Wedge probe hardening draft v1 / vocabulary
+> refinement (added later).** Phase 33E acted on the §7 recommended lane and
+> implemented the **draft v1 / vocabulary hardening only**. It is a Dixie-side
+> **docs + non-runtime fixture/probe/validator** slice.
+
+- **What it changed.** It updated `docs/admission-wedge/fixtures/README.md`, the
+  five Phase 33C probe JSONs, and `docs/admission-wedge/fixtures/validate-fixtures.mjs`.
+  The probes are bumped to `probe_version: dixie_admission_wedge_probe_v1`
+  (`status: draft_contract_probe`, `hardening_phase: "33E"`) and gain explicit
+  non-final markers (`schema_final: false`, `canonical_schema: false`,
+  `route_contract: false`), a draft `idempotency` placeholder
+  (`idempotency_final: false`), draft signer/authority fields
+  (`authority_signer_type_draft` / `authority_scope_draft` /
+  `authority_binding_final: false`), a `receipt_split` public/private boundary,
+  synthetic-only identity markers (`synthetic_binding: true` /
+  `identity_binding_final: false`), and a Straylight primitive-review marker
+  (`straylight_primitive_review: "required_before_route_design"` /
+  `straylight_primitive_review_complete: false`). The validator was hardened to
+  enforce all of the above plus a stronger no-leak / pending-vs-denied sweep.
+- **What it preserved.** All five Phase 33C semantic scenarios
+  (`candidate_pending_not_recallable`, `accept_candidate_to_admitted_assertion`,
+  `reject_candidate_no_assertion`, `supersede_with_corrected_assertion`,
+  `malformed_or_unsafe_payload_fail_closed`) are preserved unchanged in meaning;
+  none was removed, renamed, or split, and **no sixth probe was added**. The
+  public-surface values the freeside-characters Phase 45F adapter reads are
+  preserved, so the gated mirror refresh maps cleanly.
+- **What it did NOT do.** It added **no** live admission route, **no** route
+  design, **no** storage writes, **no** auth implementation, **no** live calls,
+  and **no** production admission/storage/auth/consent. It touched no app
+  source, route, config, package, or lockfile, and did not edit
+  `../freeside-characters`. It **did not freeze a final/canonical/production
+  schema**, and does **not** claim Phase 33E produces a final schema, a live
+  Dixie admission route, completed Straylight primitive review, final
+  idempotency semantics, or production signer/identity binding. The draft fields
+  are placeholders only.
+- **Validation.** `git diff --check` clean; `node
+  docs/admission-wedge/fixtures/validate-fixtures.mjs` → PASS (5/5).

--- a/docs/admission-wedge/fixtures/README.md
+++ b/docs/admission-wedge/fixtures/README.md
@@ -1,63 +1,126 @@
-# Admission Wedge — Draft Contract Probes (Phase 33C)
+# Admission Wedge — Draft Contract Probes (Phase 33C → 33E hardening)
 
-> **Phase**: 33C — Admission Wedge canonical fixture/probe draft
+> **Phase**: 33C (canonical fixture/probe draft) → **33E** (probe hardening
+> draft v1 / vocabulary refinement)
 > **Status**: **docs + non-runtime fixture/probe only.** No live route, no
 > storage, no auth, no admission writes, no runtime behavior.
-> **Schema status**: **draft v0 — NOT frozen.** These probes are a *proposal*
-> for cross-repo review, not a production schema.
+> **Schema status**: **draft v1 — NOT frozen, NOT canonical, NOT a route
+> contract.** These probes are a *proposal* for cross-repo review, not a
+> production schema.
 
-This directory holds the first Dixie-owned **draft v0** Admission Wedge contract
-probes. They are deterministic, fully synthetic, public-safe JSON files plus an
-isolated, dependency-free validator. They exist to pin a *shape* for cross-repo
-review — they do **not** implement admission.
+This directory holds the Dixie-owned Admission Wedge contract probes. Phase 33C
+authored them as **draft v0**; **Phase 33E** hardens them to **draft v1**
+(`dixie_admission_wedge_probe_v1`) — refining vocabulary and field names and
+adding draft hardening placeholders — **while preserving all five Phase 33C
+semantic scenarios unchanged in meaning**. They are deterministic, fully
+synthetic, public-safe JSON files plus an isolated, dependency-free validator.
+They exist to pin a *shape* for cross-repo review — they do **not** implement
+admission.
 
 ## What this is (and is not)
 
 - **Is**: a set of static JSON contract probes and an offline validator that
-  checks their shape and no-leak properties.
+  checks their shape, draft hardening markers, and no-leak properties.
 - **Is not**: a live route, an API handler, storage, auth/consent, an admission
-  implementation, a package export, or a frozen schema.
+  implementation, a package export, a canonical schema, a route contract, or a
+  frozen schema.
 
 Per the [Phase 33B alignment decision](../../ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md),
 **Dixie owns this first canonical probe proposal** for cross-repo review.
 **Straylight (`@loa/straylight`) remains the canonical primitive / substrate
 owner** of the assertion-lifecycle vocabulary; Dixie consumes and mirrors those
-names rather than coining its own. **Freeside Characters should wait** for this
-Dixie-authored probe set before mutating its local proof labels (fixtures,
-reducer, runner) — the probes give it a canonical shape to reconcile against
-rather than a guess. This work does **not** edit Freeside Characters and does
-not mutate its local labels.
+names rather than coining its own. A **Straylight primitive/vocabulary review is
+required before any route design and has NOT been performed** (every probe
+carries `straylight_primitive_review: "required_before_route_design"` and
+`straylight_primitive_review_complete: false`). This work does **not** edit
+Freeside Characters and does not mutate its local labels.
 
-## Not authorized by Phase 33C
+## Not authorized by Phase 33C / 33E
 
-No live Dixie admission route, no production admission, no production storage, no
-production auth/consent, no public `remember-this`, no Discord command, no
-Discord history ingestion, no user chat becoming memory, no Freeside Characters
-runtime change, no package export, no LLM/voice behavior, no Finn production
-wiring, no forget/revoke/correction UI, and **no final schema freeze**.
+No live Dixie admission route, no route design, no production admission, no
+production storage, no production auth/consent, no public `remember-this`, no
+Discord command, no Discord history ingestion, no user chat becoming memory, no
+Freeside Characters runtime change, no package export, no LLM/voice behavior, no
+Finn production wiring, no forget/revoke/correction UI, and **no final schema
+freeze**. Phase 33E adds **no** sixth probe.
 
 To be unambiguous about current reality: Dixie today exposes a read-only,
 default-off, fail-closed **recall** route (`POST /api/recall/intake`). It has
 **no admission route, no admission concept in route code, and no production
-storage**; admission semantics live upstream in `@loa/straylight`. Phase 33C
-implements no runtime behavior and changes no Dixie application/source/route/
+storage**; admission semantics live upstream in `@loa/straylight`. Phase 33C/33E
+implement no runtime behavior and change no Dixie application/source/route/
 config code.
 
-## The five probes
+## The five probes (preserved)
 
-Each probe is a single JSON object with a shared envelope: synthetic `input`
-(may carry a private `unsafe_marker:` token), a modeled transition / assertion /
-recall projection, a private `audit` object, and a clean `public_response`. The
+Phase 33E **preserves all five** Phase 33C semantic scenarios — it does not
+remove, rename, or split them, and adds no sixth probe. Each probe is a single
+JSON object with a shared envelope: synthetic `input` (may carry a private
+`unsafe_marker:` token), a draft `idempotency` placeholder, a modeled transition
+/ assertion / recall projection, a `receipt_split` declaring the public/private
+boundary, a private `audit` object, and a clean `public_response`. The
 `public_response` is the only surface a caller would see, and the validator
 proves it never leaks private material.
 
 | File | Scenario | What it proves |
 |------|----------|----------------|
-| `candidate-pending-not-recallable.json` | A | A candidate exists as canonical `proposed`; no admission transition; no admitted assertion; `recall_eligible` is false; the payload is not echoed in the public projection. |
-| `accept-candidate-to-admitted-assertion.json` | B | A candidate is accepted via an `admit_assertion` transition linking candidate → admitted assertion (canonical status `active`); it becomes recall-eligible under policy; a receipt/audit split exists; the raw payload is not echoed. |
-| `reject-candidate-no-assertion.json` | C | A candidate is denied (canonical `transition_denied` audit event); **no** admitted assertion is minted; the candidate stays non-recallable; a rejection receipt exists on the audit boundary; the public response is safe. |
+| `candidate-pending-not-recallable.json` | A | A candidate exists as canonical `proposed`; no admission transition; no admitted assertion; `recall_eligible` is false; the public outcome uses no denied/rejected vocabulary (pending ≠ denied); the payload is not echoed. |
+| `accept-candidate-to-admitted-assertion.json` | B | A candidate is accepted via an `admit_assertion` transition linking candidate → transition → admitted assertion (canonical status `active`); it becomes recall-eligible under draft policy; a public/private receipt split exists; the raw payload is not echoed. |
+| `reject-candidate-no-assertion.json` | C | A candidate is denied by an **explicit** rejection transition (canonical `transition_denied` audit event); **no** admitted assertion is minted; the candidate stays non-recallable; a rejection receipt exists on the audit boundary; the public response is safe. |
 | `supersede-with-corrected-assertion.json` | D | A prior assertion moves to canonical `superseded`; a corrected assertion is `active`; ordinary recall includes the corrected active assertion **only**; the superseded prior remains audit/provenance only; the public response is safe. |
 | `malformed-or-unsafe-payload-fail-closed.json` | E | A malformed/unsafe input fails closed with a stable reason code from the existing Dixie refusal family; **no** admitted assertion is minted; no raw payload, unsafe marker, source material, or stack trace appears in the public response. |
+
+## Phase 33E hardening (draft v1)
+
+Phase 33E updates the draft probes to **v1 / hardening revision** without
+implying a final schema. The hardening clarifies:
+
+- **Draft v1 metadata.** `probe_version: dixie_admission_wedge_probe_v1`,
+  `status: draft_contract_probe`, `hardening_phase: "33E"`, plus the explicit
+  non-final markers `schema_final: false`, `canonical_schema: false`,
+  `route_contract: false`, `runtime_enabled: false`,
+  `production_admission: false`, `public_safe: true`.
+- **Pending vs denied.** The pending probe is explicitly `proposed`/pending with
+  no transition; its public outcome must **not** use
+  `denied`/`rejected`/`transition_denied` vocabulary. The rejection probe binds
+  that vocabulary to an **explicit** denied transition, not to a mere pending
+  absence.
+- **Admitted assertion lifecycle.** The accepted probe links candidate →
+  transition → admitted assertion; the admitted assertion is canonical `active`
+  and recall-eligible under draft policy. `admitted` is a lifecycle outcome
+  label, not a final canonical status name.
+- **Corrected active / supersession.** The corrected active assertion is the
+  `active` member of a `(superseded, active)` pair (a relationship/direction,
+  not a standalone status); ordinary recall includes the corrected active
+  assertion only; the superseded prior is audit/provenance only.
+- **Signer / authority (draft).** Transition-bearing probes carry
+  `authority_signer_type_draft`, `authority_scope_draft`, and
+  `authority_binding_final: false`. The field names and binding are draft; this
+  is **not** a production auth claim, and service auth is not end-user consent.
+- **Synthetic tenant/estate/actor binding.** Identity ids are short synthetic
+  labels confined to the private `input`/`audit` sections, never the
+  `public_response`. Every probe carries `synthetic_binding: true` and
+  `identity_binding_final: false`.
+- **Idempotency placeholder (draft).** Every write/transition/fail-closed probe
+  carries an `idempotency` block (`idempotency_key_draft`,
+  `idempotency_scope_draft`, `idempotency_final: false`). This is a placeholder
+  closing the known Phase 33D gap; final idempotency semantics
+  (candidate-id-keyed vs header-keyed vs both) are **not** decided here.
+- **Receipt / audit split.** A `receipt_split` block declares the boundary:
+  `public_receipt_ref` (public-safe, mirrored on `public_response` where a
+  receipt is minted; `null` for the pending and fail-closed probes that mint no
+  public receipt), `audit_receipt_ref` (audit-private), `audit_private: true`,
+  and `public_audit_detail: false`. The full receipt detail stays on the private
+  `audit` object.
+- **Recall eligibility.** Pending/rejected/malformed remain recall-ineligible;
+  the accepted active assertion is recall-eligible; the superseded prior is not
+  ordinary-recall eligible; the corrected active assertion is ordinary-recall
+  eligible. Eligibility is paired with the canonical `recall_use_instruction`
+  (`RecallUseInstruction`) signal.
+- **Straylight primitive review marker.** Every probe records
+  `straylight_primitive_review: "required_before_route_design"` and
+  `straylight_primitive_review_complete: false` — the review is **required
+  before any route design and has not occurred**.
 
 ## Vocabulary: canonical (aligned) vs draft (proposed)
 
@@ -70,21 +133,28 @@ later, separately-gated phase; nothing here is frozen.
 | Pre-admission candidate state | `proposed` | Canonical `AssertionStatus` (Straylight-owned) — aligned. Not the Freeside-local `candidate_pending`. |
 | Admitted assertion status | `active` | Canonical `AssertionStatus` (Straylight-owned) — aligned. There is no bare `admitted` status. |
 | Act of admission | transition `admit_assertion` + audit event `assertion_admitted` | Canonical (Straylight-owned) — aligned. |
-| Denied admission | audit event `transition_denied` | Canonical (Straylight-owned) — aligned. Not a coined `rejected` status. |
+| Denied admission | audit event `transition_denied` (explicit denied transition) | Canonical (Straylight-owned) — aligned. Not a coined `rejected` status. |
 | Correction | `(superseded, active)` pair + supersede link | Canonical statuses (Straylight-owned) — aligned. No coined `corrected_active` status. |
 | Recallability signal | `RecallUseInstruction` (`usable` … `do_not_use_for_action`) | Canonical (Straylight-owned) — aligned. |
 | Shape-failure reason code | `ingress.invalid_request` | Dixie-local refusal family (Dixie-owned) — aligned to existing code. |
 | Class-failure reason code | `seam.class_validation_failed` | Dixie-local refusal family (Dixie-owned) — aligned to existing code. |
+| Signer / authority field | `authority_signer_type_draft`, `authority_scope_draft`, `authority_binding_final` | **DRAFT** — Dixie-proposed; value `policy_service` is a canonical `SignerType` member, but the field name + binding are draft and not production auth. |
+| Idempotency placeholder | `idempotency_key_draft`, `idempotency_scope_draft`, `idempotency_final` | **DRAFT** — placeholder only; semantics not final. |
+| Receipt / audit split | `receipt_split` (`public_receipt_ref`, `audit_receipt_ref`, `audit_private`, `public_audit_detail`) | **DRAFT** — Dixie-proposed split, subject to reconciliation. |
 | Link / receipt field names | `source_candidate_id`, `admission_transition_id`, `admitted_assertion_id`, `supersedes_assertion_id`, `superseded_by_assertion_id`, `recall_use_instruction`, `rendered_candidate_payload`, `receipt_public_ref` | **DRAFT** — Dixie-proposed, subject to reconciliation. |
 
 The pending-vs-denied distinction is preserved deliberately: a candidate with no
 transition is simply `proposed` (probe A), which is **not** the same as an
 explicit `transition_denied` (probe C). The probes keep these on separate
-scenarios so the distinction is provable rather than collapsed.
+scenarios so the distinction is provable rather than collapsed; the validator
+additionally asserts the pending probe's public outcome uses no rejection
+vocabulary.
 
-## No-leak rules (enforced by the validator)
+## No-leak / public-private boundary rules (enforced by the validator)
 
-The validator deep-walks each `public_response` and fails if it finds any of:
+The `public_response` is narrow; raw candidate/source/audit details remain
+private. The validator deep-walks each `public_response` and fails if it finds
+any of:
 
 - the generic synthetic `unsafe_marker:` token, or any raw candidate payload /
   source material;
@@ -93,9 +163,12 @@ The validator deep-walks each `public_response` and fails if it finds any of:
 - stack traces, `Error:`-style prefixes, or `file.ts:line` source references;
 - URLs (`http(s)://`, `ws(s)://`), bearer tokens, JWTs, `sk-` keys, or
   `-----BEGIN` PEM material;
-- long opaque IDs (`0x`-hex addresses, 40+ char hex runs);
-- audit-only keys (`tenant_id`, `estate_id`, `candidate_id`, `candidate_payload`,
-  `raw_reasons`, `policy_reason`, `receipt_id`, …).
+- long opaque IDs (`0x`-hex addresses, 40+ char hex runs, 32+ char opaque runs);
+- audit-only / private keys (`tenant_id`, `estate_id`, `candidate_id`,
+  `candidate_payload`, `raw_reasons`, `policy_reason`, `receipt_id`,
+  `audit_receipt_ref`, `audit_private`, `private_reason_family`, the
+  `idempotency_*_draft` placeholders, the `authority_*_draft` placeholders, and
+  the transition/assertion linkage ids).
 
 > **On sentinels.** No Dixie-side public leak-canary string exists in code (the
 > only over-cap sentinel is an internal `Symbol`, never serialized). These probes
@@ -111,21 +184,51 @@ node docs/admission-wedge/fixtures/validate-fixtures.mjs
 
 The validator uses **Node built-ins only** (no package install, no network, no
 storage, no env, no app/route imports). It checks that all five scenario files
-exist and parse, that the shared metadata is correct (`probe_kind`,
-`probe_version`, `schema_final=false`, `runtime_enabled=false`,
-`production_admission=false`, `public_safe=true`), that each scenario satisfies
-its invariant, and that no `public_response` leaks. It prints a deterministic
-PASS/FAIL summary and exits non-zero on any failure.
+exist and parse, that the five scenarios are preserved, that the shared draft v1
+metadata and hardening markers are correct (`probe_kind`, `probe_version`,
+`schema_final=false`, `canonical_schema=false`, `route_contract=false`,
+`runtime_enabled=false`, `production_admission=false`, `public_safe=true`,
+`hardening_phase=33E`, `identity_binding_final=false`, `synthetic_binding=true`,
+`straylight_primitive_review_complete=false`), that the draft idempotency,
+authority/signer, and receipt-split placeholders exist and are marked non-final,
+that identity ids are synthetic-only, that each scenario satisfies its invariant
+(including pending-vs-denied and the candidate→transition→admitted chain), and
+that no `public_response` leaks. It prints a deterministic PASS/FAIL summary and
+exits non-zero on any failure.
+
+## What Phase 33E still does NOT authorize
+
+Phase 33E hardens the draft probes; it changes nothing about what remains
+blocked. It does **not** authorize or imply: a live admission route, route
+design, storage writes, auth implementation, live calls, production admission,
+production storage/auth/consent, a public `remember-this`, Discord ingestion,
+user chat becoming memory, Freeside Characters runtime changes, package exports,
+LLM/voice, Finn production wiring, a forget/revoke/correction UI, a final schema
+freeze, a canonical/production schema, or a completed Straylight primitive
+review. The draft idempotency, signer/authority, and identity-binding fields are
+placeholders — not final idempotency semantics, not production auth, and not
+production identity binding.
 
 ## Provenance
 
-> **Phase 33D status note (added later).** Phase 33D
+> **Phase 33E status note (added later).** Phase 33E
 > ([`docs/ADMISSION-WEDGE-PROBE-HARDENING-GATE.md`](../../ADMISSION-WEDGE-PROBE-HARDENING-GATE.md))
-> accepts these probes as valid **draft v0** semantic probes and decides **not**
-> to mutate any probe JSON or this validator — any hardening is deferred to a
-> future, separately-gated Phase 33E that must preserve all five scenarios.
+> implemented the draft v1 / vocabulary hardening the Phase 33D gate selected
+> (its §7): it updated this README, the five probe JSONs, and the validator,
+> preserved all five Phase 33C semantic scenarios, added **no** sixth probe, and
+> did **not** add a live route, route design, storage, or auth — and it froze no
+> schema. The Freeside Characters Phase 45F local mirrors / adapter refresh
+> against `dixie_admission_wedge_probe_v1` remains a separate, separately-gated
+> effort on that repository; Phase 33E does not edit Freeside Characters.
 
+> **Phase 33D status note.** Phase 33D
+> ([`docs/ADMISSION-WEDGE-PROBE-HARDENING-GATE.md`](../../ADMISSION-WEDGE-PROBE-HARDENING-GATE.md))
+> accepted these probes as valid **draft v0** semantic probes and decided **not**
+> to mutate any probe JSON or this validator — deferring any hardening to this
+> separately-gated Phase 33E, which preserves all five scenarios.
+
+- [`docs/ADMISSION-WEDGE-PROBE-HARDENING-GATE.md`](../../ADMISSION-WEDGE-PROBE-HARDENING-GATE.md) — Phase 33D hardening-decision gate (§5 topics, §7 selected lane) and the Phase 33E status note recording this implementation.
 - [`docs/ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md`](../../ADMISSION-WEDGE-FIXTURE-PROBE-ALIGNMENT-DECISION.md) — Phase 33B Dixie-first ownership decision and minimum probe set (§6) / schema surfaces (§7) / vocabulary directions (§8).
 - [`docs/ADMISSION-WEDGE-CONTRACT-RESPONSE.md`](../../ADMISSION-WEDGE-CONTRACT-RESPONSE.md) — Phase 33A contract response: the core invariant, draft v0 vocabulary, and reconciliation directions.
 - [`docs/integration/phase-32e-recall-wedge-route-contract.md`](../../integration/phase-32e-recall-wedge-route-contract.md) — the Recall Wedge route contract and BFF/Straylight ownership split this probe set assumes (but does not mutate).
-- `@loa/straylight` — semantic owner of the assertion lifecycle and the canonical vocabulary the probes align to.
+- `@loa/straylight` — semantic owner of the assertion lifecycle and the canonical vocabulary the probes align to. **No Straylight primitive review has been performed.**

--- a/docs/admission-wedge/fixtures/accept-candidate-to-admitted-assertion.json
+++ b/docs/admission-wedge/fixtures/accept-candidate-to-admitted-assertion.json
@@ -1,13 +1,20 @@
 {
   "probe_kind": "admission_wedge_contract_probe",
-  "probe_version": "dixie_admission_wedge_probe_v0",
-  "scenario": "draft_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v1",
+  "status": "draft_contract_probe",
   "scenario_id": "accept_candidate_to_admitted_assertion",
   "schema_final": false,
+  "canonical_schema": false,
+  "route_contract": false,
   "runtime_enabled": false,
   "production_admission": false,
   "public_safe": true,
-  "intent": "A proposed candidate is accepted; an admission transition links it to an admitted, active assertion that becomes recall-eligible under policy, without echoing the raw candidate payload.",
+  "hardening_phase": "33E",
+  "identity_binding_final": false,
+  "synthetic_binding": true,
+  "straylight_primitive_review": "required_before_route_design",
+  "straylight_primitive_review_complete": false,
+  "intent": "A proposed candidate is accepted; an admission transition links it to an admitted, active assertion that becomes recall-eligible under draft policy, without echoing the raw candidate payload.",
   "invariant_refs": [
     "inv3_accepted_transition_creates_or_references_admitted_assertion",
     "inv2_candidate_not_recallable_before_admission",
@@ -27,14 +34,22 @@
     "recall_eligible",
     "recall_use_instruction",
     "rendered_candidate_payload",
-    "receipt_public_ref"
+    "public_receipt_ref",
+    "audit_receipt_ref",
+    "authority_signer_type_draft",
+    "authority_scope_draft",
+    "idempotency_key_draft",
+    "idempotency_scope_draft"
   ],
   "notes": [
-    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
-    "Canonical alignment: the ACT of admission is the canonical Straylight transition 'admit_assertion' and audit event 'assertion_admitted'; the resulting STATUS is canonical 'active'. There is NO bare 'admitted' status upstream, so the probe deliberately avoids 'admitted'/'admitted_active_assertion' as a status value.",
-    "Recall eligibility is expressed as 'under policy': a boolean recall_eligible plus the canonical RecallUseInstruction signal ('usable'), not an unconditional grant. The boolean and the canonical signal are kept side by side so future reconciliation is cheap.",
-    "Receipt/audit split: the public_response carries only a public-safe receipt reference and summary; the full admission receipt (policy reasoning, candidate ref, ids) lives on the audit object.",
-    "Link field names (source_candidate_id, admission_transition_id, admitted_assertion_id) are DRAFT and subject to reconciliation against Straylight-owned assertion types."
+    "DRAFT v1 / PROBE ONLY — Phase 33E vocabulary hardening over the Phase 33C draft v0 probe. NOT a frozen schema, NOT canonical, NOT a live route contract.",
+    "Canonical alignment: the ACT of admission is the canonical Straylight transition 'admit_assertion' and audit event 'assertion_admitted'; the resulting STATUS is canonical 'active'. There is NO bare 'admitted' status upstream, so the probe deliberately avoids 'admitted'/'admitted_active_assertion' as a status value. 'admitted' survives only as a lifecycle outcome label on public_response.outcome, not as a final canonical status name.",
+    "Chain (hardened): the probe links candidate -> transition -> admitted assertion: input.candidate_id == transition.source_candidate_id == admitted_assertion.source_candidate_id, transition.admitted_assertion_id == admitted_assertion.admitted_assertion_id, and admitted_assertion.admission_transition_id == transition.admission_transition_id.",
+    "Recall eligibility is expressed as 'under draft policy': a boolean recall_eligible plus the canonical RecallUseInstruction signal ('usable'), not an unconditional grant. The admitted active assertion is recall-eligible; the boolean and the canonical signal are kept side by side so future reconciliation is cheap.",
+    "Authority/signer (draft, non-final): the transition carries authority_signer_type_draft ('policy_service', a canonical SignerType member mirrored at app/src/routes/recall-intake.ts) plus authority_scope_draft and authority_binding_final:false. The FIELD names and binding are draft; this is NOT a production auth claim and service auth is not end-user consent.",
+    "Idempotency (draft, non-final): the admission transition write carries idempotency_key_draft / idempotency_scope_draft / idempotency_final:false. Final idempotency semantics are NOT decided here.",
+    "Receipt/audit split (hardened): public_response carries only a public-safe receipt reference (public_receipt_ref) and summary; the full admission receipt (policy reasoning, candidate ref, ids, audit_event) lives on the private audit object under audit_private:true / public_audit_detail:false. The two ref fields are deliberately distinct values.",
+    "Identity binding is synthetic-only and non-final (synthetic_binding:true, identity_binding_final:false). Link field names are DRAFT and subject to reconciliation against Straylight-owned assertion types. A Straylight primitive/vocabulary review is required before route design and has NOT been performed."
   ],
   "input": {
     "candidate_id": "cand_demo_002",
@@ -46,6 +61,11 @@
     "source_kind": "synthetic_probe",
     "source_ref": "unsafe_marker:source-ref-demo-002"
   },
+  "idempotency": {
+    "idempotency_key_draft": "idem_demo_002",
+    "idempotency_scope_draft": "per_tenant_admission_transition_draft",
+    "idempotency_final": false
+  },
   "admission_transition": {
     "admission_transition_id": "trans_demo_001",
     "transition_kind": "admit_assertion",
@@ -53,6 +73,8 @@
     "source_candidate_id": "cand_demo_002",
     "admitted_assertion_id": "assn_demo_001",
     "authority_signer_type_draft": "policy_service",
+    "authority_scope_draft": "admit_assertion_class_preference_draft",
+    "authority_binding_final": false,
     "policy_decision": "accepted_under_policy"
   },
   "admitted_assertion": {
@@ -64,11 +86,17 @@
     "recall_eligible": true,
     "recall_use_instruction": "usable"
   },
+  "receipt_split": {
+    "public_receipt_ref": "rcpt_public_demo_002",
+    "audit_receipt_ref": "rcpt_demo_002",
+    "audit_private": true,
+    "public_audit_detail": false
+  },
   "recall_projection": {
     "ordinary_recall_members": [
       "assn_demo_001"
     ],
-    "explanation": "The admitted assertion is active and recall-eligible under policy, so it appears in ordinary recall."
+    "explanation": "The admitted assertion is active and recall-eligible under draft policy, so it appears in ordinary recall."
   },
   "public_response": {
     "outcome": "admitted",
@@ -76,8 +104,8 @@
     "recall_eligible": true,
     "recall_use_instruction": "usable",
     "rendered_candidate_payload": false,
-    "receipt_public_ref": "rcpt_demo_002",
-    "public_summary": "Candidate admitted under policy. The resulting assertion is active and recall-eligible. The candidate payload is not echoed."
+    "receipt_public_ref": "rcpt_public_demo_002",
+    "public_summary": "Candidate admitted under draft policy. The resulting assertion is active and recall-eligible. The candidate payload is not echoed."
   },
   "audit": {
     "admission_receipt": {

--- a/docs/admission-wedge/fixtures/candidate-pending-not-recallable.json
+++ b/docs/admission-wedge/fixtures/candidate-pending-not-recallable.json
@@ -1,13 +1,20 @@
 {
   "probe_kind": "admission_wedge_contract_probe",
-  "probe_version": "dixie_admission_wedge_probe_v0",
-  "scenario": "draft_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v1",
+  "status": "draft_contract_probe",
   "scenario_id": "candidate_pending_not_recallable",
   "schema_final": false,
+  "canonical_schema": false,
+  "route_contract": false,
   "runtime_enabled": false,
   "production_admission": false,
   "public_safe": true,
-  "intent": "A candidate proposal exists but no admission transition has occurred; it is not recallable and its payload is never echoed in the public projection.",
+  "hardening_phase": "33E",
+  "identity_binding_final": false,
+  "synthetic_binding": true,
+  "straylight_primitive_review": "required_before_route_design",
+  "straylight_primitive_review_complete": false,
+  "intent": "A candidate proposal exists but no admission transition has occurred; it is proposed/pending, it is not recallable, and its payload is never echoed in the public projection.",
   "invariant_refs": [
     "inv1_candidate_is_not_admitted",
     "inv2_candidate_not_recallable_before_admission",
@@ -20,13 +27,19 @@
     "candidate_state",
     "recall_eligible",
     "rendered_candidate_payload",
-    "admission_transition"
+    "admission_transition",
+    "idempotency_key_draft",
+    "idempotency_scope_draft",
+    "audit_receipt_ref"
   ],
   "notes": [
-    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
+    "DRAFT v1 / PROBE ONLY — Phase 33E vocabulary hardening over the Phase 33C draft v0 probe. NOT a frozen schema, NOT canonical, NOT a live route contract.",
     "Canonical alignment: the pre-admission state uses the canonical Straylight AssertionStatus 'proposed' (Straylight-owned), NOT the Freeside-local proof label 'candidate_pending'. The scenario_id keeps the descriptive name 'candidate_pending_not_recallable' purely as a scenario label, never as a status value.",
-    "Pending-vs-denied distinction: a candidate with NO admission_transition is simply 'proposed'. This is deliberately distinct from a denied candidate (see reject-candidate-no-assertion.json, which carries a 'transition_denied' audit event). The two must not be collapsed.",
-    "Field names under draft_vocab_used are directional proposals subject to cross-repo reconciliation; only the canonical_vocab_used terms are treated as upstream-owned."
+    "Pending-vs-denied distinction (hardened): a candidate with NO admission_transition is simply 'proposed'. The public outcome 'accepted_as_proposed' must NOT use denied/rejected/transition_denied vocabulary. This is deliberately distinct from the explicit denial case (reject-candidate-no-assertion.json, which carries a 'transition_denied' audit event). The two must not be collapsed.",
+    "Idempotency (draft, non-final): the candidate-intake write attempt carries a draft idempotency placeholder (idempotency_key_draft / idempotency_scope_draft / idempotency_final:false). Final idempotency semantics (candidate-id-keyed vs header-keyed vs both) are NOT decided here.",
+    "Receipt/audit split (hardened): no public receipt is minted for a mere proposal (receipt_split.public_receipt_ref is null); the audit receipt reference is audit-private (audit_private:true, public_audit_detail:false).",
+    "Identity binding is synthetic-only and non-final (synthetic_binding:true, identity_binding_final:false). tenant/estate/actor ids are short synthetic labels confined to the private input/audit sections, never the public_response.",
+    "Field names under draft_vocab_used are directional proposals subject to cross-repo reconciliation; only canonical_vocab_used terms are treated as upstream-owned. A Straylight primitive/vocabulary review is required before any route design and has NOT been performed."
   ],
   "input": {
     "candidate_id": "cand_demo_001",
@@ -38,8 +51,19 @@
     "source_kind": "synthetic_probe",
     "source_ref": "unsafe_marker:source-ref-demo-001"
   },
+  "idempotency": {
+    "idempotency_key_draft": "idem_demo_001",
+    "idempotency_scope_draft": "per_tenant_candidate_write_draft",
+    "idempotency_final": false
+  },
   "admission_transition": null,
   "admitted_assertion": null,
+  "receipt_split": {
+    "public_receipt_ref": null,
+    "audit_receipt_ref": "rcpt_demo_001",
+    "audit_private": true,
+    "public_audit_detail": false
+  },
   "recall_projection": {
     "ordinary_recall_members": [],
     "explanation": "No admitted, active assertion exists; the proposed candidate is excluded from ordinary recall."

--- a/docs/admission-wedge/fixtures/malformed-or-unsafe-payload-fail-closed.json
+++ b/docs/admission-wedge/fixtures/malformed-or-unsafe-payload-fail-closed.json
@@ -1,13 +1,20 @@
 {
   "probe_kind": "admission_wedge_contract_probe",
-  "probe_version": "dixie_admission_wedge_probe_v0",
-  "scenario": "draft_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v1",
+  "status": "draft_contract_probe",
   "scenario_id": "malformed_or_unsafe_payload_fail_closed",
   "schema_final": false,
+  "canonical_schema": false,
+  "route_contract": false,
   "runtime_enabled": false,
   "production_admission": false,
   "public_safe": true,
-  "intent": "A malformed or unsafe candidate input is presented; the path fails closed with a stable reason code, mints no admitted assertion, and leaks no raw payload, unsafe marker, source material, or stack trace into the public response.",
+  "hardening_phase": "33E",
+  "identity_binding_final": false,
+  "synthetic_binding": true,
+  "straylight_primitive_review": "required_before_route_design",
+  "straylight_primitive_review_complete": false,
+  "intent": "A malformed or unsafe candidate input is presented; the path fails closed with a stable public reason code from the existing Dixie refusal family, mints no admitted assertion, and leaks no raw payload, unsafe marker, source material, or stack trace into the public response.",
   "invariant_refs": [
     "inv6_fail_closed_no_leak",
     "inv3_accepted_transition_creates_or_references_admitted_assertion",
@@ -17,14 +24,18 @@
   "draft_vocab_used": [
     "reason_code",
     "recall_eligible",
-    "rendered_candidate_payload"
+    "rendered_candidate_payload",
+    "audit_receipt_ref",
+    "idempotency_key_draft",
+    "idempotency_scope_draft"
   ],
   "notes": [
-    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
-    "Reason-code alignment: the public reason_code is grounded in the existing Dixie-local refusal family, NOT a coined 'unsupported_admission_shape' or 'unsafe_*' public code. A malformed envelope maps to 'ingress.invalid_request' (HTTP-400-shaped at ingress); an unsupported assertion class would instead map to 'seam.class_validation_failed'. These exact strings exist today in app/src/services/straylight-recall-intake/refusal-mapping.ts and are Dixie-owned (not Straylight-owned).",
-    "No-leak seal: the unsafe input lives only in the 'input' and 'audit' sections and carries a generic synthetic 'unsafe_marker:' token (NOT the Freeside-local sentinel string). The public_response must contain no unsafe_marker, no raw payload, no source material, and no stack trace. The validator proves this by deep-walking public_response.",
-    "Public/audit split: admission decides its own split explicitly and does NOT inherit the recall default. raw_reasons that could carry internal/unsafe material are OMITTED from the public body and retained only on the audit object — mirroring the Phase 32K storage_unavailable posture, applied here by deliberate choice.",
-    "No admitted assertion is minted on the fail-closed path."
+    "DRAFT v1 / PROBE ONLY — Phase 33E vocabulary hardening over the Phase 33C draft v0 probe. NOT a frozen schema, NOT canonical, NOT a live route contract.",
+    "Reason-code alignment (hardened): the PUBLIC reason_code is the stable Dixie-local ingress.invalid_request family, NOT a coined 'unsupported_admission_shape' or 'unsafe_*' public code. A malformed envelope maps to 'ingress.invalid_request'; an unsupported assertion class would instead map to 'seam.class_validation_failed'. These exact strings exist today in app/src/services/straylight-recall-intake/refusal-mapping.ts and are Dixie-owned (not Straylight-owned). A finer PRIVATE reason family may live on the audit object (audit.private_reason_family) without ever reaching the public body.",
+    "No-leak seal (hardened): the unsafe input lives only in the private 'input' and 'audit' sections and carries a generic synthetic 'unsafe_marker:' token (NOT the Freeside-local sentinel string). The public_response must contain NO unsafe_marker, NO raw payload, NO source material, NO stack trace, and no tenant/estate/actor id, candidate_payload, raw_reasons, or audit-only receipt detail. The validator proves this by deep-walking public_response.",
+    "Receipt/audit split (hardened): NO public receipt is minted on the fail-closed path (receipt_split.public_receipt_ref is null); the refusal is recorded on the private audit object only (audit_private:true, public_audit_detail:false).",
+    "Idempotency (draft, non-final): even a fail-closed write attempt carries idempotency_key_draft / idempotency_scope_draft / idempotency_final:false so a retried malformed submission coalesces rather than minting duplicate refusal state. Final semantics are NOT decided here.",
+    "Authority (draft): NO authority/signer field is asserted because NO admission transition occurs on the fail-closed path — the request is refused at ingress before any transition. No admitted assertion is minted. Identity binding is synthetic-only and non-final."
   ],
   "input": {
     "tenant_id": "tenant_demo",
@@ -35,8 +46,19 @@
     "candidate_payload": "unsafe_marker:malformed-body-demo-005",
     "source_ref": "unsafe_marker:source-ref-demo-005"
   },
+  "idempotency": {
+    "idempotency_key_draft": "idem_demo_005",
+    "idempotency_scope_draft": "per_tenant_candidate_write_draft",
+    "idempotency_final": false
+  },
   "admission_transition": null,
   "admitted_assertion": null,
+  "receipt_split": {
+    "public_receipt_ref": null,
+    "audit_receipt_ref": "rcpt_demo_005",
+    "audit_private": true,
+    "public_audit_detail": false
+  },
   "recall_projection": {
     "ordinary_recall_members": [],
     "explanation": "Input failed closed before any admission; no assertion exists and nothing enters ordinary recall."
@@ -49,7 +71,9 @@
     "public_summary": "The admission request was malformed and was refused. No candidate detail is echoed."
   },
   "audit": {
+    "receipt_id": "rcpt_demo_005",
     "refusal_class": "ingress.invalid_request",
+    "private_reason_family": "ingress.invalid_request.malformed_envelope_draft",
     "raw_reasons": [
       "unsafe_marker:malformed-body-demo-005",
       "draft_probe_validation: proposed_assertion_class not in canonical AssertionClass union"

--- a/docs/admission-wedge/fixtures/reject-candidate-no-assertion.json
+++ b/docs/admission-wedge/fixtures/reject-candidate-no-assertion.json
@@ -1,13 +1,20 @@
 {
   "probe_kind": "admission_wedge_contract_probe",
-  "probe_version": "dixie_admission_wedge_probe_v0",
-  "scenario": "draft_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v1",
+  "status": "draft_contract_probe",
   "scenario_id": "reject_candidate_no_assertion",
   "schema_final": false,
+  "canonical_schema": false,
+  "route_contract": false,
   "runtime_enabled": false,
   "production_admission": false,
   "public_safe": true,
-  "intent": "A proposed candidate is denied admission; no admitted assertion is minted, the candidate remains non-recallable, and a rejection receipt exists on the audit boundary.",
+  "hardening_phase": "33E",
+  "identity_binding_final": false,
+  "synthetic_binding": true,
+  "straylight_primitive_review": "required_before_route_design",
+  "straylight_primitive_review_complete": false,
+  "intent": "A proposed candidate is denied admission by an explicit rejection transition; no admitted assertion is minted, the candidate remains non-recallable, and a rejection receipt exists on the audit boundary.",
   "invariant_refs": [
     "inv4_rejected_candidate_never_recallable",
     "inv3_accepted_transition_creates_or_references_admitted_assertion",
@@ -22,14 +29,21 @@
     "source_candidate_id",
     "recall_eligible",
     "rendered_candidate_payload",
-    "receipt_public_ref"
+    "public_receipt_ref",
+    "audit_receipt_ref",
+    "authority_signer_type_draft",
+    "authority_scope_draft",
+    "idempotency_key_draft",
+    "idempotency_scope_draft"
   ],
   "notes": [
-    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
-    "Canonical alignment: rejection is anchored on the canonical Straylight audit event 'transition_denied' (a denied 'admit_assertion' transition). The probe deliberately does NOT coin a parallel 'rejected' status.",
-    "Synonym-collision flag: the Freeside-local proof labels 'rejected', 'candidate_rejected', and 'candidate_not_admitted' are a three-way synonym collision and are referenced here as proof labels only, all reconciling onto 'transition_denied'. Note 'candidate_not_admitted' (pending, never decided) is semantically distinct from an explicit denial; this probe is the explicit-denial case.",
+    "DRAFT v1 / PROBE ONLY — Phase 33E vocabulary hardening over the Phase 33C draft v0 probe. NOT a frozen schema, NOT canonical, NOT a live route contract.",
+    "Canonical alignment (hardened): rejection is anchored on the canonical Straylight audit event 'transition_denied' (a denied 'admit_assertion' transition) and a public outcome 'denied'. The denied/rejected/transition_denied vocabulary is bound to an EXPLICIT rejection transition (transition.outcome 'denied'), NOT to a mere pending absence of a transition. The probe deliberately does NOT coin a parallel 'rejected' status.",
+    "Synonym-collision flag: the Freeside-local proof labels 'rejected', 'candidate_rejected', and 'candidate_not_admitted' are a three-way synonym collision and are referenced here as proof labels only, all reconciling onto 'transition_denied'. Note 'candidate_not_admitted' (pending, never decided) is semantically distinct from this explicit denial; the pending case is candidate-pending-not-recallable.json.",
     "Rejection is terminal for recall eligibility; any future appeal/correction path is separately gated and not implied here.",
-    "Receipt/audit split: the public_response carries only a stable outcome and public summary; the denial receipt (policy reason, candidate ref, audit event) lives on the audit object."
+    "Authority/signer (draft, non-final): the rejection transition carries authority_signer_type_draft ('policy_service', a canonical SignerType member) plus authority_scope_draft and authority_binding_final:false. NOT a production auth claim.",
+    "Idempotency (draft, non-final): the denied admission write attempt carries idempotency_key_draft / idempotency_scope_draft / idempotency_final:false so a retried rejection coalesces; final semantics are NOT decided here.",
+    "Receipt/audit split (hardened): public_response carries only a stable outcome, a public-safe receipt reference (receipt_public_ref), and a public summary; the denial receipt detail (policy reason, candidate ref, audit event) lives on the private audit object (audit_private:true, public_audit_detail:false). Identity binding is synthetic-only and non-final."
   ],
   "input": {
     "candidate_id": "cand_demo_003",
@@ -41,6 +55,11 @@
     "source_kind": "synthetic_probe",
     "source_ref": "unsafe_marker:source-ref-demo-003"
   },
+  "idempotency": {
+    "idempotency_key_draft": "idem_demo_003",
+    "idempotency_scope_draft": "per_tenant_admission_transition_draft",
+    "idempotency_final": false
+  },
   "admission_transition": {
     "admission_transition_id": "trans_demo_002",
     "transition_kind": "admit_assertion",
@@ -48,9 +67,17 @@
     "source_candidate_id": "cand_demo_003",
     "admitted_assertion_id": null,
     "authority_signer_type_draft": "policy_service",
+    "authority_scope_draft": "admit_assertion_class_claim_draft",
+    "authority_binding_final": false,
     "policy_decision": "denied_by_policy"
   },
   "admitted_assertion": null,
+  "receipt_split": {
+    "public_receipt_ref": "rcpt_public_demo_003",
+    "audit_receipt_ref": "rcpt_demo_003",
+    "audit_private": true,
+    "public_audit_detail": false
+  },
   "recall_projection": {
     "ordinary_recall_members": [],
     "explanation": "No admitted assertion was minted; the denied candidate is excluded from ordinary recall and remains non-recallable."
@@ -59,6 +86,7 @@
     "outcome": "denied",
     "recall_eligible": false,
     "rendered_candidate_payload": false,
+    "receipt_public_ref": "rcpt_public_demo_003",
     "public_summary": "Candidate admission was denied. No assertion was created and the candidate is not recallable."
   },
   "audit": {

--- a/docs/admission-wedge/fixtures/supersede-with-corrected-assertion.json
+++ b/docs/admission-wedge/fixtures/supersede-with-corrected-assertion.json
@@ -1,13 +1,20 @@
 {
   "probe_kind": "admission_wedge_contract_probe",
-  "probe_version": "dixie_admission_wedge_probe_v0",
-  "scenario": "draft_contract_probe",
+  "probe_version": "dixie_admission_wedge_probe_v1",
+  "status": "draft_contract_probe",
   "scenario_id": "supersede_with_corrected_assertion",
   "schema_final": false,
+  "canonical_schema": false,
+  "route_contract": false,
   "runtime_enabled": false,
   "production_admission": false,
   "public_safe": true,
-  "intent": "An existing active assertion is superseded by a corrected active assertion; ordinary recall includes only the corrected active assertion while the superseded prior state remains audit/provenance only.",
+  "hardening_phase": "33E",
+  "identity_binding_final": false,
+  "synthetic_binding": true,
+  "straylight_primitive_review": "required_before_route_design",
+  "straylight_primitive_review_complete": false,
+  "intent": "An existing active assertion is superseded by a corrected active assertion; ordinary recall includes only the corrected active assertion while the superseded prior assertion remains audit/provenance only.",
   "invariant_refs": [
     "inv5_supersession_auditable_recall_active_only",
     "inv2_candidate_not_recallable_before_admission",
@@ -26,15 +33,22 @@
     "recall_eligible",
     "recall_use_instruction",
     "rendered_candidate_payload",
-    "receipt_public_ref"
+    "public_receipt_ref",
+    "audit_receipt_ref",
+    "authority_signer_type_draft",
+    "authority_scope_draft",
+    "idempotency_key_draft",
+    "idempotency_scope_draft"
   ],
   "notes": [
-    "DRAFT / PROBE ONLY — not a frozen schema and not a live contract.",
-    "Canonical alignment: correction is expressed as the canonical (superseded, active) PAIR — the prior assertion moves to canonical status 'superseded' and the corrected assertion is canonical status 'active' with a supersede link. The probe deliberately does NOT coin a 'corrected'/'corrected_active' status; 'corrected active' is direction, not a new status value.",
-    "The superseded prior remains audit/provenance only: recall_eligible is false on the superseded record (signalled with RecallUseInstruction 'do_not_use_for_action'), and it is excluded from ordinary recall.",
+    "DRAFT v1 / PROBE ONLY — Phase 33E vocabulary hardening over the Phase 33C draft v0 probe. NOT a frozen schema, NOT canonical, NOT a live route contract.",
+    "Canonical alignment: correction is expressed as the canonical (superseded, active) PAIR — the prior assertion moves to canonical status 'superseded' and the corrected assertion is canonical status 'active' with a supersede link. The probe deliberately does NOT coin a 'corrected'/'corrected_active' status; 'corrected active' is a relationship/direction, not a new standalone status value.",
+    "Recall direction (hardened): ordinary recall includes the corrected active assertion ONLY (recall_projection.ordinary_recall_members). The superseded prior remains audit/provenance only: recall_eligible is false on the superseded record (signalled with RecallUseInstruction 'do_not_use_for_action') and it is in excluded_from_ordinary_recall.",
     "Supersession is a follow-on transition over an already-admitted assertion, not a first-pass admission outcome.",
-    "Forget/revoke/correction UI remains out of scope; this probe defines no user-facing correction surface.",
-    "Link field names (supersedes_assertion_id, superseded_by_assertion_id, supersession_transition_id) are DRAFT and subject to reconciliation against Straylight-owned assertion types."
+    "Authority/signer (draft, non-final): the supersession transition carries authority_signer_type_draft ('policy_service', a canonical SignerType member) plus authority_scope_draft and authority_binding_final:false. NOT a production auth claim.",
+    "Idempotency (draft, non-final): the supersession write carries idempotency_key_draft / idempotency_scope_draft / idempotency_final:false; final semantics are NOT decided here.",
+    "Receipt/audit split (hardened): public_response carries only a public-safe receipt reference (receipt_public_ref) and summary; the full supersession receipt lives on the private audit object (audit_private:true, public_audit_detail:false). The superseded prior body stays audit-only.",
+    "Forget/revoke/correction UI remains out of scope; this probe defines no user-facing correction surface. Identity binding is synthetic-only and non-final; link field names are DRAFT and subject to reconciliation against Straylight-owned assertion types."
   ],
   "input": {
     "tenant_id": "tenant_demo",
@@ -45,6 +59,11 @@
     "source_kind": "synthetic_probe",
     "source_ref": "unsafe_marker:source-ref-demo-004"
   },
+  "idempotency": {
+    "idempotency_key_draft": "idem_demo_004",
+    "idempotency_scope_draft": "per_tenant_supersession_transition_draft",
+    "idempotency_final": false
+  },
   "supersession_transition": {
     "supersession_transition_id": "trans_demo_003",
     "transition_kind": "admit_assertion",
@@ -52,6 +71,8 @@
     "supersedes_assertion_id": "assn_demo_002",
     "corrected_assertion_id": "assn_demo_003",
     "authority_signer_type_draft": "policy_service",
+    "authority_scope_draft": "supersede_assertion_class_claim_draft",
+    "authority_binding_final": false,
     "policy_decision": "correction_accepted_under_policy"
   },
   "assertions": [
@@ -73,6 +94,12 @@
       "recall_use_instruction": "usable"
     }
   ],
+  "receipt_split": {
+    "public_receipt_ref": "rcpt_public_demo_004",
+    "audit_receipt_ref": "rcpt_demo_004",
+    "audit_private": true,
+    "public_audit_detail": false
+  },
   "recall_projection": {
     "ordinary_recall_members": [
       "assn_demo_003"
@@ -88,7 +115,7 @@
     "recall_eligible": true,
     "recall_use_instruction": "usable",
     "rendered_candidate_payload": false,
-    "receipt_public_ref": "rcpt_demo_004",
+    "receipt_public_ref": "rcpt_public_demo_004",
     "public_summary": "A corrected active assertion now supersedes the prior assertion. Ordinary recall reflects only the corrected active assertion."
   },
   "audit": {

--- a/docs/admission-wedge/fixtures/validate-fixtures.mjs
+++ b/docs/admission-wedge/fixtures/validate-fixtures.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
-// Phase 33C — Admission Wedge draft contract-probe validator.
+// Phase 33E — Admission Wedge draft v1 contract-probe validator.
 //
 // DOCS-ONLY / NON-RUNTIME. This script is an isolated, dependency-free shape /
-// no-leak validator over the JSON probe fixtures in this directory. It is NOT
-// wired into the application, NOT imported by any route, and exercises NO live
-// admission behavior.
+// no-leak / hardening validator over the JSON probe fixtures in this directory.
+// It is NOT wired into the application, NOT imported by any route, and exercises
+// NO live admission behavior. It freezes no schema and authorizes no route,
+// storage, auth, or live admission.
 //
 // Hard isolation rules (enforced by construction):
 //   * Node built-ins ONLY (node:fs, node:path, node:url). No third-party deps.
@@ -13,16 +14,29 @@
 //   * No database, storage, network, or environment access.
 //   * Validates ONLY files under docs/admission-wedge/fixtures.
 //
-// What it proves:
-//   1. All five required scenario files exist and parse as JSON.
-//   2. Shared metadata is present and correct (probe_kind / probe_version /
-//      schema_final=false / runtime_enabled=false / production_admission=false /
-//      public_safe=true).
+// What it proves (Phase 33E hardening):
+//   1. All five required scenario files exist and parse as JSON, and the five
+//      semantic scenarios are preserved (no rename / split / removal).
+//   2. Shared metadata is present and correct for draft v1: probe_kind /
+//      probe_version='dixie_admission_wedge_probe_v1' / status /
+//      schema_final=false / canonical_schema=false / route_contract=false /
+//      runtime_enabled=false / production_admission=false / public_safe=true /
+//      hardening_phase='33E' / identity_binding_final=false /
+//      synthetic_binding=true / straylight_primitive_review markers (review NOT
+//      complete, required before route design).
 //   3. No public_response leaks raw candidate payload, unsafe markers, sentinel
-//      strings, stack traces, URLs, tokens, PEM keys, long IDs, or audit-only
-//      fields.
-//   4. Each scenario satisfies its load-bearing invariant (pending / accept /
-//      reject / supersede / fail-closed).
+//      strings, stack traces, URLs, tokens, PEM keys, long opaque IDs, or
+//      audit-only / private fields (tenant/estate/actor ids, candidate_payload,
+//      raw_reasons, audit/idempotency/authority detail).
+//   4. Synthetic-only identity binding: tenant/estate/actor ids are short
+//      synthetic labels, never real-looking or long operational IDs.
+//   5. Each scenario satisfies its load-bearing invariant (pending / accept /
+//      reject / supersede / fail-closed), including the hardened pending-vs-
+//      denied distinction, the candidate->transition->admitted chain, the
+//      corrected-active-only recall projection, and the fail-closed no-mint.
+//   6. Draft hardening placeholders exist and are marked non-final: idempotency
+//      (all five write/transition/fail-closed probes), authority/signer (all
+//      transition-bearing probes), and the public/private receipt split.
 //
 // It emits a deterministic pass/fail summary and exits non-zero on any failure.
 
@@ -32,7 +46,8 @@ import { fileURLToPath } from 'node:url';
 
 const FIXTURES_DIR = dirname(fileURLToPath(import.meta.url));
 
-// scenario_id -> on-disk filename. The five required scenarios.
+// scenario_id -> on-disk filename. The five required scenarios (PRESERVED — a
+// future phase must not rename, split, or remove these).
 const REQUIRED = {
   candidate_pending_not_recallable: 'candidate-pending-not-recallable.json',
   accept_candidate_to_admitted_assertion: 'accept-candidate-to-admitted-assertion.json',
@@ -42,7 +57,30 @@ const REQUIRED = {
 };
 
 const PROBE_KIND = 'admission_wedge_contract_probe';
-const PROBE_VERSION = 'dixie_admission_wedge_probe_v0';
+const PROBE_VERSION = 'dixie_admission_wedge_probe_v1';
+const PROBE_STATUS = 'draft_contract_probe';
+const HARDENING_PHASE = '33E';
+
+// Scenarios that carry an explicit admission/supersession transition (and so
+// must carry a draft authority/signer field).
+const TRANSITION_BEARING = new Set([
+  'accept_candidate_to_admitted_assertion',
+  'reject_candidate_no_assertion',
+  'supersede_with_corrected_assertion',
+]);
+
+// Scenarios that mint a public-safe receipt reference on the public_response.
+const PUBLIC_RECEIPT_BEARING = new Set([
+  'accept_candidate_to_admitted_assertion',
+  'reject_candidate_no_assertion',
+  'supersede_with_corrected_assertion',
+]);
+
+// Scenarios that mint NO public receipt (only a private audit receipt ref).
+const NO_PUBLIC_RECEIPT = new Set([
+  'candidate_pending_not_recallable',
+  'malformed_or_unsafe_payload_fail_closed',
+]);
 
 // Reason codes the fail-closed public path may carry. Grounded in the existing
 // Dixie-local refusal family (app/src/services/straylight-recall-intake/
@@ -72,7 +110,7 @@ const FORBIDDEN_SUBSTRINGS = [
   '-----BEGIN ',
 ];
 
-// Regex leak patterns checked against every string value in a public_response.
+// Regex leak patterns checked against every string value/key in a public_response.
 const FORBIDDEN_PATTERNS = [
   { name: 'url', re: /\bhttps?:\/\//i },
   { name: 'ws-url', re: /\bwss?:\/\//i },
@@ -81,6 +119,7 @@ const FORBIDDEN_PATTERNS = [
   { name: 'bearer-token', re: /\bBearer\s+\S+/ },
   { name: '0x-hex-address', re: /0x[0-9a-fA-F]{16,}/ },
   { name: 'long-hex-id', re: /\b[0-9a-fA-F]{40,}\b/ },
+  { name: 'long-opaque-id', re: /[A-Za-z0-9_-]{32,}/ },
   { name: 'stack-frame', re: /\bat\s+\/?\S+:\d+:\d+/ },
   { name: 'source-line-ref', re: /\.[jt]s:\d+/ },
   { name: 'error-prefix', re: /\b(?:Error|TypeError|RangeError|SyntaxError):\s/ },
@@ -89,28 +128,69 @@ const FORBIDDEN_PATTERNS = [
 // Keys that are audit-only / private and must never appear in a public_response
 // (deep). The public projection carries only public-safe references/summaries.
 const FORBIDDEN_PUBLIC_KEYS = new Set([
+  // identity binding (synthetic, audit-only)
   'tenant_id',
   'estate_id',
   'candidate_id',
   'source_candidate_id',
+  'prior_assertion_id',
   'proposing_actor_id',
   'correcting_actor_id',
   'caller_actor_id',
   'actor_id',
   'service_actor',
+  // candidate / source material
   'candidate_payload',
   'corrected_candidate_payload',
   'source_ref',
   'source_kind',
+  // audit reasoning / receipts
   'raw_reasons',
   'policy_reason',
   'policy_decision',
   'receipt_id',
   'audit_only',
+  'audit_private',
+  'public_audit_detail',
+  'audit_receipt_ref',
+  'private_reason_family',
+  'refusal_class',
   'decision_time_label',
   'audit_event',
+  'recall_eligibility_result',
+  // transition / assertion linkage ids (audit-only)
+  'admission_transition_id',
   'admitted_assertion_id',
+  'supersession_transition_id',
+  'supersedes_assertion_id',
+  'superseded_by_assertion_id',
+  'corrected_assertion_id',
+  // draft idempotency placeholders (audit/internal, never public)
+  'idempotency_key_draft',
+  'idempotency_scope_draft',
+  'idempotency_final',
+  // draft authority placeholders (never public)
+  'authority_signer_type_draft',
+  'authority_scope_draft',
+  'authority_binding_final',
 ]);
+
+// Tokens that, if present in a pending probe's public outcome surface, would
+// wrongly collapse "proposed/pending" into "denied". The pending scenario must
+// not use rejection vocabulary on its public outcome.
+const REJECTION_VOCAB = /\b(?:denied|rejected|transition_denied)\b/i;
+
+// Synthetic identity fields checked on the private input section. They must be
+// short, lower-snake synthetic labels — never real-looking or long ids.
+const IDENTITY_FIELDS = [
+  'tenant_id',
+  'estate_id',
+  'proposing_actor_id',
+  'correcting_actor_id',
+  'caller_actor_id',
+];
+const SYNTHETIC_ID_RE = /^[a-z][a-z0-9_]*$/;
+const SYNTHETIC_ID_MAX_LEN = 40;
 
 // ---------------------------------------------------------------------------
 // Reporting helpers
@@ -139,9 +219,9 @@ function* walk(node, path = '$') {
 function noLeakFailures(publicResponse) {
   const failures = [];
   for (const node of walk(publicResponse, '$.public_response')) {
-    // Forbidden audit-only keys.
+    // Forbidden audit-only / private keys.
     if (node.kind === 'key' && FORBIDDEN_PUBLIC_KEYS.has(node.value)) {
-      failures.push(`audit-only key "${node.value}" present in public_response at ${node.path}`);
+      failures.push(`audit-only/private key "${node.value}" present in public_response at ${node.path}`);
     }
     // Forbidden substrings (checked on keys AND values).
     for (const s of FORBIDDEN_SUBSTRINGS) {
@@ -160,18 +240,131 @@ function noLeakFailures(publicResponse) {
 }
 
 // ---------------------------------------------------------------------------
-// Per-probe semantic checks
+// Shared hardening checks
 // ---------------------------------------------------------------------------
 
 function checkMetadata(probe, push) {
   if (probe.probe_kind !== PROBE_KIND) push(`probe_kind must be "${PROBE_KIND}" (got ${JSON.stringify(probe.probe_kind)})`);
-  if (probe.probe_version !== PROBE_VERSION) push(`probe_version must be "${PROBE_VERSION}" (got ${JSON.stringify(probe.probe_version)})`);
-  if (probe.schema_final !== false) push('schema_final must be false');
+  if (probe.probe_version !== PROBE_VERSION) push(`probe_version must be "${PROBE_VERSION}" (draft v1) (got ${JSON.stringify(probe.probe_version)})`);
+  if (probe.status !== PROBE_STATUS) push(`status must be "${PROBE_STATUS}" (got ${JSON.stringify(probe.status)})`);
+  if (probe.schema_final !== false) push('schema_final must be false (schema is NOT frozen)');
+  if (probe.canonical_schema !== false) push('canonical_schema must be false (not a canonical schema)');
+  if (probe.route_contract !== false) push('route_contract must be false (not a live route contract)');
   if (probe.runtime_enabled !== false) push('runtime_enabled must be false');
   if (probe.production_admission !== false) push('production_admission must be false');
   if (probe.public_safe !== true) push('public_safe must be true');
+  if (probe.hardening_phase !== HARDENING_PHASE) push(`hardening_phase must be "${HARDENING_PHASE}" (got ${JSON.stringify(probe.hardening_phase)})`);
+  if (probe.identity_binding_final !== false) push('identity_binding_final must be false (synthetic-only binding)');
+  if (probe.synthetic_binding !== true) push('synthetic_binding must be true (synthetic-only identity binding)');
   if (!probe.public_response || typeof probe.public_response !== 'object') push('public_response object is required');
 }
+
+// Straylight primitive review must be marked required-before-route-design and
+// NOT complete. The probe must not claim a completed primitive review or a
+// final/canonical schema.
+function checkStraylightMarkers(probe, push) {
+  if (probe.straylight_primitive_review !== 'required_before_route_design') {
+    push(`straylight_primitive_review must be "required_before_route_design" (got ${JSON.stringify(probe.straylight_primitive_review)})`);
+  }
+  if (probe.straylight_primitive_review_complete !== false) {
+    push('straylight_primitive_review_complete must be false (no Straylight primitive review has occurred)');
+  }
+}
+
+// Synthetic-only identity binding: any identity field present on input must be
+// a short, lower-snake synthetic label (rejects long / real-looking ids).
+function checkSyntheticIdentity(probe, push) {
+  const input = probe.input;
+  if (!input || typeof input !== 'object') return; // input shape is per-scenario
+  for (const f of IDENTITY_FIELDS) {
+    if (!(f in input)) continue;
+    const v = input[f];
+    if (typeof v !== 'string' || !SYNTHETIC_ID_RE.test(v) || v.length > SYNTHETIC_ID_MAX_LEN) {
+      push(`identity field input.${f} must be a short synthetic label (got ${JSON.stringify(v)})`);
+    }
+  }
+}
+
+// Draft idempotency placeholder, required on every write/transition/fail-closed
+// probe and explicitly marked non-final.
+function checkIdempotency(probe, push) {
+  const idem = probe.idempotency;
+  if (!idem || typeof idem !== 'object') {
+    push('idempotency draft placeholder object is required (idempotency_key_draft / idempotency_scope_draft / idempotency_final)');
+    return;
+  }
+  if (typeof idem.idempotency_key_draft !== 'string' || idem.idempotency_key_draft.length === 0) {
+    push('idempotency.idempotency_key_draft must be a non-empty draft string');
+  }
+  if (typeof idem.idempotency_scope_draft !== 'string' || idem.idempotency_scope_draft.length === 0) {
+    push('idempotency.idempotency_scope_draft must be a non-empty draft string');
+  }
+  if (idem.idempotency_final !== false) {
+    push('idempotency.idempotency_final must be false (idempotency semantics are NOT final)');
+  }
+}
+
+// Public/private receipt split. Every probe declares the split markers; the
+// public_receipt_ref is non-null and mirrored on the public_response only for
+// receipt-bearing scenarios, and null for the no-public-receipt scenarios.
+function checkReceiptSplit(probe, scenarioId, push) {
+  const rs = probe.receipt_split;
+  if (!rs || typeof rs !== 'object') {
+    push('receipt_split object is required (public_receipt_ref / audit_receipt_ref / audit_private / public_audit_detail)');
+    return;
+  }
+  if (rs.audit_private !== true) push('receipt_split.audit_private must be true');
+  if (rs.public_audit_detail !== false) push('receipt_split.public_audit_detail must be false');
+  if (typeof rs.audit_receipt_ref !== 'string' || rs.audit_receipt_ref.length === 0) {
+    push('receipt_split.audit_receipt_ref must be a non-empty (audit-private) reference');
+  }
+  if (PUBLIC_RECEIPT_BEARING.has(scenarioId)) {
+    if (typeof rs.public_receipt_ref !== 'string' || rs.public_receipt_ref.length === 0) {
+      push('receipt_split.public_receipt_ref must be a non-empty public-safe reference for this scenario');
+    } else if (probe.public_response?.receipt_public_ref !== rs.public_receipt_ref) {
+      push('receipt_split.public_receipt_ref must equal public_response.receipt_public_ref');
+    }
+  }
+  if (NO_PUBLIC_RECEIPT.has(scenarioId)) {
+    if (rs.public_receipt_ref !== null) {
+      push('receipt_split.public_receipt_ref must be null (no public receipt is minted for this scenario)');
+    }
+    if ('receipt_public_ref' in (probe.public_response ?? {})) {
+      push('public_response must not carry receipt_public_ref for a no-public-receipt scenario');
+    }
+  }
+}
+
+// Transition-bearing probes carry a DRAFT authority/signer field that does not
+// claim production auth.
+function transitionObject(probe) {
+  if (probe.admission_transition && typeof probe.admission_transition === 'object') return probe.admission_transition;
+  if (probe.supersession_transition && typeof probe.supersession_transition === 'object') return probe.supersession_transition;
+  return null;
+}
+
+function checkAuthorityDraft(probe, push) {
+  const t = transitionObject(probe);
+  if (!t) {
+    push('transition-bearing scenario must carry an admission/supersession transition object');
+    return;
+  }
+  if (typeof t.authority_signer_type_draft !== 'string' || t.authority_signer_type_draft.length === 0) {
+    push('transition must carry a draft authority field authority_signer_type_draft');
+  } else if (/production|final|live/i.test(t.authority_signer_type_draft)) {
+    push('authority_signer_type_draft must not claim production/final/live auth');
+  }
+  if (typeof t.authority_scope_draft !== 'string' || t.authority_scope_draft.length === 0) {
+    push('transition must carry a draft authority_scope_draft field');
+  }
+  if (t.authority_binding_final !== false) {
+    push('transition.authority_binding_final must be false (authority binding is NOT final / not production auth)');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-probe semantic checks (preserved invariants + hardening)
+// ---------------------------------------------------------------------------
 
 function checkPending(probe, push) {
   if (probe.admission_transition !== null) push('candidate_pending: admission_transition must be null (no transition yet)');
@@ -179,6 +372,14 @@ function checkPending(probe, push) {
   if (probe.public_response?.recall_eligible !== false) push('candidate_pending: public_response.recall_eligible must be false');
   if (probe.public_response?.candidate_state !== 'proposed') push('candidate_pending: public_response.candidate_state must be canonical "proposed"');
   if (probe.public_response?.rendered_candidate_payload !== false) push('candidate_pending: rendered_candidate_payload must be false');
+  // Hardened pending-vs-denied: a pending candidate must NOT use rejection
+  // vocabulary on its public outcome surface.
+  const pr = probe.public_response ?? {};
+  for (const k of ['outcome', 'candidate_state', 'public_summary']) {
+    if (typeof pr[k] === 'string' && REJECTION_VOCAB.test(pr[k])) {
+      push(`candidate_pending: public_response.${k} must not use denied/rejected/transition_denied vocabulary (pending != denied)`);
+    }
+  }
 }
 
 function checkAccept(probe, push) {
@@ -202,9 +403,12 @@ function checkAccept(probe, push) {
 
 function checkReject(probe, push) {
   const t = probe.admission_transition;
+  // Rejection vocabulary must be bound to an EXPLICIT transition, not a pending absence.
+  if (!t || typeof t !== 'object') { push('reject: an explicit admission_transition object is required'); return; }
   if (probe.admitted_assertion !== null) push('reject: admitted_assertion must be null (no assertion minted)');
-  if (t && t.admitted_assertion_id !== null) push('reject: transition.admitted_assertion_id must be null');
-  if (t && t.outcome !== 'denied') push('reject: transition outcome must be "denied"');
+  if (t.admitted_assertion_id !== null) push('reject: transition.admitted_assertion_id must be null');
+  if (t.transition_kind !== 'admit_assertion') push('reject: transition_kind must be canonical "admit_assertion"');
+  if (t.outcome !== 'denied') push('reject: transition outcome must be "denied"');
   if (probe.audit?.admission_receipt?.audit_event !== 'transition_denied') push('reject: audit event must be canonical "transition_denied"');
   if (probe.public_response?.recall_eligible !== false) push('reject: public_response.recall_eligible must be false');
   if (probe.public_response?.outcome !== 'denied') push('reject: public_response.outcome must be "denied"');
@@ -225,6 +429,8 @@ function checkSupersede(probe, push) {
   const ordinary = probe.recall_projection?.ordinary_recall_members ?? [];
   if (active && !ordinary.includes(active.assertion_id)) push('supersede: ordinary recall must include the corrected active assertion');
   if (superseded && ordinary.includes(superseded.assertion_id)) push('supersede: ordinary recall must EXCLUDE the superseded assertion');
+  if (probe.public_response?.recall_eligible !== true) push('supersede: public_response.recall_eligible must be true (corrected active)');
+  if (probe.public_response?.rendered_candidate_payload !== false) push('supersede: rendered_candidate_payload must be false');
 }
 
 function checkMalformed(probe, push) {
@@ -270,15 +476,28 @@ function validate() {
       continue;
     }
 
-    // scenario_id must match the file's slot.
+    // scenario_id must match the file's slot (scenarios preserved, never renamed).
     if (probe.scenario_id !== scenarioId) push(`scenario_id must be "${scenarioId}" (got ${JSON.stringify(probe.scenario_id)})`);
 
+    // Shared metadata + hardening markers.
     checkMetadata(probe, push);
+    checkStraylightMarkers(probe, push);
+    checkSyntheticIdentity(probe, push);
 
     // No-leak sweep over the public response.
     for (const f of noLeakFailures(probe.public_response ?? {})) push(f);
 
-    // Per-scenario semantic invariant.
+    // Draft idempotency placeholder is required on every write/transition/
+    // fail-closed probe (all five scenarios here).
+    checkIdempotency(probe, push);
+
+    // Public/private receipt split markers.
+    checkReceiptSplit(probe, scenarioId, push);
+
+    // Transition-bearing probes carry a draft authority/signer field.
+    if (TRANSITION_BEARING.has(scenarioId)) checkAuthorityDraft(probe, push);
+
+    // Per-scenario semantic invariant (preserved + hardened).
     const semantic = SEMANTIC_CHECKS[scenarioId];
     if (semantic) semantic(probe, push);
 
@@ -290,9 +509,10 @@ function validate() {
 
 function report(results) {
   const lines = [];
-  lines.push('Phase 33C — Admission Wedge draft contract-probe validation');
-  lines.push('===========================================================');
+  lines.push('Phase 33E — Admission Wedge draft v1 contract-probe validation');
+  lines.push('===============================================================');
   lines.push(`fixtures dir: ${FIXTURES_DIR}`);
+  lines.push(`probe version: ${PROBE_VERSION}`);
   lines.push(`required probes: ${Object.keys(REQUIRED).length}`);
   lines.push('');
 
@@ -312,7 +532,7 @@ function report(results) {
   }
 
   lines.push('');
-  lines.push('-----------------------------------------------------------');
+  lines.push('---------------------------------------------------------------');
   if (failedProbes === 0) {
     lines.push(`RESULT: PASS — ${results.length}/${results.length} probes valid, 0 failures.`);
   } else {


### PR DESCRIPTION
## Summary

Phase 33E hardens the Admission Wedge draft probes from v0 to v1.

This is Dixie-side docs + non-runtime fixture/probe/validator hardening only. It updates the five existing probe JSON files, the fixture README, the isolated docs-only validator, and the Phase 33D hardening gate note.

It preserves all five Phase 33C semantic scenarios and adds no sixth probe.

## Files

Modified:

- docs/ADMISSION-WEDGE-PROBE-HARDENING-GATE.md
- docs/admission-wedge/fixtures/README.md
- docs/admission-wedge/fixtures/validate-fixtures.mjs
- docs/admission-wedge/fixtures/candidate-pending-not-recallable.json
- docs/admission-wedge/fixtures/accept-candidate-to-admitted-assertion.json
- docs/admission-wedge/fixtures/reject-candidate-no-assertion.json
- docs/admission-wedge/fixtures/supersede-with-corrected-assertion.json
- docs/admission-wedge/fixtures/malformed-or-unsafe-payload-fail-closed.json

No app source, route/API handler, storage/migration, auth implementation, package/lockfile, config, CI, generated files, or Freeside Characters files changed.

## Probe hardening

All five probes are updated to:

- `probe_version: dixie_admission_wedge_probe_v1`
- `status: draft_contract_probe`
- `hardening_phase: "33E"`
- `schema_final: false`
- `canonical_schema: false`
- `route_contract: false`
- `runtime_enabled: false`
- `production_admission: false`
- `public_safe: true`

The v1 hardening clarifies:

- pending-vs-denied vocabulary
- explicit rejected transition semantics
- accepted candidate → transition → admitted active assertion linkage
- superseded prior assertion vs corrected active assertion relation
- malformed / unsafe fail-closed behavior
- public/private no-leak boundary
- draft signer/authority fields
- synthetic tenant/estate/actor binding
- draft idempotency placeholders
- receipt/audit public-private split
- recall eligibility representation
- Straylight primitive review marker

## Preserved scenarios

The five semantic scenarios are preserved:

- candidate_pending_not_recallable
- accept_candidate_to_admitted_assertion
- reject_candidate_no_assertion
- supersede_with_corrected_assertion
- malformed_or_unsafe_payload_fail_closed

No scenario file was removed, renamed, split, or replaced. No sixth probe was added.

## Validator hardening

The validator remains isolated and docs-only:

- Node built-ins only
- no app imports
- no route imports
- no storage/network/env access
- deterministic PASS/FAIL output
- nonzero on failure

It now enforces:

- all five required files and scenarios exist
- v1 metadata and non-final flags
- synthetic IDs only
- public no-leak rules
- pending scenario does not use denied / rejected / transition_denied public vocabulary
- rejected scenario has explicit denied transition and no admitted assertion
- accepted scenario links candidate → transition → admitted assertion
- supersession includes corrected active assertion only in ordinary recall
- malformed scenario fails closed and mints no admitted assertion
- draft authority/signer fields
- idempotency placeholders marked non-final
- receipt/audit split
- Straylight primitive review incomplete / required before route design

## Cross-repo compatibility

Freeside Characters Phase 45F local mirrors still pin `dixie_admission_wedge_probe_v0`.

That is acceptable because:

- Freeside Characters reads its own local mirrored probes, not these Dixie files.
- The Freeside adapter fails closed on an unknown probe version.
- A future Freeside mirror-refresh gate is required before Freeside consumes v1 mirrors.
- The public-surface fields Freeside semantically depends on remain preserved in v1.

## Results

Codex returned:

- VERDICT: ACCEPT
- no required patches

Codex confirmed:

- scope is exactly the eight expected modified files
- no app source, route/API handler, storage/migration, auth, package/lockfile, config, CI, generated, or Freeside Characters files changed
- all five semantic probes are preserved
- no sixth JSON probe exists
- v0 → v1 is acceptable and does not imply final schema
- cross-repo compatibility with Freeside Characters is acceptable
- validator hardening is acceptable
- no stale ladder wording, phase-numbering contradiction, schema-freeze overclaim, raw leak, or unredacted operational detail found

Validation:

- git diff --check: clean
- node docs/admission-wedge/fixtures/validate-fixtures.mjs: PASS, 5/5 probes valid
- extra Freeside cross-repo check: bun test packages/persona-engine/src/recall-wedge/admission-wedge-dixie-probe-adapter.test.ts: 37 pass, 0 fail

## Non-goals

This PR does not authorize or add:

- route/API handler
- route design
- storage writes
- auth implementation
- live calls
- live admission route
- production admission
- production storage/auth/consent
- public remember-this
- Discord command
- Discord history ingestion
- user chat becoming memory
- Freeside Characters runtime changes
- package exports
- LLM/voice
- Finn production wiring
- forget/revoke/correction UI
- final schema freeze
- completed Straylight primitive review claim
- final idempotency semantics
- production signer/authority semantics
- production tenant/estate/actor identity binding
