### PR TITLE
fix(web): add generic API post/delete helpers

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -50,6 +50,19 @@ export const api = {
     return apiFetch<T>(path);
   },
 
+  /** Generic POST request */
+  post<T>(path: string, body?: unknown): Promise<T> {
+    return apiFetch<T>(path, {
+      method: 'POST',
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+  },
+
+  /** Generic DELETE request */
+  delete<T>(path: string): Promise<T> {
+    return apiFetch<T>(path, { method: 'DELETE' });
+  },
+
   sendChat(prompt: string, sessionId?: string): Promise<ChatResponse> {
     return apiFetch('/api/chat', {
       method: 'POST',


### PR DESCRIPTION
Fixes #88.

This adds generic `api.post` and `api.delete` helpers to the typed web API client so `ScheduleManager` can call the schedule create/cancel endpoints without TypeScript errors.

Validation:
- `cd web && npm run typecheck`
- `cd web && npm test -- --run`

Bounty reference: charles-openclaw/charles-microbounties#16