### PR TITLE
Phase 33N feat: add Admission Wedge dev route spike

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,3 +95,17 @@ DIXIE_AUTONOMOUS_BUDGET=100000
 
 # HMAC secret for schedule callback verification (empty rejects all callbacks in production)
 # DIXIE_SCHEDULE_CALLBACK_SECRET=change-me-if-using-scheduled-callbacks
+
+# Phase 33N — dev/operator-only Admission Wedge route SPIKE (default OFF; NON-PRODUCTION).
+# Authorized narrowly by docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md.
+# Uses Storage Option A (no durable storage, no DB writes, no migrations). NOT production
+# admission. See docs/admission-wedge/PHASE-33N-DEV-SPIKE-RUNBOOK.md.
+# When unset/not exactly "true", POST /api/admission/intake is not registered at all.
+# DIXIE_ADMISSION_INTAKE_ENABLED=false
+# Dev/operator service token checked against the dedicated `x-admission-service-token` header
+# (NOT `Authorization`, to avoid colliding with the global /api/* allowlist gate). Synthetic;
+# NOT production auth; never logged/echoed. With BOTH this and the operator allowlist empty,
+# the enabled spike rejects all calls (fail-closed).
+# DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN=
+# Comma-separated dev/operator id allowlist checked against the `x-admission-operator-id` header.
+# DIXIE_ADMISSION_INTAKE_OPERATOR_IDS=

--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -91,6 +91,28 @@ export interface DixieConfig {
   recallIntakeDevSeedEnabled: boolean;
   /** Synthetic dev/operator tenant id to seed (empty when disabled). */
   recallIntakeDevSeedTenantId: string;
+
+  // Phase 33N: dev/operator-only Admission Wedge route spike (default OFF;
+  // NON-PRODUCTION). Authorized narrowly by Phase 33M
+  // (docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md
+  // §7–§15). Uses Storage Option A — no durable Admission Wedge storage, no DB
+  // writes, no migrations; safe future-intent receipts / public-safe outcomes
+  // only. The route is mounted in server.ts ONLY when this flag is true. This
+  // does NOT authorize production admission/storage/auth/consent, Freeside
+  // runtime integration, Discord ingestion, public remember-this, a final
+  // schema, or a completed Straylight primitive review.
+  admissionIntakeSpikeEnabled: boolean;
+  /** Dev/operator service token, checked constant-time against the dedicated
+   *  `x-admission-service-token` header — NOT `Authorization: Bearer`. The
+   *  global `/api/*` allowlist gate already owns `Authorization` (JWT wallet or
+   *  `Bearer dxk_` key) and is not exempt for `/api/admission`, so the admission
+   *  dev gate is layered behind that allowlist via a dedicated header to avoid
+   *  collision. '' when unset. NOT production auth; never logged or echoed
+   *  publicly. */
+  admissionIntakeSpikeServiceToken: string;
+  /** Dev/operator id allowlist (checked against the `x-admission-operator-id`
+   *  header); [] when unset. An empty token AND empty allowlist rejects all. */
+  admissionIntakeSpikeOperatorIds: string[];
 }
 
 /**
@@ -156,6 +178,23 @@ const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
  *                                          identity format. Enabled + missing/invalid → throws
  *                                          at startup (fail-closed; never silently seed nothing).
  *                                          Provide via env/secret — do NOT commit a live id.
+ *
+ * Phase 33N additions (dev/operator-only Admission Wedge route SPIKE; default OFF; NON-PRODUCTION):
+ * DIXIE_ADMISSION_INTAKE_ENABLED         (optional) — when 'true', mount the dev/operator-only
+ *                                          POST /api/admission/intake route SPIKE. Default 'false';
+ *                                          when off the route is NOT registered at all. dev/operator
+ *                                          ONLY — NOT production admission. Uses no durable storage
+ *                                          (Storage Option A). Authorized narrowly by Phase 33M.
+ * DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN   (optional) — dev/operator service token checked against
+ *                                          the dedicated `x-admission-service-token` header
+ *                                          (constant-time); NOT `Authorization` (avoids colliding
+ *                                          with the global /api/* allowlist gate). Empty when
+ *                                          unset. NOT production auth; never logged/echoed.
+ * DIXIE_ADMISSION_INTAKE_OPERATOR_IDS    (optional) — comma-separated dev/operator id allowlist
+ *                                          checked against the `x-admission-operator-id` header.
+ *                                          Empty when unset. With BOTH the token and the operator
+ *                                          allowlist empty, the enabled spike rejects ALL calls
+ *                                          (fail-closed; no production default).
  */
 export function loadConfig(): DixieConfig {
   const finnUrl = process.env.FINN_URL;
@@ -349,5 +388,20 @@ export function loadConfig(): DixieConfig {
         recallIntakeDevSeedTenantId: tenantId,
       };
     })(),
+
+    // Phase 33N: dev/operator-only Admission Wedge route spike (default off,
+    // NON-PRODUCTION). The gate is the explicit enable flag; all spike config
+    // defaults to off/false/empty. The token and operator-id allowlist are
+    // parsed unconditionally (so they are inert when the spike is disabled);
+    // the route handler enforces the fail-closed "empty token AND empty
+    // allowlist rejects all" rule, and the route is only mounted in server.ts
+    // when admissionIntakeSpikeEnabled is true. No production defaults.
+    admissionIntakeSpikeEnabled: process.env.DIXIE_ADMISSION_INTAKE_ENABLED === 'true',
+    admissionIntakeSpikeServiceToken:
+      process.env.DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN ?? '',
+    admissionIntakeSpikeOperatorIds: (process.env.DIXIE_ADMISSION_INTAKE_OPERATOR_IDS ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
   };
 }

--- a/app/src/routes/admission-intake.ts
+++ b/app/src/routes/admission-intake.ts
@@ -1,0 +1,285 @@
+// Phase 33N — POST /api/admission/intake (dev/operator-only route SPIKE).
+//
+// NON-PRODUCTION. Authorized NARROWLY by Phase 33M
+// (docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md §7–§15):
+// a single, disabled-by-default, dev/operator-only route spike behind an
+// explicit env gate + operator/service allowlist, using Storage Option A (no
+// durable Admission Wedge storage, no DB writes, no migrations — safe
+// future-intent receipts / public-safe outcomes only). Rollback is trivial:
+// there is no durable state to roll back.
+//
+// This route does NOT authorize and does NOT implement: production admission;
+// production storage/auth/consent; Freeside runtime/client integration; Discord
+// ingestion; user chat becoming memory; a public `remember-this`; a final
+// schema; final idempotency/signer/authority semantics; production
+// tenant/estate/actor identity binding; or a completed Straylight primitive
+// review. It mounts ONLY when DIXIE_ADMISSION_INTAKE_ENABLED === 'true'
+// (server.ts conditional mount; default off → route not registered at all).
+//
+// Import discipline: this file imports ONLY Dixie-local service primitives and
+// `hono`. It performs NO `@loa/straylight` import and NO Freeside import.
+
+import { Hono, type Context } from 'hono';
+import { getRequestContext } from '../validation.js';
+import {
+  authorizeAdmissionSpike,
+  classifyAdmissionSpike,
+  AdmissionSpikeUnsupportedShapeError,
+  buildAdmissionSpikePublicResponse,
+  findAdmissionPublicLeaks,
+  ADMISSION_SPIKE_FAIL_CLOSED,
+  ADMISSION_SPIKE_SHAPE_REFUSAL_CODE,
+  type AdmissionSpikeClassification,
+  type AdmissionSpikeGateConfig,
+} from '../services/admission-wedge-spike/index.js';
+
+/** Header carrying the dev/operator id (checked against the allowlist). */
+const OPERATOR_ID_HEADER = 'x-admission-operator-id';
+
+/** Dedicated header carrying the dev/operator service token. NOT
+ *  `Authorization` — see auth-gate.ts for the rationale (avoids colliding with
+ *  the global /api/* allowlist gate, which is not exempt for /api/admission). */
+const SERVICE_TOKEN_HEADER = 'x-admission-service-token';
+
+/** Endpoint-local body cap. The dev-spike body is tiny; this is well under the
+ *  global /api/* 100KB limit and bounds the read before JSON.parse. */
+const DEFAULT_BODY_MAX_BYTES = 8_192;
+
+export interface AdmissionSpikeAuditEvent {
+  event:
+    | 'admission_intake_spike.disabled'
+    | 'admission_intake_spike.unauthorized'
+    | 'admission_intake_spike.refused'
+    | 'admission_intake_spike.outcome';
+  /** Public-safe scenario id (or undefined for gate/auth refusals). */
+  scenario_id?: string;
+  /** Public-safe outcome class (or undefined). */
+  outcome_class?: string;
+  request_id?: string;
+}
+
+export interface AdmissionSpikeRouteDeps {
+  /** Defense-in-depth: when false, the handler returns a safe disabled refusal
+   *  even if mounted. server.ts only mounts the route when enabled is true. */
+  enabled: boolean;
+  gate: AdmissionSpikeGateConfig;
+  bodyMaxBytes?: number;
+  /** Audit emit hook (defaults to no-op). Receives ONLY public-safe fields —
+   *  never raw body, tokens, or operator ids. */
+  emitAudit?: (event: AdmissionSpikeAuditEvent) => void;
+  /** Test seam (Phase 33M §10 partial-failure): invoked after classification,
+   *  before the public response is finalized. Throwing simulates a partial
+   *  internal failure; the handler MUST fail closed (no durable state under
+   *  Option A; no recallable / partially-admitted residue). */
+  beforeFinalize?: (classification: AdmissionSpikeClassification) => void;
+  /** Runtime no-leak guard (DI seam). Defaults to `findAdmissionPublicLeaks`.
+   *  EVERY public response — disabled, unauthorized, malformed, oversized,
+   *  classifier-error, partial-failure, and all classified outcomes — is
+   *  deep-walked through this guard before it is sent; a non-empty result fails
+   *  closed to a hardcoded known-safe fallback (Phase 33M §14). Injectable so
+   *  tests can prove the guard is invoked on every response path and that a
+   *  forced leak fails closed without leaking the guard's own findings. */
+  noLeakGuard?: (body: unknown) => string[];
+}
+
+/** Stable public-safe refusal body for the disabled gate. Leaks nothing. */
+function disabledRefusalBody() {
+  return {
+    spike: 'dev_operator_only_non_production' as const,
+    outcome_class: 'refused' as const,
+    error: 'admission.spike_disabled',
+    message: 'admission intake dev spike is disabled',
+  };
+}
+
+/** Stable public-safe refusal body for an unauthorized caller. Reveals nothing
+ *  about which gate failed or whether a credential almost matched. */
+function unauthorizedRefusalBody() {
+  return {
+    spike: 'dev_operator_only_non_production' as const,
+    outcome_class: 'refused' as const,
+    error: 'admission.unauthorized_dev_operator',
+    message: 'dev/operator authorization required',
+  };
+}
+
+/** Stable public-safe fail-closed refusal body (malformed / unsupported /
+ *  partial-failure). Uses the existing stable Dixie shape-failure code; never
+ *  leaks the hidden reason. */
+function failClosedRefusalBody() {
+  const c = ADMISSION_SPIKE_FAIL_CLOSED;
+  return {
+    spike: 'dev_operator_only_non_production' as const,
+    outcome_class: c.outcome_class,
+    scenario_id: 'malformed_or_unsafe_payload_fail_closed',
+    recall_eligible: false as const,
+    recall_projection: { ordinary_recall_includes: [], ordinary_recall_excludes: [] },
+    public_receipt_ref: null,
+    safe_reason_code: ADMISSION_SPIKE_SHAPE_REFUSAL_CODE,
+    error: ADMISSION_SPIKE_SHAPE_REFUSAL_CODE,
+    message: 'admission intake request refused',
+  };
+}
+
+/** Hardcoded, known-safe fail-closed body returned ONLY when the runtime
+ *  no-leak guard rejects (or throws on) an outgoing body — a never-expected
+ *  event, since every public body is built structurally safe. It is a FIXED
+ *  literal of short, safe strings, deliberately NOT re-run through the guard
+ *  (no recursion), and it carries NONE of the guard's findings, so the failure
+ *  detail never reaches the client. Proven safe by the no-leak unit test. */
+function guardFailedFallbackBody() {
+  return {
+    spike: 'dev_operator_only_non_production' as const,
+    outcome_class: 'refused' as const,
+    error: 'admission.fail_closed',
+    message: 'admission intake request refused',
+  };
+}
+
+/** Public HTTP statuses the spike ever emits (all ContentfulStatusCode). */
+type AdmissionSpikeStatus = 200 | 400 | 403 | 404 | 500;
+
+export function createAdmissionIntakeRoutes(deps: AdmissionSpikeRouteDeps): Hono {
+  const app = new Hono();
+  const emit = deps.emitAudit ?? (() => undefined);
+  const bodyMaxBytes = deps.bodyMaxBytes ?? DEFAULT_BODY_MAX_BYTES;
+  const noLeakGuard = deps.noLeakGuard ?? findAdmissionPublicLeaks;
+
+  /**
+   * THE single send path for the route. Every public response — without
+   * exception — is finalized here: the body is deep-walked through the runtime
+   * no-leak guard (Phase 33M §14) BEFORE it is serialized. If the guard reports
+   * any finding (or throws), the response collapses to a hardcoded known-safe
+   * fail-closed fallback at HTTP 500; that fallback is NOT re-guarded (no
+   * recursion) and carries none of the guard's findings, so the failure detail
+   * never reaches the client. This makes the docs claim ("every public body is
+   * deep-walked") a runtime invariant, not just a comment.
+   *
+   * `onSend` (the per-path public-safe audit event) is emitted ONLY when the
+   * guard passes and the intended body is actually sent. A guard failure emits
+   * exactly one `admission_intake_spike.refused` instead.
+   */
+  function sendPublicResponse(
+    c: Context,
+    status: AdmissionSpikeStatus,
+    body: Record<string, unknown>,
+    requestId: string | undefined,
+    onSend: AdmissionSpikeAuditEvent,
+  ): Response {
+    let leaks: string[];
+    try {
+      leaks = noLeakGuard(body);
+    } catch {
+      // A guard that throws is treated exactly like a detected leak: fail
+      // closed. Never surface the thrown error.
+      leaks = ['guard_threw'];
+    }
+    if (leaks.length > 0) {
+      // NOTE: deliberately do NOT include `leaks` in the response — the guard's
+      // own findings can describe the rejected (potentially sensitive) body.
+      emit({ event: 'admission_intake_spike.refused', request_id: requestId });
+      return c.json(guardFailedFallbackBody(), 500);
+    }
+    emit(onSend);
+    return c.json(body, status);
+  }
+
+  app.post('/', async (c) => {
+    const { requestId } = getRequestContext(c);
+
+    // (0) Disabled gate — defense-in-depth fail-closed (Phase 33M §9).
+    if (!deps.enabled) {
+      return sendPublicResponse(c, 404, disabledRefusalBody(), requestId, {
+        event: 'admission_intake_spike.disabled',
+        request_id: requestId,
+      });
+    }
+
+    // (1) Dev/operator auth gate — NOT production auth (Phase 33M §12). One
+    // stable refusal for missing/invalid/non-operator; never reveals which
+    // gate failed or whether a credential almost matched.
+    const authorized = authorizeAdmissionSpike(deps.gate, {
+      serviceToken: c.req.header(SERVICE_TOKEN_HEADER),
+      operatorId: c.req.header(OPERATOR_ID_HEADER),
+    });
+    if (!authorized) {
+      return sendPublicResponse(c, 403, unauthorizedRefusalBody(), requestId, {
+        event: 'admission_intake_spike.unauthorized',
+        request_id: requestId,
+      });
+    }
+
+    // (2) Bounded body read + parse. Any read/parse problem fails closed with
+    // the stable shape-failure refusal (no leak of the hidden reason).
+    const refused: AdmissionSpikeAuditEvent = {
+      event: 'admission_intake_spike.refused',
+      request_id: requestId,
+    };
+    let raw: unknown;
+    try {
+      const contentLengthHeader = c.req.header('content-length');
+      if (contentLengthHeader) {
+        const len = Number.parseInt(contentLengthHeader, 10);
+        if (Number.isFinite(len) && len > bodyMaxBytes) {
+          return sendPublicResponse(c, 400, failClosedRefusalBody(), requestId, refused);
+        }
+      }
+      const text = await c.req.raw.clone().text();
+      if (Buffer.byteLength(text, 'utf8') > bodyMaxBytes) {
+        return sendPublicResponse(c, 400, failClosedRefusalBody(), requestId, refused);
+      }
+      raw = text.length === 0 ? null : JSON.parse(text);
+    } catch {
+      return sendPublicResponse(c, 400, failClosedRefusalBody(), requestId, refused);
+    }
+
+    // (3) Pure classification (Approach C — only the five Phase 33L scenario
+    // forms; everything else throws and fails closed). Mints nothing durable.
+    let classification: AdmissionSpikeClassification;
+    try {
+      classification = classifyAdmissionSpike(raw);
+    } catch (err) {
+      // Unsupported shape (or any classifier error) → identical public-safe
+      // fail-closed refusal as the explicit malformed scenario.
+      if (!(err instanceof AdmissionSpikeUnsupportedShapeError)) {
+        // Defensive: any unexpected classifier error also fails closed.
+      }
+      return sendPublicResponse(c, 400, failClosedRefusalBody(), requestId, refused);
+    }
+
+    // (4) Partial-failure posture (Phase 33M §13.1). Any internal partial
+    // failure during finalization fails closed: under Option A there is NO
+    // durable state to roll back, NO recallable assertion is created, and NO
+    // duplicate/partially-admitted residue can exist. The response collapses
+    // to the stable public-safe refusal.
+    try {
+      deps.beforeFinalize?.(classification);
+    } catch {
+      return sendPublicResponse(c, 400, failClosedRefusalBody(), requestId, refused);
+    }
+
+    // (5) Build the deterministic public-safe body. The runtime no-leak guard
+    // runs inside sendPublicResponse (as it does for EVERY response path), so a
+    // (never-expected) leak fails closed to the known-safe fallback there. The
+    // outcome audit event is emitted only when the guard passes and the body is
+    // actually sent.
+    const body = buildAdmissionSpikePublicResponse(classification);
+    return sendPublicResponse(
+      c,
+      classification.http_status,
+      body as unknown as Record<string, unknown>,
+      requestId,
+      {
+        event:
+          classification.outcome_class === 'refused'
+            ? 'admission_intake_spike.refused'
+            : 'admission_intake_spike.outcome',
+        scenario_id: body.scenario_id,
+        outcome_class: body.outcome_class,
+        request_id: requestId,
+      },
+    );
+  });
+
+  return app;
+}

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -25,6 +25,7 @@ import { createIdentityRoutes } from './routes/identity.js';
 import { createWsTicketRoutes } from './routes/ws-ticket.js';
 import { createMemoryRoutes } from './routes/memory.js';
 import { createRecallIntakeRoutes } from './routes/recall-intake.js';
+import { createAdmissionIntakeRoutes } from './routes/admission-intake.js';
 import {
   createCapabilityHolder,
   createBoundedEstateStore,
@@ -609,6 +610,36 @@ export function createDixieApp(config: DixieConfig): DixieApp {
         perEstateMutex: recallMutex,
         perTenantRateLimit: recallRateLimit,
         intakeLog: recallIntakeLog,
+        emitAudit: (ev) => log('info', { ...ev }),
+      }),
+    );
+  }
+
+  // --- Phase 33N: dev/operator-only Admission Wedge route SPIKE (default OFF) ---
+  // Conditional mount. When disabled (the default), the route is NOT registered
+  // at all — a request to POST /api/admission/intake falls through to the SPA
+  // fallback / 404. Authorized NARROWLY by Phase 33M
+  // (docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md §7–§15)
+  // as a NON-PRODUCTION, dev/operator-only spike using Storage Option A (no
+  // durable Admission Wedge storage, no DB writes, no migrations — safe
+  // future-intent receipts / public-safe outcomes only). This is NOT production
+  // admission and does NOT authorize production storage/auth/consent, Freeside
+  // runtime integration, Discord ingestion, public remember-this, a final
+  // schema, or a completed Straylight primitive review. The dev/operator gate
+  // (service token + operator-id allowlist) fails closed when both are empty.
+  if (config.admissionIntakeSpikeEnabled) {
+    log('warn', {
+      event: 'admission_intake_spike_active',
+      note: 'dev/operator-only Admission Wedge route spike enabled — NOT production admission',
+    });
+    app.route(
+      '/api/admission/intake',
+      createAdmissionIntakeRoutes({
+        enabled: true,
+        gate: {
+          serviceToken: config.admissionIntakeSpikeServiceToken,
+          operatorIds: config.admissionIntakeSpikeOperatorIds,
+        },
         emitAudit: (ev) => log('info', { ...ev }),
       }),
     );

--- a/app/src/services/admission-wedge-spike/auth-gate.ts
+++ b/app/src/services/admission-wedge-spike/auth-gate.ts
@@ -1,0 +1,96 @@
+// Phase 33N — dev/operator-only Admission Wedge route SPIKE: auth gate.
+//
+// This is a DEV/OPERATOR-ONLY gate, NOT production auth (Phase 33M §12).
+// Service authentication here only proves a caller MAY exercise the dev spike;
+// it does NOT prove end-user/channel/tenant/surface authorization, and it does
+// NOT implement an end-user consent model. It exists to prove the spike is not
+// public — never to claim production signer/authority semantics.
+//
+// Header choice (deliberate, documented): the service token is read from a
+// DEDICATED `x-admission-service-token` header, NOT `Authorization: Bearer`.
+// Rationale: the spike route is mounted under `/api/*`, behind the global
+// allowlist middleware (server.ts), which already consumes `Authorization`
+// (JWT wallet or `Bearer dxk_` api key) and is NOT exempt for `/api/admission`.
+// Reusing `Authorization` for the dev token would collide with that global
+// gate (a non-dxk/non-JWT bearer is rejected by the allowlist before the route
+// runs, and would be needlessly run through the JWT verifier). A dedicated
+// header keeps the spike behind BOTH the global allowlist (defense-in-depth)
+// AND this dev/operator gate, without collision. The repo's only
+// `Authorization: Bearer` service gate (admin) works only because admin is
+// allowlist-exempt; the admission spike is not, so it does not reuse that
+// pattern.
+//
+// Fail-closed rules (Phase 33M §1, §9):
+//   * with BOTH the service token AND the operator-id allowlist empty/unset,
+//     the gate rejects ALL calls (no production default);
+//   * each CONFIGURED gate must pass: if a service token is configured, the
+//     caller must present a matching `x-admission-service-token`; if an
+//     operator-id allowlist is configured, the caller must present an
+//     allowlisted `x-admission-operator-id`. Both configured → both required;
+//   * comparisons are constant-time and never reveal whether a token almost
+//     matched, nor which gate failed.
+
+import { safeEqual } from '../../utils/crypto.js';
+
+export interface AdmissionSpikeGateConfig {
+  /** Configured dev/operator service token ('' = not configured). */
+  serviceToken: string;
+  /** Configured dev/operator id allowlist ([] = not configured). */
+  operatorIds: string[];
+}
+
+export interface AdmissionSpikeCredentials {
+  /** `x-admission-service-token` header value (or undefined). */
+  serviceToken: string | undefined;
+  /** `x-admission-operator-id` header value (or undefined). */
+  operatorId: string | undefined;
+}
+
+/** Constant-time membership test that does not early-exit (avoids leaking which
+ *  entry matched / how far the scan got). Returns false for an empty list. */
+function allowlistContains(list: string[], candidate: string): boolean {
+  let matched = false;
+  for (const entry of list) {
+    // Bitwise-OR accumulation; safeEqual itself is constant-time per pair.
+    matched = safeEqual(entry, candidate) || matched;
+  }
+  return matched;
+}
+
+/**
+ * Decide whether the caller may exercise the dev/operator spike. Returns a
+ * single boolean; the route maps `false` to one stable public-safe refusal
+ * regardless of WHY (missing/invalid/non-operator), so no information about
+ * which gate failed or whether a credential almost matched is exposed.
+ */
+export function authorizeAdmissionSpike(
+  config: AdmissionSpikeGateConfig,
+  creds: AdmissionSpikeCredentials,
+): boolean {
+  const tokenConfigured = config.serviceToken.length > 0;
+  const operatorConfigured = config.operatorIds.length > 0;
+
+  // Fail closed: an empty token AND empty allowlist rejects all calls.
+  if (!tokenConfigured && !operatorConfigured) return false;
+
+  // Each CONFIGURED gate must pass. Unconfigured gates do not block, but at
+  // least one is configured (guaranteed by the check above).
+  let tokenOk = true;
+  if (tokenConfigured) {
+    const presented = creds.serviceToken;
+    tokenOk =
+      presented !== undefined &&
+      presented.length > 0 &&
+      safeEqual(presented, config.serviceToken);
+  }
+
+  let operatorOk = true;
+  if (operatorConfigured) {
+    operatorOk =
+      creds.operatorId !== undefined &&
+      creds.operatorId.length > 0 &&
+      allowlistContains(config.operatorIds, creds.operatorId);
+  }
+
+  return tokenOk && operatorOk;
+}

--- a/app/src/services/admission-wedge-spike/classifier.ts
+++ b/app/src/services/admission-wedge-spike/classifier.ts
@@ -1,0 +1,195 @@
+// Phase 33N — dev/operator-only Admission Wedge route SPIKE: pure classifier
+// and public-response builder.
+//
+// Authorized NARROWLY by Phase 33M
+// (docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md §7–§15)
+// as a disabled-by-default, dev/operator-only, NON-PRODUCTION route spike.
+//
+// SCOPE / NON-GOALS:
+//   * dev/operator ONLY — never production admission, never a public path;
+//   * Storage Option A — NO durable Admission Wedge storage, NO database
+//     writes, NO migrations. This module is PURE: it computes a deterministic
+//     public-safe outcome from a recognized dev-spike request shape and mints
+//     NOTHING durable. "Rollback" is trivial: there is no durable state;
+//   * it does NOT prove a production schema, production auth/consent,
+//     production tenant/estate/actor binding, final idempotency, a completed
+//     Straylight primitive review, or Freeside runtime integration;
+//   * it echoes NO request-controlled material into the public response — the
+//     response is built purely from the classified scenario, so a public
+//     response can carry no raw candidate payload, source, token, or id from
+//     the request body (the no-leak boundary is structural, not just checked).
+//
+// Request shape (Approach C — Phase 33M §3): the classifier matches the
+// minimal draft fields the Phase 33L route-contract test vectors carry on
+// their `request_vector` (`transition_intent`), behind a required synthetic
+// non-production marker, and FAILS CLOSED for any unsupported shape. It does
+// NOT widen beyond the five Phase 33L scenarios.
+
+import { z } from 'zod';
+
+/** Synthetic, non-production discriminator the dev-spike body must carry.
+ *  Its presence makes a request an explicit dev-spike request rather than
+ *  any production admission body (no production body shape is accepted). */
+export const ADMISSION_SPIKE_BODY_MARKER = 'admission_intake_dev_spike_v0';
+
+/** The five draft `transition_intent` values carried by the Phase 33L
+ *  route-contract test vectors (their `request_vector.transition_intent`),
+ *  mapped 1:1 to the five frozen scenarios. No sixth scenario. */
+export const ADMISSION_TRANSITION_INTENTS = {
+  /** Vector A — candidate proposed, no transition. */
+  pending: 'none_candidate_write_only_draft',
+  /** Vector B — explicit accept/admit transition. */
+  accept: 'admit_assertion_accept_draft',
+  /** Vector C — explicit reject/deny transition. */
+  reject: 'admit_assertion_deny_draft',
+  /** Vector D — supersession with correction. */
+  supersede: 'supersede_with_correction_draft',
+  /** Vector E — explicit malformed/unsafe, refused at ingress. */
+  malformed: 'none_refused_at_ingress_before_transition_draft',
+} as const;
+
+export type AdmissionSpikeScenario = keyof typeof ADMISSION_TRANSITION_INTENTS;
+
+const INTENT_TO_SCENARIO: Record<string, AdmissionSpikeScenario> = {
+  [ADMISSION_TRANSITION_INTENTS.pending]: 'pending',
+  [ADMISSION_TRANSITION_INTENTS.accept]: 'accept',
+  [ADMISSION_TRANSITION_INTENTS.reject]: 'reject',
+  [ADMISSION_TRANSITION_INTENTS.supersede]: 'supersede',
+  [ADMISSION_TRANSITION_INTENTS.malformed]: 'malformed',
+};
+
+/** Stable, public-safe shape-failure code (the existing Dixie-local refusal
+ *  family code the Phase 33L fail-closed vector reuses). NOT an admission
+ *  final code. */
+export const ADMISSION_SPIKE_SHAPE_REFUSAL_CODE = 'ingress.invalid_request';
+
+/** Draft, non-final public reason marker for an explicit denied transition
+ *  (mirrors the Phase 33L reject vector's `safe_reason_code`). */
+export const ADMISSION_SPIKE_DENIED_REASON_DRAFT = 'admission_transition_denied_draft_non_final';
+
+// Carried-forward Phase 33J §5/§6 unresolved primitive-review markers (NOT
+// resolved by this spike — the Straylight primitive review remains required
+// and not complete).
+export const ADMISSION_SPIKE_UNRESOLVED_ROWS = ['E', 'G', 'H', 'K', 'N', 'O'] as const;
+export const ADMISSION_SPIKE_REVIEW_DEPENDENT_ROWS = ['J'] as const;
+
+// Strict dev-spike request schema. Extra keys are rejected (strict) so a
+// production-ish or arbitrary body fails closed rather than being silently
+// accepted. The schema accepts ONLY the two minimal fields the Phase 33L
+// route-contract vectors carry on their `request_vector`: the synthetic
+// dev-spike marker plus the draft transition discriminator. It deliberately
+// accepts NO free-form memory/candidate payload and does NOT widen beyond the
+// five scenarios.
+const AdmissionSpikeBodySchema = z
+  .object({
+    spike: z.literal(ADMISSION_SPIKE_BODY_MARKER),
+    transition_intent: z.enum(
+      Object.values(ADMISSION_TRANSITION_INTENTS) as [string, ...string[]],
+    ),
+  })
+  .strict();
+
+export interface AdmissionSpikeClassification {
+  scenario: AdmissionSpikeScenario;
+  outcome_class:
+    | 'accepted_as_proposed'
+    | 'admitted'
+    | 'denied'
+    | 'superseded_with_correction'
+    | 'refused';
+  /** Deterministic public HTTP status for the outcome. 200 for the four
+   *  deterministic admission outcomes; 400 for the fail-closed refusal. */
+  http_status: 200 | 400;
+  /** Whether the outcome is recall-eligible (future-intent, draft, review-
+   *  dependent). Pending / reject / malformed are never recallable. */
+  recall_eligible: boolean;
+  /** Whether a public-safe (synthetic) receipt reference is minted. NO durable
+   *  receipt is ever written (Option A) — this only governs whether a SAFE
+   *  synthetic placeholder appears publicly. */
+  mints_public_receipt_ref: boolean;
+  /** Public-safe reason code (or null). Either the stable Dixie shape-failure
+   *  code or a clearly-draft/non-final admission marker. */
+  safe_reason_code: string | null;
+}
+
+const CLASSIFICATIONS: Record<AdmissionSpikeScenario, AdmissionSpikeClassification> = {
+  pending: {
+    scenario: 'pending',
+    outcome_class: 'accepted_as_proposed',
+    http_status: 200,
+    recall_eligible: false,
+    mints_public_receipt_ref: false,
+    safe_reason_code: null,
+  },
+  accept: {
+    scenario: 'accept',
+    outcome_class: 'admitted',
+    http_status: 200,
+    recall_eligible: true,
+    mints_public_receipt_ref: true,
+    safe_reason_code: null,
+  },
+  reject: {
+    scenario: 'reject',
+    outcome_class: 'denied',
+    http_status: 200,
+    recall_eligible: false,
+    mints_public_receipt_ref: true,
+    safe_reason_code: ADMISSION_SPIKE_DENIED_REASON_DRAFT,
+  },
+  supersede: {
+    scenario: 'supersede',
+    outcome_class: 'superseded_with_correction',
+    http_status: 200,
+    recall_eligible: true,
+    mints_public_receipt_ref: true,
+    safe_reason_code: null,
+  },
+  malformed: {
+    scenario: 'malformed',
+    outcome_class: 'refused',
+    http_status: 400,
+    recall_eligible: false,
+    mints_public_receipt_ref: false,
+    safe_reason_code: ADMISSION_SPIKE_SHAPE_REFUSAL_CODE,
+  },
+};
+
+/** The deterministic fail-closed classification — used for any unsupported /
+ *  malformed / unsafe shape and as the partial-failure result. */
+export const ADMISSION_SPIKE_FAIL_CLOSED: AdmissionSpikeClassification =
+  CLASSIFICATIONS.malformed;
+
+/**
+ * Thrown when a request does not match a supported dev-spike shape. The route
+ * catches this and returns the SAME public-safe fail-closed refusal as the
+ * explicit malformed scenario — it never reveals the hidden reason.
+ */
+export class AdmissionSpikeUnsupportedShapeError extends Error {
+  constructor() {
+    super('unsupported admission dev-spike request shape');
+    this.name = 'AdmissionSpikeUnsupportedShapeError';
+  }
+}
+
+/**
+ * Pure classifier. Recognizes only the five Phase 33L scenario forms via the
+ * draft `transition_intent` discriminator (behind the synthetic dev-spike
+ * marker) and FAILS CLOSED for everything else by throwing
+ * `AdmissionSpikeUnsupportedShapeError`. Mints nothing durable.
+ *
+ * The explicit malformed scenario (vector E) is RECOGNIZED and returns the
+ * fail-closed `refused` classification; a genuinely unsupported shape THROWS
+ * — both routes collapse to the identical public-safe refusal at the handler.
+ */
+export function classifyAdmissionSpike(input: unknown): AdmissionSpikeClassification {
+  const parsed = AdmissionSpikeBodySchema.safeParse(input);
+  if (!parsed.success) {
+    throw new AdmissionSpikeUnsupportedShapeError();
+  }
+  const scenario = INTENT_TO_SCENARIO[parsed.data.transition_intent];
+  if (!scenario) {
+    throw new AdmissionSpikeUnsupportedShapeError();
+  }
+  return CLASSIFICATIONS[scenario];
+}

--- a/app/src/services/admission-wedge-spike/index.ts
+++ b/app/src/services/admission-wedge-spike/index.ts
@@ -1,0 +1,41 @@
+// Phase 33N — dev/operator-only Admission Wedge route SPIKE: service barrel.
+//
+// Exposes the service-layer primitives the route composes. NON-PRODUCTION,
+// dev/operator-only, Storage Option A (no durable storage). Authorized narrowly
+// by Phase 33M
+// (docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md).
+//
+// NOTE: this is an internal service barrel only. It is deliberately NOT
+// re-exported from any package entrypoint — the spike adds NO package export
+// (Phase 33M §8). It performs NO `@loa/straylight` runtime value import and NO
+// Freeside import.
+
+export {
+  classifyAdmissionSpike,
+  AdmissionSpikeUnsupportedShapeError,
+  ADMISSION_SPIKE_BODY_MARKER,
+  ADMISSION_TRANSITION_INTENTS,
+  ADMISSION_SPIKE_SHAPE_REFUSAL_CODE,
+  ADMISSION_SPIKE_DENIED_REASON_DRAFT,
+  ADMISSION_SPIKE_FAIL_CLOSED,
+  ADMISSION_SPIKE_UNRESOLVED_ROWS,
+  ADMISSION_SPIKE_REVIEW_DEPENDENT_ROWS,
+  type AdmissionSpikeScenario,
+  type AdmissionSpikeClassification,
+} from './classifier.js';
+
+export {
+  buildAdmissionSpikePublicResponse,
+  type AdmissionSpikePublicResponse,
+} from './public-response.js';
+
+export {
+  findAdmissionPublicLeaks,
+  isAdmissionPublicSafe,
+} from './no-leak.js';
+
+export {
+  authorizeAdmissionSpike,
+  type AdmissionSpikeGateConfig,
+  type AdmissionSpikeCredentials,
+} from './auth-gate.js';

--- a/app/src/services/admission-wedge-spike/no-leak.ts
+++ b/app/src/services/admission-wedge-spike/no-leak.ts
@@ -1,0 +1,187 @@
+// Phase 33N — dev/operator-only Admission Wedge route SPIKE: runtime no-leak
+// guard (defense-in-depth).
+//
+// This is the RUNTIME no-leak baseline the Phase 33M gate (§14) requires the
+// spike to inherit from the Phase 33L route-contract test-vector validator's
+// denylist
+// (docs/admission-wedge/route-contract-test-vectors/validate-route-contract-test-vectors.mjs:
+// FORBIDDEN_PUBLIC_KEYS / FORBIDDEN_SUBSTRINGS / FORBIDDEN_PATTERNS + the
+// UUID / long-opaque-run rules). The denylist is MIRRORED here as a small,
+// dependency-free runtime module — the docs validator is NOT imported into
+// runtime (it stays Node-built-ins-only, docs-bound), per Phase 33M §10.
+//
+// `findAdmissionPublicLeaks` deep-walks any public response object and returns
+// a list of human-readable leak findings (empty when clean). The route uses it
+// as a last-line assertion before serializing a public body; the tests use it
+// to deep-walk every public surface (disabled / unauthorized / malformed / all
+// five scenarios / partial-failure).
+
+/** Forbidden private/operational/forbidden-category keys (mirrors the Phase
+ *  33L validator's FORBIDDEN_PUBLIC_KEYS). Presence as a key on a public
+ *  surface is a leak regardless of value. */
+const FORBIDDEN_PUBLIC_KEYS = new Set<string>([
+  'tenant_id',
+  'estate_id',
+  'candidate_id',
+  'source_candidate_id',
+  'prior_assertion_id',
+  'proposing_actor_id',
+  'correcting_actor_id',
+  'caller_actor_id',
+  'subject_actor_id',
+  'actor_id',
+  'candidate_payload',
+  'corrected_candidate_payload',
+  'source_ref',
+  'source_kind',
+  'raw_reasons',
+  'raw_reason',
+  'policy_reason',
+  'private_reason_family',
+  'receipt_id',
+  'audit_receipt_ref',
+  'idempotency_key',
+  'idempotency_key_draft',
+  'authority_signer_type_draft',
+  'authority_scope_draft',
+  'admission_transition_id',
+  'admitted_assertion_id',
+  'supersedes_assertion_id',
+  'superseded_by_assertion_id',
+  // README §9 no-leak categories + variants.
+  'raw_candidate_payload',
+  'raw_candidate_payloads',
+  'rendered_candidate_payloads',
+  'source_material',
+  'source_materials',
+  'private_audit_fields',
+  'private_audit_field',
+  'operational_ids',
+  'operational_id',
+  'operational_tenant_estate_actor_ids',
+  'authority_signature_material',
+  'authority_signature',
+  'signature_material',
+  'tokens',
+  'token',
+  'secrets',
+  'secret',
+  'urls',
+  'url',
+  'stack_traces',
+  'stack_trace',
+  'stack_traces_debug_internals',
+  'storage_internals',
+  'storage_internal',
+]);
+
+/** Negative-assertion keys: legitimate ONLY as the boolean literal `false`. */
+const NEGATIVE_ASSERTION_KEYS = new Set<string>(['rendered_candidate_payload']);
+
+/** Forbidden substrings (mirrors the Phase 33L validator). */
+const FORBIDDEN_SUBSTRINGS = [
+  'unsafe_marker:',
+  'BODY_OVER_CAP',
+  'body-over-cap',
+  'runtime_seam:internal:',
+  'CANDIDATE_PRIVATE_SENTINEL',
+  'SOURCE_SENTINEL',
+  'SUPERSEDED_PRIVATE_SENTINEL',
+  'ADMITTED_PRIVATE_SENTINEL',
+  'STRAYLIGHT_RUNTIME_DIXIE_KEY',
+  'ADMIN_KEY',
+  'Traceback',
+  'node_modules/',
+  '-----BEGIN ',
+];
+
+/** Forbidden regex leak patterns (mirrors the Phase 33L validator). */
+const FORBIDDEN_PATTERNS: Array<{ name: string; re: RegExp }> = [
+  { name: 'url', re: /\bhttps?:\/\//i },
+  { name: 'ws-url', re: /\bwss?:\/\//i },
+  { name: 'jwt', re: /\beyJ[A-Za-z0-9_-]{8,}/ },
+  { name: 'openai-style-key', re: /\bsk-[A-Za-z0-9]{16,}/ },
+  { name: 'bearer-token', re: /\bBearer\s+\S+/ },
+  { name: '0x-hex-address', re: /0x[0-9a-fA-F]{16,}/ },
+  { name: 'long-hex-id', re: /\b[0-9a-fA-F]{40,}\b/ },
+  { name: 'long-opaque-id', re: /[A-Za-z0-9]{32,}/ },
+  { name: 'stack-frame', re: /\bat\s+\/?\S+:\d+:\d+/ },
+  { name: 'error-prefix', re: /\b(?:Error|TypeError|RangeError|SyntaxError):\s/ },
+];
+
+/** UUID shape (incl. v4) — opaque operational identifier; never permitted. */
+const UUID_RE =
+  /\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b/;
+
+/** Any unbroken alphanumeric run this long is treated as an opaque/operational
+ *  id and rejected (mirrors the Phase 33L MAX_OPAQUE_RUN). */
+const MAX_OPAQUE_RUN = 24;
+const OPAQUE_RUN_RE = new RegExp(`[A-Za-z0-9]{${MAX_OPAQUE_RUN},}`);
+
+interface WalkNode {
+  kind: 'key' | 'value';
+  path: string;
+  value: string;
+  child?: unknown;
+}
+
+function* walk(node: unknown, path: string): Generator<WalkNode> {
+  if (node === null || node === undefined) return;
+  if (typeof node === 'string') {
+    yield { kind: 'value', path, value: node };
+    return;
+  }
+  if (typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) yield* walk(node[i], `${path}[${i}]`);
+    return;
+  }
+  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+    yield { kind: 'key', path: `${path}.${k}`, value: k, child: v };
+    yield* walk(v, `${path}.${k}`);
+  }
+}
+
+/**
+ * Deep-walk a public response and return all no-leak findings (empty array =
+ * clean). Checks forbidden keys, negative-assertion-key discipline, forbidden
+ * substrings, forbidden regex patterns, UUIDs, and long opaque runs — across
+ * every key and string value at any depth.
+ */
+export function findAdmissionPublicLeaks(surface: unknown): string[] {
+  const failures: string[] = [];
+  for (const node of walk(surface, '$.public')) {
+    if (node.kind === 'key') {
+      if (FORBIDDEN_PUBLIC_KEYS.has(node.value)) {
+        failures.push(`forbidden public key "${node.value}" at ${node.path}`);
+      }
+      if (NEGATIVE_ASSERTION_KEYS.has(node.value) && node.child !== false) {
+        failures.push(
+          `negative-assertion key "${node.value}" at ${node.path} must be boolean false`,
+        );
+      }
+    }
+    for (const s of FORBIDDEN_SUBSTRINGS) {
+      if (node.value.includes(s)) {
+        failures.push(`forbidden substring "${s}" at ${node.path}`);
+      }
+    }
+    for (const p of FORBIDDEN_PATTERNS) {
+      if (p.re.test(node.value)) {
+        failures.push(`forbidden ${p.name} pattern at ${node.path}`);
+      }
+    }
+    if (UUID_RE.test(node.value)) {
+      failures.push(`UUID-shaped operational id at ${node.path}`);
+    }
+    if (node.kind === 'value' && OPAQUE_RUN_RE.test(node.value)) {
+      failures.push(`opaque/operational-id-shaped run (>=${MAX_OPAQUE_RUN}) at ${node.path}`);
+    }
+  }
+  return failures;
+}
+
+/** Convenience boolean wrapper. */
+export function isAdmissionPublicSafe(surface: unknown): boolean {
+  return findAdmissionPublicLeaks(surface).length === 0;
+}

--- a/app/src/services/admission-wedge-spike/public-response.ts
+++ b/app/src/services/admission-wedge-spike/public-response.ts
@@ -1,0 +1,116 @@
+// Phase 33N — dev/operator-only Admission Wedge route SPIKE: public-response
+// builder (Storage Option A; NON-PRODUCTION).
+//
+// Builds the deterministic, public-safe response body for a classified
+// dev-spike outcome. The body is constructed PURELY from the classification
+// plus fixed synthetic placeholders — it NEVER incorporates request-controlled
+// material, raw candidate payloads, source material, operational ids,
+// idempotency keys, authority/signature material, tokens, urls, or storage
+// internals. The no-leak boundary is therefore structural; the runtime
+// no-leak helper (no-leak.ts) is a defense-in-depth check, not the sole guard.
+
+import type {
+  AdmissionSpikeClassification,
+  AdmissionSpikeScenario,
+} from './classifier.js';
+import {
+  ADMISSION_SPIKE_UNRESOLVED_ROWS,
+  ADMISSION_SPIKE_REVIEW_DEPENDENT_ROWS,
+} from './classifier.js';
+
+/** Fixed synthetic public-safe receipt placeholder. NOT an operational id, NOT
+ *  durable — Option A mints no durable receipt. Short, descriptive, never
+ *  derived from request material. */
+const SYNTHETIC_PUBLIC_RECEIPT_REF = 'admission-spike-receipt-draft';
+
+/** Fixed synthetic recall-projection placeholders (mirror the Phase 33L
+ *  vectors' projection placeholders). */
+const ADMITTED_ACTIVE_PLACEHOLDER = 'admitted_active_assertion_draft_placeholder';
+const CORRECTED_ACTIVE_PLACEHOLDER = 'corrected_active_assertion_draft_placeholder';
+const SUPERSEDED_PRIOR_PLACEHOLDER = 'superseded_prior_assertion_draft_placeholder';
+
+export interface AdmissionSpikePublicResponse {
+  /** Clearly marks this as a dev/operator-only, non-production spike. */
+  spike: 'dev_operator_only_non_production';
+  outcome_class: AdmissionSpikeClassification['outcome_class'];
+  scenario_id: string;
+  recall_eligible: boolean;
+  /** Safe recall projection summary (synthetic placeholders only). */
+  recall_projection: {
+    ordinary_recall_includes: string[];
+    ordinary_recall_excludes: string[];
+  };
+  /** Public-safe synthetic receipt reference, or null when none is minted. */
+  public_receipt_ref: string | null;
+  /** Public-safe reason code, or null. */
+  safe_reason_code: string | null;
+  /** Non-final / draft indicators — the spike claims nothing final. */
+  draft_markers: {
+    schema_final: false;
+    route_contract_final: false;
+    production_admission: false;
+    straylight_primitive_review_complete: false;
+    idempotency_final: false;
+    unresolved_review_rows: readonly string[];
+    review_dependent_non_final_rows: readonly string[];
+  };
+}
+
+const SCENARIO_IDS: Record<AdmissionSpikeScenario, string> = {
+  pending: 'candidate_pending_not_recallable',
+  accept: 'accept_candidate_to_admitted_assertion',
+  reject: 'reject_candidate_no_assertion',
+  supersede: 'supersede_with_corrected_assertion',
+  malformed: 'malformed_or_unsafe_payload_fail_closed',
+};
+
+function recallProjectionFor(scenario: AdmissionSpikeScenario): {
+  ordinary_recall_includes: string[];
+  ordinary_recall_excludes: string[];
+} {
+  switch (scenario) {
+    case 'accept':
+      return {
+        ordinary_recall_includes: [ADMITTED_ACTIVE_PLACEHOLDER],
+        ordinary_recall_excludes: [],
+      };
+    case 'supersede':
+      return {
+        ordinary_recall_includes: [CORRECTED_ACTIVE_PLACEHOLDER],
+        ordinary_recall_excludes: [SUPERSEDED_PRIOR_PLACEHOLDER],
+      };
+    case 'pending':
+    case 'reject':
+    case 'malformed':
+    default:
+      return { ordinary_recall_includes: [], ordinary_recall_excludes: [] };
+  }
+}
+
+/**
+ * Build the deterministic public-safe response body from a classification.
+ * Pure: identical input → identical output; no request-controlled material is
+ * ever incorporated.
+ */
+export function buildAdmissionSpikePublicResponse(
+  c: AdmissionSpikeClassification,
+): AdmissionSpikePublicResponse {
+  return {
+    spike: 'dev_operator_only_non_production',
+    outcome_class: c.outcome_class,
+    scenario_id: SCENARIO_IDS[c.scenario],
+    recall_eligible: c.recall_eligible,
+    recall_projection: recallProjectionFor(c.scenario),
+    public_receipt_ref: c.mints_public_receipt_ref ? SYNTHETIC_PUBLIC_RECEIPT_REF : null,
+    safe_reason_code: c.safe_reason_code,
+    draft_markers: {
+      schema_final: false,
+      route_contract_final: false,
+      production_admission: false,
+      straylight_primitive_review_complete: false,
+      idempotency_final: false,
+      unresolved_review_rows: ADMISSION_SPIKE_UNRESOLVED_ROWS,
+      review_dependent_non_final_rows: ADMISSION_SPIKE_REVIEW_DEPENDENT_ROWS,
+    },
+  };
+}

--- a/app/tests/integration/admission-intake/full-stack.test.ts
+++ b/app/tests/integration/admission-intake/full-stack.test.ts
@@ -1,0 +1,212 @@
+// Phase 33N — the dev/operator-only Admission Wedge route spike, exercised
+// through the FULL DixieApp middleware stack (global JWT + allowlist + the
+// spike's own dev/operator gate). This proves:
+//   * an allowlisted caller presenting the dedicated `x-admission-service-token`
+//     header reaches the spike and gets a served outcome — the dedicated header
+//     does NOT collide with the global `Authorization`-based allowlist gate;
+//   * the global allowlist still fails closed for a non-allowlisted caller
+//     (the dev/operator gate is layered ON TOP of the allowlist, not instead);
+//   * with the spike disabled, the route is absent through the full stack.
+//
+// Mirrors the dev-seeded-live-estate full-stack pattern (JWT mint + allowlist
+// addEntry + mock finn). All ids/tokens are synthetic and public-safe.
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { serve } from '@hono/node-server';
+import * as jose from 'jose';
+import { createDixieApp, type DixieApp } from '../../../src/server.js';
+import type { DixieConfig } from '../../../src/config.js';
+import {
+  ADMISSION_SPIKE_BODY_MARKER,
+  ADMISSION_TRANSITION_INTENTS,
+  findAdmissionPublicLeaks,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+const JWT_SECRET = 'phase-33n-fullstack-jwt-secret-32chars!!';
+const SERVICE_TOKEN = 'phase-33n-dev-operator-token-synthetic';
+const OPERATOR = 'op-fullstack';
+// Synthetic allowlisted wallet (lowercase 0x+40hex so viem getAddress accepts).
+const ALLOWLISTED = '0xabcdef0000000000000000000000000000000033';
+const NOT_ALLOWLISTED = '0xabcdef0000000000000000000000000000000044';
+
+function baseConfig(finnPort: number): DixieConfig {
+  return {
+    port: 3601,
+    finnUrl: `http://localhost:${finnPort}`,
+    finnWsUrl: `ws://localhost:${finnPort}`,
+    corsOrigins: ['*'],
+    allowlistPath: '',
+    adminKey: 'phase-33n-admin-key',
+    jwtPrivateKey: JWT_SECRET,
+    jwtAlgorithm: 'HS256',
+    jwtLegacyHs256Secret: null,
+    nodeEnv: 'test',
+    logLevel: 'error',
+    rateLimitRpm: 1000,
+    otelEndpoint: null,
+    databaseUrl: null,
+    redisUrl: null,
+    natsUrl: null,
+    memoryProjectionTtlSec: 300,
+    memoryMaxEventsPerQuery: 100,
+    convictionTierTtlSec: 300,
+    personalityTtlSec: 1800,
+    autonomousPermissionTtlSec: 300,
+    autonomousBudgetDefaultMicroUsd: 100_000,
+    databasePoolSize: 10,
+    rateLimitBackend: 'memory',
+    scheduleCallbackSecret: 'phase-33n-callback-secret',
+    x402Enabled: false,
+    x402FacilitatorUrl: null,
+    billingJwtSecret: null,
+    pricingApiUrl: null,
+    pricingTtlSec: 300,
+    recallIntakeEnabled: false,
+    straylightRuntimeDixieKey: '',
+    recallIntakeBodyMaxBytes: 32_768,
+    recallIntakeRateRpm: 1000,
+    recallIntakeMaxAssertionsPerTenant: 512,
+    recallIntakeMaxAssertionBytesPerTenant: 1_048_576,
+    recallIntakeIdempotencyTtlSec: 900,
+    recallIntakeIdempotencyMaxEntries: 4_096,
+    recallIntakeDevSeedEnabled: false,
+    recallIntakeDevSeedTenantId: '',
+    admissionIntakeSpikeEnabled: true,
+    admissionIntakeSpikeServiceToken: SERVICE_TOKEN,
+    admissionIntakeSpikeOperatorIds: [OPERATOR],
+  };
+}
+
+function createMockFinn(): Hono {
+  const mock = new Hono();
+  mock.get('/api/health', (c) => c.json({ status: 'ok', version: '1.0.0-mock' }));
+  return mock;
+}
+
+async function mintJwt(wallet: string): Promise<string> {
+  const secret = new TextEncoder().encode(JWT_SECRET);
+  return new jose.SignJWT({ sub: wallet, tier: 'free' })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .setIssuer('dixie-bff')
+    .setAudience('dixie-bff')
+    .sign(secret);
+}
+
+let mockFinnServer: ReturnType<typeof serve>;
+const MOCK_FINN_PORT = 15600 + Math.floor(Math.random() * 600);
+
+beforeAll(() => {
+  mockFinnServer = serve({ fetch: createMockFinn().fetch, port: MOCK_FINN_PORT });
+});
+afterAll(() => {
+  mockFinnServer?.close();
+});
+
+beforeEach(() => {
+  delete process.env.DIXIE_ADMISSION_INTAKE_ENABLED;
+});
+afterEach(() => {
+  delete process.env.DIXIE_ADMISSION_INTAKE_ENABLED;
+});
+
+function buildEnabledApp(): DixieApp {
+  const app = createDixieApp(baseConfig(MOCK_FINN_PORT));
+  app.allowlistStore.addEntry('wallet', ALLOWLISTED);
+  return app;
+}
+
+function spikeBody(intent: string) {
+  return JSON.stringify({ spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: intent });
+}
+
+describe('Phase 33N — admission spike through the full DixieApp stack', () => {
+  it('allowlisted caller + dedicated service-token header reaches the spike (200 served)', async () => {
+    const app = buildEnabledApp();
+    const jwt = await mintJwt(ALLOWLISTED);
+    const res = await app.app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${jwt}`,
+        'x-admission-service-token': SERVICE_TOKEN,
+        'x-admission-operator-id': OPERATOR,
+      },
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const body = JSON.parse(text);
+    expect(body.outcome_class).toBe('admitted');
+    expect(body.spike).toBe('dev_operator_only_non_production');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+    // The dedicated header did not collide with the global Authorization gate,
+    // and neither the JWT nor the dev token leaks into the public body.
+    expect(text).not.toContain(SERVICE_TOKEN);
+    expect(text).not.toContain(jwt);
+    expect(text).not.toMatch(/eyJ[A-Za-z0-9_-]+\./);
+  });
+
+  it('global allowlist still fails closed for a non-allowlisted caller (dev gate is layered on top)', async () => {
+    const app = buildEnabledApp();
+    const jwt = await mintJwt(NOT_ALLOWLISTED);
+    const res = await app.app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${jwt}`,
+        'x-admission-service-token': SERVICE_TOKEN,
+        'x-admission-operator-id': OPERATOR,
+      },
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    // Rejected by the global allowlist gate BEFORE the spike runs — even with a
+    // valid dev/operator token. The spike never serves a non-allowlisted caller.
+    expect(res.status).toBe(403);
+    const body = JSON.parse(await res.text());
+    expect(body.spike).toBeUndefined();
+    expect(body.outcome_class).toBeUndefined();
+  });
+
+  it('valid allowlist but wrong dev token → spike denies (403), no leak', async () => {
+    const app = buildEnabledApp();
+    const jwt = await mintJwt(ALLOWLISTED);
+    const res = await app.app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${jwt}`,
+        'x-admission-service-token': 'wrong-dev-token',
+        'x-admission-operator-id': OPERATOR,
+      },
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(403);
+    const body = JSON.parse(await res.text());
+    expect(body.error).toBe('admission.unauthorized_dev_operator');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+  });
+
+  it('with the spike disabled, the route is absent through the full stack', async () => {
+    const app = createDixieApp({ ...baseConfig(MOCK_FINN_PORT), admissionIntakeSpikeEnabled: false });
+    app.allowlistStore.addEntry('wallet', ALLOWLISTED);
+    expect(app.app.routes.some((r) => r.path.includes('/api/admission'))).toBe(false);
+    const jwt = await mintJwt(ALLOWLISTED);
+    const res = await app.app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${jwt}`,
+        'x-admission-service-token': SERVICE_TOKEN,
+        'x-admission-operator-id': OPERATOR,
+      },
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    // No spike body is ever produced when disabled.
+    const text = await res.text();
+    expect(text).not.toContain('dev_operator_only_non_production');
+    expect(res.status).not.toBe(200);
+  });
+});

--- a/app/tests/integration/admission-intake/registration.test.ts
+++ b/app/tests/integration/admission-intake/registration.test.ts
@@ -1,0 +1,112 @@
+// Phase 33N — server-level conditional mount of the dev/operator-only
+// Admission Wedge route spike. Proves the route is NOT registered at all when
+// the spike is disabled (the default), and IS registered when enabled — the
+// disabled-by-default registration posture (Phase 33M §9, mirroring
+// recall-intake's server.ts:567 conditional mount).
+//
+// Uses a full DixieConfig built locally (mirroring dev-seeded-live-estate
+// baseConfig) and inspects Hono's `app.routes` registration table — no network
+// or DB. A mock finn is not needed because we never issue a request here; we
+// only assert the route table.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDixieApp } from '../../../src/server.js';
+import type { DixieConfig } from '../../../src/config.js';
+
+const MOCK_FINN_PORT = 13900;
+
+function baseConfig(): DixieConfig {
+  return {
+    port: 3777,
+    finnUrl: `http://localhost:${MOCK_FINN_PORT}`,
+    finnWsUrl: `ws://localhost:${MOCK_FINN_PORT}`,
+    corsOrigins: ['*'],
+    allowlistPath: '',
+    adminKey: 'phase-33n-admin-key',
+    jwtPrivateKey: 'phase-33n-jwt-secret-32-chars-aaaaaa!!',
+    jwtAlgorithm: 'HS256',
+    jwtLegacyHs256Secret: null,
+    nodeEnv: 'test',
+    logLevel: 'error',
+    rateLimitRpm: 1000,
+    otelEndpoint: null,
+    databaseUrl: null,
+    redisUrl: null,
+    natsUrl: null,
+    memoryProjectionTtlSec: 300,
+    memoryMaxEventsPerQuery: 100,
+    convictionTierTtlSec: 300,
+    personalityTtlSec: 1800,
+    autonomousPermissionTtlSec: 300,
+    autonomousBudgetDefaultMicroUsd: 100_000,
+    databasePoolSize: 10,
+    rateLimitBackend: 'memory',
+    scheduleCallbackSecret: 'phase-33n-callback-secret',
+    x402Enabled: false,
+    x402FacilitatorUrl: null,
+    billingJwtSecret: null,
+    pricingApiUrl: null,
+    pricingTtlSec: 300,
+    recallIntakeEnabled: false,
+    straylightRuntimeDixieKey: '',
+    recallIntakeBodyMaxBytes: 32_768,
+    recallIntakeRateRpm: 1000,
+    recallIntakeMaxAssertionsPerTenant: 512,
+    recallIntakeMaxAssertionBytesPerTenant: 1_048_576,
+    recallIntakeIdempotencyTtlSec: 900,
+    recallIntakeIdempotencyMaxEntries: 4_096,
+    recallIntakeDevSeedEnabled: false,
+    recallIntakeDevSeedTenantId: '',
+    // Phase 33N spike defaults (overridden per-case).
+    admissionIntakeSpikeEnabled: false,
+    admissionIntakeSpikeServiceToken: '',
+    admissionIntakeSpikeOperatorIds: [],
+  };
+}
+
+function hasAdmissionRoute(app: ReturnType<typeof createDixieApp>): boolean {
+  return app.app.routes.some((r) => r.path.includes('/api/admission'));
+}
+
+// Some env may leak the enable flag in; neutralize for determinism.
+beforeEach(() => {
+  delete process.env.DIXIE_ADMISSION_INTAKE_ENABLED;
+});
+afterEach(() => {
+  delete process.env.DIXIE_ADMISSION_INTAKE_ENABLED;
+});
+
+describe('Phase 33N — admission spike route registration is gated and off by default', () => {
+  it('default (disabled): NO /api/admission route is registered', () => {
+    const app = createDixieApp(baseConfig());
+    expect(hasAdmissionRoute(app)).toBe(false);
+  });
+
+  it('enabled: the /api/admission/intake route IS registered', () => {
+    const app = createDixieApp({ ...baseConfig(), admissionIntakeSpikeEnabled: true });
+    expect(hasAdmissionRoute(app)).toBe(true);
+  });
+
+  it('disabled spike does not register the route even with a token/allowlist set', () => {
+    const app = createDixieApp({
+      ...baseConfig(),
+      admissionIntakeSpikeEnabled: false,
+      admissionIntakeSpikeServiceToken: 'dev-token-synthetic',
+      admissionIntakeSpikeOperatorIds: ['op-alice'],
+    });
+    expect(hasAdmissionRoute(app)).toBe(false);
+  });
+
+  it('a disabled-spike app never returns a spike body for the admission path', async () => {
+    const app = createDixieApp(baseConfig());
+    // With no admission route mounted, the request never reaches a spike
+    // handler. The global /api/* allowlist middleware fails closed first
+    // (401) for an unauthenticated caller; either way the response is NOT a
+    // spike body and NOT a 200 success.
+    const res = await app.app.request('/api/admission/intake', { method: 'POST' });
+    expect(res.status).not.toBe(200);
+    const text = await res.text();
+    expect(text).not.toContain('admission.spike_disabled');
+    expect(text).not.toContain('dev_operator_only_non_production');
+  });
+});

--- a/app/tests/integration/admission-intake/route-gate.test.ts
+++ b/app/tests/integration/admission-intake/route-gate.test.ts
@@ -1,0 +1,536 @@
+// Phase 33N — POST /api/admission/intake dev/operator-only route SPIKE,
+// end-to-end against an in-process Hono app (NON-PRODUCTION, Storage Option A).
+//
+// Proves: disabled-gate refusal, unauthorized refusal (missing/invalid/non-
+// operator), all five scenarios over the real handler, malformed fail-closed,
+// deep-walk no-leak over EVERY public response, partial-failure fails closed,
+// and that no durable storage / Freeside import is reachable from the spike.
+//
+// The handler is mounted directly (mirroring recall-intake/route.test.ts), so
+// this test exercises the route logic, not the global middleware stack (the
+// server-level conditional mount is proven in registration.test.ts).
+
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import {
+  createAdmissionIntakeRoutes,
+  type AdmissionSpikeAuditEvent,
+} from '../../../src/routes/admission-intake.js';
+import {
+  ADMISSION_SPIKE_BODY_MARKER,
+  ADMISSION_TRANSITION_INTENTS,
+  findAdmissionPublicLeaks,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+const TOKEN = 'dev-operator-token-synthetic-route-001';
+const OPERATOR = 'op-route-test';
+
+// --- Forced-leak fail-closed expectations (Patch 2, second round) ---
+//
+// The EXACT hardcoded known-safe fallback body the route returns when the
+// runtime no-leak guard reports a finding OR throws (route guardFailedFallback-
+// Body()). Every forced-leak path on every guard-failure mode must return this
+// body VERBATIM — no extra fields, no intended-body residue, no guard details.
+const GUARD_FAILED_FALLBACK_BODY = {
+  spike: 'dev_operator_only_non_production',
+  outcome_class: 'refused',
+  error: 'admission.fail_closed',
+  message: 'admission intake request refused',
+} as const;
+
+// A single poison string an adversarial guard might surface as a "finding":
+// a forbidden public key plus a long opaque/operational id shape.
+const POISON = 'tenant_id-0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+// A guard-detail blob that embeds EVERY class of sentinel a guard could
+// plausibly leak: the poison, a forbidden-key phrase, an Error:/stack/secret
+// trace, the service token, the operator id, and the body marker. Both the
+// returns-a-finding and the throws guard modes carry this; the route must let
+// NONE of it reach the wire or the audit trail.
+const GUARD_DETAIL = `forbidden public key "tenant_id" ${POISON} :: Error: secret in stack at /x.ts:1:1 token=${TOKEN} operator=${OPERATOR} marker=${ADMISSION_SPIKE_BODY_MARKER}`;
+
+// Substrings that must NEVER appear on the wire (or in audit) for a forced-leak
+// fail-closed response. Three groups: (1) guard findings / injected secrets,
+// (2) credentials + request-controlled material, (3) "intended rejected body"
+// content — the per-path body the route was BUILDING when the guard tripped,
+// which must not survive the collapse to the fixed fallback. None of these is a
+// substring of the four fixed fallback strings, so they never false-positive.
+const FORCED_LEAK_FORBIDDEN_SUBSTRINGS: string[] = [
+  // (1) guard findings / injected secrets / error internals
+  'tenant_id',
+  POISON,
+  'forbidden public key',
+  'Error:',
+  'stack',
+  'secret',
+  GUARD_DETAIL,
+  // (2) credentials + request material
+  TOKEN,
+  OPERATOR,
+  ADMISSION_SPIKE_BODY_MARKER,
+  // (3) intended (rejected) body content — must not survive the fail-closed
+  // collapse. These appear in the per-path intended bodies (disabled /
+  // unauthorized / fail-closed / the five classified outcomes) but never in the
+  // fixed fallback.
+  'scenario_id',
+  'recall_projection',
+  'recall_eligible',
+  'safe_reason_code',
+  'public_receipt_ref',
+  'draft_markers',
+  'admission-spike-receipt-draft',
+  'ingress.invalid_request',
+  'malformed_or_unsafe_payload_fail_closed',
+  'admission.spike_disabled',
+  'admission.unauthorized_dev_operator',
+  'accepted_as_proposed',
+  'admitted_active_assertion_draft_placeholder',
+  'corrected_active_assertion_draft_placeholder',
+  'superseded_prior_assertion_draft_placeholder',
+];
+
+function buildApp(opts?: {
+  enabled?: boolean;
+  serviceToken?: string;
+  operatorIds?: string[];
+  beforeFinalize?: () => void;
+  noLeakGuard?: (body: unknown) => string[];
+}) {
+  const audit: AdmissionSpikeAuditEvent[] = [];
+  const app = new Hono();
+  app.route(
+    '/api/admission/intake',
+    createAdmissionIntakeRoutes({
+      enabled: opts?.enabled ?? true,
+      gate: {
+        serviceToken: opts?.serviceToken ?? TOKEN,
+        operatorIds: opts?.operatorIds ?? [OPERATOR],
+      },
+      beforeFinalize: opts?.beforeFinalize,
+      noLeakGuard: opts?.noLeakGuard,
+      emitAudit: (e) => audit.push(e),
+    }),
+  );
+  return { app, audit };
+}
+
+function authHeaders(extra?: Record<string, string>) {
+  return {
+    'content-type': 'application/json',
+    'x-admission-service-token': TOKEN,
+    'x-admission-operator-id': OPERATOR,
+    ...extra,
+  };
+}
+
+function spikeBody(transition_intent: string) {
+  return JSON.stringify({ spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent });
+}
+
+describe('POST /api/admission/intake — disabled gate (default-off posture)', () => {
+  it('returns a safe disabled refusal (404) leaking nothing', async () => {
+    const { app, audit } = buildApp({ enabled: false });
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(404);
+    const text = await res.text();
+    const body = JSON.parse(text);
+    expect(body.outcome_class).toBe('refused');
+    expect(body.error).toBe('admission.spike_disabled');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+    expect(audit.some((e) => e.event === 'admission_intake_spike.disabled')).toBe(true);
+  });
+});
+
+describe('POST /api/admission/intake — auth gate (dev/operator-only)', () => {
+  it('missing auth denies (403)', async () => {
+    const { app } = buildApp();
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(403);
+    const body = JSON.parse(await res.text());
+    expect(body.error).toBe('admission.unauthorized_dev_operator');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+  });
+
+  it('invalid token denies (403)', async () => {
+    const { app } = buildApp();
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders({ 'x-admission-service-token': 'wrong-token' }),
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('non-operator denies (403)', async () => {
+    const { app } = buildApp();
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders({ 'x-admission-operator-id': 'op-mallory' }),
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('empty token AND empty allowlist rejects all even when enabled', async () => {
+    const { app } = buildApp({ serviceToken: '', operatorIds: [] });
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('does not reveal the token or whether it almost matched on refusal', async () => {
+    const { app } = buildApp();
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders({ 'x-admission-service-token': TOKEN.slice(0, -1) }),
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(403);
+    const text = await res.text();
+    expect(text).not.toContain(TOKEN);
+    expect(text).not.toContain(TOKEN.slice(0, -1));
+    expect(text).not.toMatch(/almost|prefix|partial/i);
+  });
+});
+
+describe('POST /api/admission/intake — five scenarios (authorized)', () => {
+  const cases: Array<{ name: string; intent: string; status: number; outcome: string; recall: boolean }> = [
+    { name: 'A pending', intent: ADMISSION_TRANSITION_INTENTS.pending, status: 200, outcome: 'accepted_as_proposed', recall: false },
+    { name: 'B accept', intent: ADMISSION_TRANSITION_INTENTS.accept, status: 200, outcome: 'admitted', recall: true },
+    { name: 'C reject', intent: ADMISSION_TRANSITION_INTENTS.reject, status: 200, outcome: 'denied', recall: false },
+    { name: 'D supersede', intent: ADMISSION_TRANSITION_INTENTS.supersede, status: 200, outcome: 'superseded_with_correction', recall: true },
+    { name: 'E malformed', intent: ADMISSION_TRANSITION_INTENTS.malformed, status: 400, outcome: 'refused', recall: false },
+  ];
+
+  for (const tc of cases) {
+    it(`${tc.name}: ${tc.outcome} (${tc.status}), no leak`, async () => {
+      const { app, audit } = buildApp();
+      const res = await app.request('/api/admission/intake', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: spikeBody(tc.intent),
+      });
+      expect(res.status).toBe(tc.status);
+      const body = JSON.parse(await res.text());
+      expect(body.outcome_class).toBe(tc.outcome);
+      expect(body.recall_eligible).toBe(tc.recall);
+      expect(body.spike).toBe('dev_operator_only_non_production');
+      expect(findAdmissionPublicLeaks(body)).toEqual([]);
+      // Audit carries only public-safe fields.
+      const serialized = JSON.stringify(audit);
+      expect(serialized).not.toContain(TOKEN);
+      expect(serialized).not.toContain(OPERATOR);
+    });
+  }
+});
+
+describe('POST /api/admission/intake — malformed / unsupported fail-closed', () => {
+  const bad: Array<[string, string]> = [
+    ['invalid JSON', '{ not json'],
+    ['missing marker', JSON.stringify({ transition_intent: ADMISSION_TRANSITION_INTENTS.accept })],
+    ['unknown intent', JSON.stringify({ spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: 'invent' })],
+    ['free-form payload', JSON.stringify({ spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: ADMISSION_TRANSITION_INTENTS.accept, candidate_payload: { text: 'remember this' } })],
+    ['empty body', ''],
+  ];
+  for (const [name, raw] of bad) {
+    it(`${name} → 400 ingress.invalid_request, nothing recallable, no leak`, async () => {
+      const { app } = buildApp();
+      const res = await app.request('/api/admission/intake', {
+        method: 'POST',
+        headers: authHeaders(),
+        body: raw,
+      });
+      expect(res.status).toBe(400);
+      const body = JSON.parse(await res.text());
+      expect(body.outcome_class).toBe('refused');
+      expect(body.safe_reason_code).toBe('ingress.invalid_request');
+      expect(body.recall_eligible).toBe(false);
+      expect(findAdmissionPublicLeaks(body)).toEqual([]);
+      // The hidden reason (e.g. the raw payload) never appears in the body.
+      expect(JSON.stringify(body)).not.toContain('remember this');
+    });
+  }
+});
+
+describe('POST /api/admission/intake — partial-failure posture (Phase 33M §13.1)', () => {
+  it('an internal partial failure fails closed with the stable refusal, no recallable state', async () => {
+    const { app } = buildApp({
+      beforeFinalize: () => {
+        throw new Error('simulated partial internal failure');
+      },
+    });
+    // Use the accept scenario (which WOULD have been recall-eligible) to prove
+    // a partial failure produces NO recallable admitted assertion.
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(400);
+    const body = JSON.parse(await res.text());
+    expect(body.outcome_class).toBe('refused');
+    expect(body.safe_reason_code).toBe('ingress.invalid_request');
+    expect(body.recall_eligible).toBe(false);
+    expect(body.public_receipt_ref ?? null).toBeNull();
+    expect(body.recall_projection?.ordinary_recall_includes ?? []).toEqual([]);
+    // The simulated error message must not leak into the public body.
+    expect(JSON.stringify(body)).not.toContain('simulated partial internal failure');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+  });
+
+  it('retrying the same accept request never mints a duplicate (Option A future-intent)', async () => {
+    const { app } = buildApp();
+    const headers = authHeaders();
+    const body = spikeBody(ADMISSION_TRANSITION_INTENTS.accept);
+    const r1 = await app.request('/api/admission/intake', { method: 'POST', headers, body });
+    const r2 = await app.request('/api/admission/intake', { method: 'POST', headers, body });
+    const t1 = await r1.text();
+    const t2 = await r2.text();
+    // Deterministic, identical, no durable state → no duplicate assertion.
+    expect(r1.status).toBe(r2.status);
+    expect(t1).toBe(t2);
+    expect(JSON.parse(t1).public_receipt_ref).toBe('admission-spike-receipt-draft');
+  });
+});
+
+describe('POST /api/admission/intake — no-leak deep-walk over every public surface', () => {
+  it('covers disabled / unauthorized / malformed / all five scenarios', async () => {
+    const surfaces: Array<{ label: string; app: Hono; headers: Record<string, string>; body: string }> = [];
+
+    // disabled
+    surfaces.push({ label: 'disabled', app: buildApp({ enabled: false }).app, headers: authHeaders(), body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept) });
+    // unauthorized
+    surfaces.push({ label: 'unauthorized', app: buildApp().app, headers: { 'content-type': 'application/json' }, body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept) });
+    // malformed
+    surfaces.push({ label: 'malformed', app: buildApp().app, headers: authHeaders(), body: '{ not json' });
+    // five scenarios
+    for (const intent of Object.values(ADMISSION_TRANSITION_INTENTS)) {
+      surfaces.push({ label: `scenario:${intent}`, app: buildApp().app, headers: authHeaders(), body: spikeBody(intent) });
+    }
+
+    for (const s of surfaces) {
+      const res = await s.app.request('/api/admission/intake', { method: 'POST', headers: s.headers, body: s.body });
+      const text = await res.text();
+      const parsed = JSON.parse(text);
+      const leaks = findAdmissionPublicLeaks(parsed);
+      expect({ label: s.label, leaks }).toEqual({ label: s.label, leaks: [] });
+      // Wire-text scan for obvious leak shapes.
+      expect(text).not.toMatch(/eyJ[A-Za-z0-9_-]+\./); // no JWT
+      expect(text).not.toContain('.ts:');
+      expect(text).not.toContain('Traceback');
+    }
+  });
+});
+
+// Patch 1 (Phase 33N audit): the runtime no-leak guard MUST inspect EVERY
+// public body — not only the classified-outcome responses. These tests use the
+// `noLeakGuard` DI seam to prove (a) the guard is actually invoked for every
+// response path (disabled / unauthorized / oversized / malformed / classifier-
+// error / partial-failure / a successful classified outcome), and (b) when the
+// guard reports a leak on any path, the route fails closed to a hardcoded
+// known-safe fallback that itself leaks neither the rejected body nor the
+// guard's own findings.
+
+// Every distinct response path, expressed as a buildApp() options + request.
+// `cleanEvent` is the SINGLE per-path audit event the route emits when the guard
+// passes (used to prove exactly-one-event behavior and that a guard failure
+// suppresses this event in favor of the stable refused event).
+type GuardPathCase = {
+  label: string;
+  opts: Parameters<typeof buildApp>[0];
+  headers: Record<string, string>;
+  body: string;
+  cleanEvent: AdmissionSpikeAuditEvent['event'];
+};
+
+// The five CLASSIFIED responses (Patch 2): every transition_intent the
+// classifier recognizes. Note `classified:malformed` is the EXPLICIT malformed
+// classification (vector E — recognized → refused/400), which is distinct from
+// the `classifier-error` path below (an UNRECOGNIZED intent that throws). The
+// four non-refused outcomes emit `…outcome`; the explicit malformed emits
+// `…refused` (carrying scenario_id + outcome_class on the clean path).
+const CLASSIFIED_CASES: Array<{ label: string; intent: string; cleanEvent: AdmissionSpikeAuditEvent['event'] }> = [
+  { label: 'classified:pending', intent: ADMISSION_TRANSITION_INTENTS.pending, cleanEvent: 'admission_intake_spike.outcome' },
+  { label: 'classified:accept', intent: ADMISSION_TRANSITION_INTENTS.accept, cleanEvent: 'admission_intake_spike.outcome' },
+  { label: 'classified:reject', intent: ADMISSION_TRANSITION_INTENTS.reject, cleanEvent: 'admission_intake_spike.outcome' },
+  { label: 'classified:supersede', intent: ADMISSION_TRANSITION_INTENTS.supersede, cleanEvent: 'admission_intake_spike.outcome' },
+  { label: 'classified:malformed', intent: ADMISSION_TRANSITION_INTENTS.malformed, cleanEvent: 'admission_intake_spike.refused' },
+];
+
+function guardPathCases(spyGuard?: (body: unknown) => string[]): GuardPathCase[] {
+  return [
+    { label: 'disabled', opts: { enabled: false, noLeakGuard: spyGuard }, headers: authHeaders(), body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept), cleanEvent: 'admission_intake_spike.disabled' },
+    { label: 'unauthorized', opts: { noLeakGuard: spyGuard }, headers: { 'content-type': 'application/json' }, body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept), cleanEvent: 'admission_intake_spike.unauthorized' },
+    // A body well past the 8KB endpoint cap trips the byte-length check before
+    // JSON.parse (deterministic regardless of any recomputed content-length).
+    { label: 'oversized', opts: { noLeakGuard: spyGuard }, headers: authHeaders(), body: '{"spike":"' + 'x'.repeat(9000) + '"}', cleanEvent: 'admission_intake_spike.refused' },
+    { label: 'malformed', opts: { noLeakGuard: spyGuard }, headers: authHeaders(), body: '{ not json', cleanEvent: 'admission_intake_spike.refused' },
+    { label: 'classifier-error', opts: { noLeakGuard: spyGuard }, headers: authHeaders(), body: JSON.stringify({ spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: 'totally-unknown-intent' }), cleanEvent: 'admission_intake_spike.refused' },
+    { label: 'partial-failure', opts: { noLeakGuard: spyGuard, beforeFinalize: () => { throw new Error('boom'); } }, headers: authHeaders(), body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept), cleanEvent: 'admission_intake_spike.refused' },
+    // All five classified responses (Patch 2): pending, accept, reject,
+    // supersede, and the explicit malformed classification.
+    ...CLASSIFIED_CASES.map((tc) => ({
+      label: tc.label,
+      opts: { noLeakGuard: spyGuard },
+      headers: authHeaders(),
+      body: spikeBody(tc.intent),
+      cleanEvent: tc.cleanEvent,
+    })),
+  ];
+}
+
+describe('POST /api/admission/intake — runtime no-leak guard runs on EVERY response path (Patch 1)', () => {
+  it('invokes the injected guard exactly once for every public response path', async () => {
+    // Covers all non-classified paths AND all five classified responses
+    // (pending / accept / reject / supersede / explicit malformed) — Patch 2.
+    for (const tc of guardPathCases()) {
+      let calls = 0;
+      const seen: unknown[] = [];
+      const spyGuard = (body: unknown) => {
+        calls += 1;
+        seen.push(body);
+        return []; // clean — let the intended body through
+      };
+      const { app, audit } = buildApp({ ...tc.opts, noLeakGuard: spyGuard });
+      await app.request('/api/admission/intake', { method: 'POST', headers: tc.headers, body: tc.body });
+      // The guard saw this path's outgoing body before it was sent.
+      expect({ path: tc.label, calls }).toEqual({ path: tc.label, calls: 1 });
+      // And what it inspected was an object (the public body), never a string.
+      expect({ path: tc.label, isObject: typeof seen[0] === 'object' && seen[0] !== null }).toEqual({
+        path: tc.label,
+        isObject: true,
+      });
+      // On a CLEAN guard, exactly one audit event fires for this path — the
+      // intended per-path event — and NOT the stable guard-failure refused
+      // event (unless this path's clean event already IS `…refused`).
+      expect({ path: tc.label, len: audit.length }).toEqual({ path: tc.label, len: 1 });
+      expect({ path: tc.label, event: audit[0]!.event }).toEqual({ path: tc.label, event: tc.cleanEvent });
+    }
+  });
+
+  // The two guard-FAILURE modes the route treats identically (fail closed):
+  // (a) the guard RETURNS a non-empty finding list, and (b) the guard THROWS.
+  // Patch 2 (second round): the error/secret/stack-leak proof must hold for
+  // EVERY forced-leak path under BOTH modes — not only for one standalone
+  // throwing-guard test. Each mode's guard embeds the full GUARD_DETAIL blob
+  // (poison + forbidden-key phrase + Error:/stack/secret + token + operator +
+  // body marker); none of it may reach the wire or the audit trail.
+  const GUARD_FAILURE_MODES: Array<{
+    mode: string;
+    makeGuard: () => (body: unknown) => string[];
+  }> = [
+    { mode: 'returns-finding', makeGuard: () => () => [GUARD_DETAIL] },
+    {
+      mode: 'throws',
+      makeGuard:
+        () =>
+        () => {
+          throw new Error(GUARD_DETAIL);
+        },
+    },
+  ];
+
+  it('fails closed to the EXACT known-safe fallback on every path under both guard-failure modes', async () => {
+    // Adversarial: force the guard to fail (return a finding OR throw) as if a
+    // forbidden field had slipped into the outgoing body. Every path — including
+    // all five classified responses (pending / accept / reject / supersede /
+    // explicit malformed) — must collapse to the HARDCODED fallback (HTTP 500):
+    // exact body equality, never the intended body, never the guard's findings,
+    // and never an Error/stack/secret. (Patch 2.)
+    for (const gm of GUARD_FAILURE_MODES) {
+      for (const tc of guardPathCases()) {
+        const where = `${tc.label}/${gm.mode}`;
+        const { app, audit } = buildApp({ ...tc.opts, noLeakGuard: gm.makeGuard() });
+        const res = await app.request('/api/admission/intake', {
+          method: 'POST',
+          headers: tc.headers,
+          body: tc.body,
+        });
+        expect({ where, status: res.status }).toEqual({ where, status: 500 });
+        const text = await res.text();
+        const body = JSON.parse(text);
+
+        // (1) EXACT fallback body equality — proves no extra fields, no
+        // intended-body residue, and no guard detail are present (`toEqual`
+        // requires the object to have EXACTLY these keys/values).
+        expect({ where, body }).toEqual({ where, body: { ...GUARD_FAILED_FALLBACK_BODY } });
+
+        // (2) Wire-text sentinel sweep — the serialized client response carries
+        // none of: guard findings, poison, forbidden-key text, TOKEN, OPERATOR,
+        // body marker, intended rejected-body content, Error:, stack, or secret.
+        for (const forbidden of FORCED_LEAK_FORBIDDEN_SUBSTRINGS) {
+          expect({ where, forbidden, present: text.includes(forbidden) }).toEqual({
+            where,
+            forbidden,
+            present: false,
+          });
+        }
+        // (3) The fallback is clean under the REAL guard.
+        expect({ where, leaks: findAdmissionPublicLeaks(body) }).toEqual({ where, leaks: [] });
+
+        // (4) Exact audit behavior on guard failure: EXACTLY ONE event (not
+        // audit.some), the STABLE refused event, and NOT the original per-path
+        // clean event. The guard-failure refused event carries NO scenario_id
+        // and NO outcome_class — distinguishing it from a clean classified
+        // refused event (e.g. classified:malformed) which would carry both.
+        expect({ where, len: audit.length }).toEqual({ where, len: 1 });
+        const event = audit[0]!;
+        expect({ where, event: event.event }).toEqual({
+          where,
+          event: 'admission_intake_spike.refused',
+        });
+        expect({ where, scenario_id: event.scenario_id ?? null }).toEqual({ where, scenario_id: null });
+        expect({ where, outcome_class: event.outcome_class ?? null }).toEqual({
+          where,
+          outcome_class: null,
+        });
+        // (5) No guard details / secrets / token / operator / request body in
+        // the audit trail either — same sentinel sweep applied to the audit.
+        const serializedAudit = JSON.stringify(audit);
+        for (const forbidden of FORCED_LEAK_FORBIDDEN_SUBSTRINGS) {
+          expect({ where, forbidden, inAudit: serializedAudit.includes(forbidden) }).toEqual({
+            where,
+            forbidden,
+            inAudit: false,
+          });
+        }
+      }
+    }
+  });
+
+  it('fails closed (does not crash or leak) when the guard itself THROWS (focused smoke test)', async () => {
+    // Retained as a focused, readable smoke test. It is NO LONGER the sole proof
+    // of error/secret/stack non-leakage — the forced-leak matrix above now
+    // exercises the throwing-guard mode on every path. A guard that throws must
+    // be treated like a detected leak — never a 500 with a stack trace, never
+    // the intended body.
+    const throwingGuard = () => {
+      throw new Error('guard exploded: tenant_id=secret');
+    };
+    const { app } = buildApp({ noLeakGuard: throwingGuard });
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: spikeBody(ADMISSION_TRANSITION_INTENTS.accept),
+    });
+    expect(res.status).toBe(500);
+    const text = await res.text();
+    const body = JSON.parse(text);
+    expect(body).toEqual({ ...GUARD_FAILED_FALLBACK_BODY });
+    expect(text).not.toContain('guard exploded');
+    expect(text).not.toContain('secret');
+    expect(text).not.toContain('Error:');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/auth-gate.test.ts
+++ b/app/tests/unit/admission-wedge-spike/auth-gate.test.ts
@@ -1,0 +1,82 @@
+// Phase 33N — dev/operator-only Admission Wedge spike auth gate (NOT
+// production auth). Proves the fail-closed gate semantics:
+//   * empty token AND empty allowlist → reject ALL;
+//   * configured token → matching `x-admission-service-token` required;
+//   * configured operator allowlist → allowlisted `x-admission-operator-id`
+//     required;
+//   * both configured → both required;
+//   * non-operator / missing / invalid → denied.
+//
+// The service token is read from a DEDICATED header (NOT `Authorization`) to
+// avoid colliding with the global /api/* allowlist gate — see auth-gate.ts.
+// All ids/tokens are synthetic and public-safe.
+
+import { describe, expect, it } from 'vitest';
+import { authorizeAdmissionSpike } from '../../../src/services/admission-wedge-spike/index.js';
+
+const TOKEN = 'dev-operator-token-synthetic-0001';
+
+describe('Phase 33N — admission spike auth gate (dev/operator-only, fail-closed)', () => {
+  it('empty token AND empty allowlist rejects all (no production default)', () => {
+    const gate = { serviceToken: '', operatorIds: [] };
+    expect(authorizeAdmissionSpike(gate, { serviceToken: undefined, operatorId: undefined })).toBe(false);
+    // Even a plausible-looking credential cannot pass when nothing is configured.
+    expect(
+      authorizeAdmissionSpike(gate, { serviceToken: TOKEN, operatorId: 'op-alice' }),
+    ).toBe(false);
+  });
+
+  describe('service token only configured', () => {
+    const gate = { serviceToken: TOKEN, operatorIds: [] };
+
+    it('matching token authorizes', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: TOKEN, operatorId: undefined })).toBe(true);
+    });
+    it('missing token denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: undefined, operatorId: undefined })).toBe(false);
+    });
+    it('wrong token denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: 'wrong-token-value-xxxx', operatorId: undefined })).toBe(false);
+    });
+    it('almost-right token (prefix) denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: TOKEN.slice(0, -1), operatorId: undefined })).toBe(false);
+    });
+    it('empty token string denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: '', operatorId: undefined })).toBe(false);
+    });
+  });
+
+  describe('operator allowlist only configured', () => {
+    const gate = { serviceToken: '', operatorIds: ['op-alice', 'op-bob'] };
+
+    it('allowlisted operator authorizes', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: undefined, operatorId: 'op-bob' })).toBe(true);
+    });
+    it('non-allowlisted operator denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: undefined, operatorId: 'op-mallory' })).toBe(false);
+    });
+    it('missing operator id denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: undefined, operatorId: undefined })).toBe(false);
+    });
+    it('empty operator id denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: undefined, operatorId: '' })).toBe(false);
+    });
+  });
+
+  describe('both token and operator allowlist configured', () => {
+    const gate = { serviceToken: TOKEN, operatorIds: ['op-alice'] };
+
+    it('both valid authorizes', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: TOKEN, operatorId: 'op-alice' })).toBe(true);
+    });
+    it('valid token but non-operator denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: TOKEN, operatorId: 'op-mallory' })).toBe(false);
+    });
+    it('valid operator but wrong token denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: 'wrong', operatorId: 'op-alice' })).toBe(false);
+    });
+    it('valid operator but missing token denies', () => {
+      expect(authorizeAdmissionSpike(gate, { serviceToken: undefined, operatorId: 'op-alice' })).toBe(false);
+    });
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/classifier-scenarios.test.ts
+++ b/app/tests/unit/admission-wedge-spike/classifier-scenarios.test.ts
@@ -1,0 +1,241 @@
+// Phase 33N — dev/operator-only Admission Wedge spike classifier + scenario
+// behavior + no-leak (NON-PRODUCTION, Storage Option A).
+//
+// Uses the Phase 33L route-contract test vectors as the FIXTURE CONTRACT
+// EVIDENCE (Phase 33M §7, §9): the classifier's `transition_intent`
+// discriminators are read from the actual vector JSON `request_vector`, and the
+// classified outcomes are checked against each vector's
+// `expected_public_response` / `expected_recall_projection`. The vectors are
+// read read-only as fixtures in this test ONLY — no docs validator is imported
+// into runtime, and the vector JSON is NOT mutated.
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  classifyAdmissionSpike,
+  AdmissionSpikeUnsupportedShapeError,
+  ADMISSION_SPIKE_BODY_MARKER,
+  buildAdmissionSpikePublicResponse,
+  findAdmissionPublicLeaks,
+  type AdmissionSpikeScenario,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+// docs/admission-wedge/route-contract-test-vectors lives at the repo root,
+// three levels up from app/tests/unit/admission-wedge-spike.
+const VECTORS_DIR = resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'docs',
+  'admission-wedge',
+  'route-contract-test-vectors',
+);
+
+interface RouteVector {
+  scenario_id: string;
+  request_vector: { transition_intent: string };
+  expected_public_response: {
+    outcome_class: string;
+    recall_eligible: boolean;
+    safe_reason_code: string | null;
+  };
+  expected_recall_projection: {
+    ordinary_recall_includes: string[];
+    ordinary_recall_excludes: string[];
+  };
+}
+
+function loadVector(file: string): RouteVector {
+  return JSON.parse(readFileSync(join(VECTORS_DIR, file), 'utf8')) as RouteVector;
+}
+
+// scenario → (vector file, our scenario key). Frozen-by-count: exactly five.
+const SCENARIOS: Array<{
+  file: string;
+  scenario: AdmissionSpikeScenario;
+  vectorScenarioId: string;
+}> = [
+  { file: 'candidate-pending-not-recallable.json', scenario: 'pending', vectorScenarioId: 'candidate_pending_not_recallable' },
+  { file: 'accept-candidate-to-admitted-assertion.json', scenario: 'accept', vectorScenarioId: 'accept_candidate_to_admitted_assertion' },
+  { file: 'reject-candidate-no-assertion.json', scenario: 'reject', vectorScenarioId: 'reject_candidate_no_assertion' },
+  { file: 'supersede-with-corrected-assertion.json', scenario: 'supersede', vectorScenarioId: 'supersede_with_corrected_assertion' },
+  { file: 'malformed-or-unsafe-payload-fail-closed.json', scenario: 'malformed', vectorScenarioId: 'malformed_or_unsafe_payload_fail_closed' },
+];
+
+function bodyForVector(v: RouteVector) {
+  return {
+    spike: ADMISSION_SPIKE_BODY_MARKER,
+    transition_intent: v.request_vector.transition_intent,
+  };
+}
+
+describe('Phase 33N — classifier maps the five Phase 33L vectors deterministically', () => {
+  it('exactly five scenarios are recognized (frozen-by-count; no sixth)', () => {
+    expect(SCENARIOS).toHaveLength(5);
+    const ids = new Set(SCENARIOS.map((s) => s.vectorScenarioId));
+    expect(ids.size).toBe(5);
+  });
+
+  for (const { file, scenario, vectorScenarioId } of SCENARIOS) {
+    describe(`${vectorScenarioId}`, () => {
+      const vector = loadVector(file);
+
+      it('vector loads and its scenario_id matches', () => {
+        expect(vector.scenario_id).toBe(vectorScenarioId);
+      });
+
+      it('classifies to the expected outcome_class and recall eligibility', () => {
+        const c = classifyAdmissionSpike(bodyForVector(vector));
+        expect(c.scenario).toBe(scenario);
+        expect(c.outcome_class).toBe(vector.expected_public_response.outcome_class);
+        expect(c.recall_eligible).toBe(vector.expected_public_response.recall_eligible);
+      });
+
+      it('public response recall projection matches the vector projection', () => {
+        const c = classifyAdmissionSpike(bodyForVector(vector));
+        const body = buildAdmissionSpikePublicResponse(c);
+        expect(body.recall_projection.ordinary_recall_includes).toEqual(
+          vector.expected_recall_projection.ordinary_recall_includes,
+        );
+        expect(body.recall_projection.ordinary_recall_excludes).toEqual(
+          vector.expected_recall_projection.ordinary_recall_excludes,
+        );
+      });
+
+      it('public response is deep-walk no-leak clean', () => {
+        const c = classifyAdmissionSpike(bodyForVector(vector));
+        const body = buildAdmissionSpikePublicResponse(c);
+        expect(findAdmissionPublicLeaks(body)).toEqual([]);
+      });
+
+      it('public response carries the non-final draft markers and never claims final/production', () => {
+        const c = classifyAdmissionSpike(bodyForVector(vector));
+        const body = buildAdmissionSpikePublicResponse(c);
+        expect(body.spike).toBe('dev_operator_only_non_production');
+        expect(body.draft_markers.schema_final).toBe(false);
+        expect(body.draft_markers.production_admission).toBe(false);
+        expect(body.draft_markers.straylight_primitive_review_complete).toBe(false);
+        expect(body.draft_markers.idempotency_final).toBe(false);
+        expect(body.draft_markers.unresolved_review_rows).toEqual(['E', 'G', 'H', 'K', 'N', 'O']);
+        expect(body.draft_markers.review_dependent_non_final_rows).toEqual(['J']);
+      });
+    });
+  }
+});
+
+describe('Phase 33N — scenario-specific behaviors (Phase 33M §3 A–E)', () => {
+  function classify(scenario: AdmissionSpikeScenario) {
+    const entry = SCENARIOS.find((s) => s.scenario === scenario)!;
+    return classifyAdmissionSpike(bodyForVector(loadVector(entry.file)));
+  }
+
+  it('A. pending: proposed, not recallable, no denied/rejected vocabulary, no public receipt', () => {
+    const c = classify('pending');
+    const body = buildAdmissionSpikePublicResponse(c);
+    expect(body.outcome_class).toBe('accepted_as_proposed');
+    expect(body.recall_eligible).toBe(false);
+    expect(body.public_receipt_ref).toBeNull();
+    expect(body.recall_projection.ordinary_recall_includes).toEqual([]);
+    // Pending must NOT use denied/rejected vocabulary.
+    expect(body.outcome_class).not.toMatch(/denied|rejected|refused/);
+    expect(body.safe_reason_code).toBeNull();
+  });
+
+  it('B. accept: admitted, recall-eligible future-intent, corrected/admitted active in projection', () => {
+    const c = classify('accept');
+    const body = buildAdmissionSpikePublicResponse(c);
+    expect(body.outcome_class).toBe('admitted');
+    expect(body.recall_eligible).toBe(true);
+    expect(body.recall_projection.ordinary_recall_includes).toEqual([
+      'admitted_active_assertion_draft_placeholder',
+    ]);
+    expect(body.recall_projection.ordinary_recall_excludes).toEqual([]);
+  });
+
+  it('C. reject: denied, no assertion, not recallable, stable draft denial code', () => {
+    const c = classify('reject');
+    const body = buildAdmissionSpikePublicResponse(c);
+    expect(body.outcome_class).toBe('denied');
+    expect(body.recall_eligible).toBe(false);
+    expect(body.recall_projection.ordinary_recall_includes).toEqual([]);
+    expect(body.safe_reason_code).toBe('admission_transition_denied_draft_non_final');
+  });
+
+  it('D. supersede: corrected-active included, superseded prior excluded from ordinary recall', () => {
+    const c = classify('supersede');
+    const body = buildAdmissionSpikePublicResponse(c);
+    expect(body.outcome_class).toBe('superseded_with_correction');
+    expect(body.recall_eligible).toBe(true);
+    expect(body.recall_projection.ordinary_recall_includes).toEqual([
+      'corrected_active_assertion_draft_placeholder',
+    ]);
+    expect(body.recall_projection.ordinary_recall_excludes).toEqual([
+      'superseded_prior_assertion_draft_placeholder',
+    ]);
+  });
+
+  it('E. malformed: fail-closed refusal with the stable Dixie shape-failure code, nothing recallable', () => {
+    const c = classify('malformed');
+    const body = buildAdmissionSpikePublicResponse(c);
+    expect(body.outcome_class).toBe('refused');
+    expect(c.http_status).toBe(400);
+    expect(body.recall_eligible).toBe(false);
+    expect(body.public_receipt_ref).toBeNull();
+    expect(body.safe_reason_code).toBe('ingress.invalid_request');
+    expect(body.recall_projection.ordinary_recall_includes).toEqual([]);
+  });
+});
+
+describe('Phase 33N — classifier fails closed on unsupported shapes (no widening)', () => {
+  const UNSUPPORTED: Array<[string, unknown]> = [
+    ['null', null],
+    ['empty object', {}],
+    ['missing marker', { transition_intent: 'admit_assertion_accept_draft' }],
+    ['wrong marker', { spike: 'something_else', transition_intent: 'admit_assertion_accept_draft' }],
+    ['unknown transition_intent', { spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: 'invent_new_intent' }],
+    ['free-form candidate payload (production-ish)', { spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: 'admit_assertion_accept_draft', candidate_payload: { text: 'remember this' } }],
+    ['extra keys (strict)', { spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: 'admit_assertion_accept_draft', tenant_id: '0xabc' }],
+    ['array', []],
+    ['string', 'admit_assertion_accept_draft'],
+  ];
+
+  for (const [name, input] of UNSUPPORTED) {
+    it(`throws AdmissionSpikeUnsupportedShapeError for: ${name}`, () => {
+      expect(() => classifyAdmissionSpike(input)).toThrow(AdmissionSpikeUnsupportedShapeError);
+    });
+  }
+
+  it('any extra key (e.g. a UUID-bearing field) is rejected by the strict schema', () => {
+    // The strict schema accepts ONLY {spike, transition_intent}; any extra
+    // field — including one carrying a UUID / operational id — fails closed.
+    expect(() =>
+      classifyAdmissionSpike({
+        spike: ADMISSION_SPIKE_BODY_MARKER,
+        transition_intent: 'admit_assertion_accept_draft',
+        candidate_ref: '550e8400-e29b-41d4-a716-446655440000',
+      }),
+    ).toThrow(AdmissionSpikeUnsupportedShapeError);
+  });
+});
+
+describe('Phase 33N — idempotency / duplicate-mint impossibility (Option A future-intent)', () => {
+  it('classification is pure: same input → identical outcome, no durable state, no duplicate', () => {
+    const body = { spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: 'admit_assertion_accept_draft' };
+    const a = classifyAdmissionSpike(body);
+    const b = classifyAdmissionSpike(body);
+    // Deterministic and identical — Option A mints nothing durable, so a
+    // "retry" cannot create a duplicate admitted/corrected assertion.
+    expect(a).toEqual(b);
+    const r1 = buildAdmissionSpikePublicResponse(a);
+    const r2 = buildAdmissionSpikePublicResponse(b);
+    expect(r1).toEqual(r2);
+    // The public response never echoes an idempotency KEY. (It does carry an
+    // `idempotency_final: false` draft marker — a non-final flag, not a key —
+    // so we assert the forbidden key/value, not the substring "idempotency".)
+    expect(findAdmissionPublicLeaks(r1)).toEqual([]);
+    expect(JSON.stringify(r1)).not.toMatch(/idempotency_key/i);
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/config-gate.test.ts
+++ b/app/tests/unit/admission-wedge-spike/config-gate.test.ts
@@ -1,0 +1,94 @@
+// Phase 33N — dev/operator-only Admission Wedge route spike config gate.
+//
+// The spike is default-OFF (NON-PRODUCTION). This test pins:
+//   * production defaults are safe (disabled, empty token, empty allowlist);
+//   * the explicit env flag is the gate (token/operator-ids alone do not
+//     enable it);
+//   * the operator-id allowlist parses comma-separated values and trims them;
+//   * an enabled spike with NO token AND NO operator allowlist still LOADS
+//     (config does not throw) — the fail-closed "reject all" rule is enforced
+//     at the route layer, proven in route-gate.test.ts.
+//
+// No live ids/secrets appear here; all values are synthetic and public-safe.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../../../src/config.js';
+
+const REQUIRED = {
+  FINN_URL: 'http://localhost:3000',
+  DIXIE_JWT_PRIVATE_KEY: 'a'.repeat(64),
+  NODE_ENV: 'test',
+};
+
+describe('config — Phase 33N admission intake spike gate (default off, non-production)', () => {
+  const saved: Record<string, string | undefined> = {};
+  const TOUCH = [
+    ...Object.keys(REQUIRED),
+    'DIXIE_ADMISSION_INTAKE_ENABLED',
+    'DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN',
+    'DIXIE_ADMISSION_INTAKE_OPERATOR_IDS',
+  ];
+
+  beforeEach(() => {
+    for (const k of TOUCH) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    Object.assign(process.env, REQUIRED);
+  });
+  afterEach(() => {
+    for (const k of TOUCH) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('default-off: spike disabled, token empty, operator allowlist empty', () => {
+    const c = loadConfig();
+    expect(c.admissionIntakeSpikeEnabled).toBe(false);
+    expect(c.admissionIntakeSpikeServiceToken).toBe('');
+    expect(c.admissionIntakeSpikeOperatorIds).toEqual([]);
+  });
+
+  it('production defaults are safe even with a token/allowlist set but flag unset', () => {
+    // Presence of a token or operator allowlist WITHOUT the enable flag must
+    // not turn the spike on — the gate is the explicit enable flag.
+    process.env.DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN = 'dev-operator-token-synthetic';
+    process.env.DIXIE_ADMISSION_INTAKE_OPERATOR_IDS = 'op-alice,op-bob';
+    const c = loadConfig();
+    expect(c.admissionIntakeSpikeEnabled).toBe(false);
+  });
+
+  it('enabled flag === "true" turns the spike on', () => {
+    process.env.DIXIE_ADMISSION_INTAKE_ENABLED = 'true';
+    process.env.DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN = 'dev-operator-token-synthetic';
+    const c = loadConfig();
+    expect(c.admissionIntakeSpikeEnabled).toBe(true);
+    expect(c.admissionIntakeSpikeServiceToken).toBe('dev-operator-token-synthetic');
+  });
+
+  it('any value other than the literal "true" leaves the spike off', () => {
+    for (const v of ['1', 'TRUE', 'yes', 'on', '']) {
+      process.env.DIXIE_ADMISSION_INTAKE_ENABLED = v;
+      const c = loadConfig();
+      expect(c.admissionIntakeSpikeEnabled).toBe(false);
+    }
+  });
+
+  it('operator ids parse comma-separated and trim whitespace; blanks dropped', () => {
+    process.env.DIXIE_ADMISSION_INTAKE_ENABLED = 'true';
+    process.env.DIXIE_ADMISSION_INTAKE_OPERATOR_IDS = ' op-alice , op-bob ,, op-carol ';
+    const c = loadConfig();
+    expect(c.admissionIntakeSpikeOperatorIds).toEqual(['op-alice', 'op-bob', 'op-carol']);
+  });
+
+  it('enabled with NO token AND NO operator allowlist still loads (route rejects all)', () => {
+    // Config does not throw; the fail-closed "empty token AND empty allowlist
+    // rejects all calls" rule is enforced by the route auth gate, not config.
+    process.env.DIXIE_ADMISSION_INTAKE_ENABLED = 'true';
+    const c = loadConfig();
+    expect(c.admissionIntakeSpikeEnabled).toBe(true);
+    expect(c.admissionIntakeSpikeServiceToken).toBe('');
+    expect(c.admissionIntakeSpikeOperatorIds).toEqual([]);
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/no-leak.test.ts
+++ b/app/tests/unit/admission-wedge-spike/no-leak.test.ts
@@ -1,0 +1,80 @@
+// Phase 33N — runtime no-leak guard. Proves the deep-walk inherits the Phase
+// 33L denylist as the runtime baseline (Phase 33M §14): it rejects forbidden
+// public keys, forbidden substrings/patterns, UUIDs, and long opaque ids, at
+// any depth — and passes clean public-safe bodies.
+
+import { describe, expect, it } from 'vitest';
+import { findAdmissionPublicLeaks, isAdmissionPublicSafe } from '../../../src/services/admission-wedge-spike/index.js';
+
+describe('Phase 33N — findAdmissionPublicLeaks (runtime no-leak baseline)', () => {
+  it('passes a clean public-safe body', () => {
+    const clean = {
+      spike: 'dev_operator_only_non_production',
+      outcome_class: 'admitted',
+      scenario_id: 'accept_candidate_to_admitted_assertion',
+      recall_eligible: true,
+      recall_projection: { ordinary_recall_includes: ['admitted_active_assertion_draft_placeholder'], ordinary_recall_excludes: [] },
+      public_receipt_ref: 'admission-spike-receipt-draft',
+      safe_reason_code: null,
+    };
+    expect(findAdmissionPublicLeaks(clean)).toEqual([]);
+    expect(isAdmissionPublicSafe(clean)).toBe(true);
+  });
+
+  describe('rejects forbidden public KEYS at any depth', () => {
+    const forbiddenKeys = [
+      'tenant_id', 'estate_id', 'candidate_id', 'candidate_payload', 'raw_candidate_payload',
+      'source_material', 'raw_reasons', 'policy_reason', 'idempotency_key', 'authority_signature_material',
+      'admitted_assertion_id', 'receipt_id', 'audit_receipt_ref', 'token', 'secret', 'storage_internals',
+    ];
+    for (const key of forbiddenKeys) {
+      it(`flags "${key}"`, () => {
+        const leaks = findAdmissionPublicLeaks({ outcome_class: 'admitted', nested: { [key]: 'x' } });
+        expect(leaks.length).toBeGreaterThan(0);
+        expect(leaks.join(' ')).toContain(key);
+      });
+    }
+  });
+
+  it('allows rendered_candidate_payload ONLY as boolean false', () => {
+    expect(findAdmissionPublicLeaks({ rendered_candidate_payload: false })).toEqual([]);
+    expect(findAdmissionPublicLeaks({ rendered_candidate_payload: 'some text' }).length).toBeGreaterThan(0);
+    expect(findAdmissionPublicLeaks({ rendered_candidate_payload: true }).length).toBeGreaterThan(0);
+  });
+
+  describe('rejects forbidden value shapes', () => {
+    it('UUID', () => {
+      expect(findAdmissionPublicLeaks({ x: '550e8400-e29b-41d4-a716-446655440000' }).length).toBeGreaterThan(0);
+    });
+    it('long opaque run (>=24 chars)', () => {
+      expect(findAdmissionPublicLeaks({ x: 'abcdef0123456789abcdef0123456789' }).length).toBeGreaterThan(0);
+    });
+    it('0x hex address', () => {
+      expect(findAdmissionPublicLeaks({ x: '0xabcdef0000000000000000000000000000000001' }).length).toBeGreaterThan(0);
+    });
+    it('url', () => {
+      expect(findAdmissionPublicLeaks({ x: 'see https://example.com/x' }).length).toBeGreaterThan(0);
+    });
+    it('JWT', () => {
+      expect(findAdmissionPublicLeaks({ x: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' }).length).toBeGreaterThan(0);
+    });
+    it('bearer token', () => {
+      expect(findAdmissionPublicLeaks({ x: 'Bearer sometoken' }).length).toBeGreaterThan(0);
+    });
+    it('stack frame', () => {
+      // Matches the Phase 33L `stack-frame` pattern /\bat\s+\/?\S+:\d+:\d+/.
+      expect(findAdmissionPublicLeaks({ x: 'at /app/src/foo.ts:12:3' }).length).toBeGreaterThan(0);
+    });
+    it('internal seam substring', () => {
+      expect(findAdmissionPublicLeaks({ x: 'runtime_seam:internal:boom' }).length).toBeGreaterThan(0);
+    });
+    it('unsafe marker substring', () => {
+      expect(findAdmissionPublicLeaks({ x: 'unsafe_marker:danger' }).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('walks arrays and deeply nested objects', () => {
+    const deep = { a: { b: [{ c: { tenant_id: '0xabc' } }] } };
+    expect(findAdmissionPublicLeaks(deep).length).toBeGreaterThan(0);
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/scope-guards.test.ts
+++ b/app/tests/unit/admission-wedge-spike/scope-guards.test.ts
@@ -1,0 +1,364 @@
+// Phase 33N — static scope guards (Phase 33M §8, §10). These assert, as
+// source-tree invariants, that the dev/operator-only Admission Wedge spike
+// stays inside its authorized envelope:
+//   * NO Freeside import anywhere in the spike path;
+//   * NO `@loa/straylight` import (runtime or type) anywhere in the spike path;
+//   * NO production storage / DB / migration / pg reachable from the spike;
+//   * NO package export of the spike (it is an internal service barrel only);
+//   * the Phase 33L route-contract validator stays Node-built-ins-only and is
+//     NOT imported from app/ (it imports nothing from app/, no runtime).
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+// TypeScript is already a dev dependency (devDependencies.typescript) — the
+// durable-write scanner below uses its parser so the comment stripper is sound
+// against every TS construct (nested templates, regex char classes, JSDoc), NOT
+// a hand-rolled character scanner that an adversary can bypass. No new package.
+import ts from 'typescript';
+
+const REPO_APP = resolve(__dirname, '..', '..', '..');
+const REPO_ROOT = resolve(REPO_APP, '..');
+const SPIKE_SERVICE_DIR = join(REPO_APP, 'src', 'services', 'admission-wedge-spike');
+const SPIKE_ROUTE_FILE = join(REPO_APP, 'src', 'routes', 'admission-intake.ts');
+
+function walkTs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...walkTs(full));
+    else if (full.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+const SPIKE_FILES = [...walkTs(SPIKE_SERVICE_DIR), SPIKE_ROUTE_FILE];
+
+const ANY_IMPORT_RE = /^\s*import\b[^'"]*?from\s*['"]([^'"]+)['"]/gm;
+const BARE_IMPORT_RE = /^\s*import\s*['"]([^'"]+)['"]/gm;
+
+/**
+ * Strip comments using the TypeScript PARSER so the durable-write denylist
+ * below scans executable source only — without false-positiving on the spike's
+ * own prose ("NO database writes, NO migrations", etc.) AND without ANY way for
+ * an adversary to hide a durable-write token after a `//` / `/*` smuggled into
+ * a string, template (including nested `${`//`}` substitutions), or regex
+ * literal (including char classes like `/[//]/`).
+ *
+ * Patch 1 (Phase 33N audit, second round): the previous HAND-ROLLED scanner was
+ * provably bypassable. Codex reproduced two valid-TypeScript counterexamples
+ * that produced ZERO denylist hits because the scanner truncated the line at a
+ * `//` it should never have treated as a comment:
+ *
+ *   const marker = `${`//`}`; pool.query("UPDATE records SET x = 1");
+ *   function f() { throw /[//]/; } pool.query("UPDATE records SET x = 1");
+ *
+ * The first hid `pool.query`/`UPDATE` because the scanner did not understand
+ * NESTED template-expression substitutions (`${ ... }` containing another
+ * template); the second because it only recognized a regex literal after a
+ * limited predecessor set (so the `/` after `throw` was read as division and
+ * the `//` in the char class started a "comment").
+ *
+ * Rather than keep expanding brittle character rules, this uses the real
+ * grammar: `ts.createSourceFile` parses the source, and we keep the EXACT
+ * source character ranges of every leaf token (identifiers, keywords,
+ * punctuation, and the full text of string/template/regex literals), blanking
+ * only the inter-token characters — which is exactly the comment trivia (plus
+ * insignificant whitespace, which we preserve). JSDoc (`/** ... *␣/`) is
+ * promoted by the parser to AST nodes attached to the following declaration, so
+ * we skip the entire JSDoc subtree (it is a comment, not executable source).
+ *
+ * Result: a `//` or `/*` that lives INSIDE a literal is part of that literal's
+ * token text and is preserved verbatim (so any durable-write token after it
+ * stays visible to the denylist), while a `//` or `/*` that is a REAL comment
+ * is trivia between tokens and is blanked. This is sound for every TypeScript
+ * construct, not just the ones an author happened to anticipate.
+ */
+function stripComments(src: string): string {
+  const sf = ts.createSourceFile(
+    'scope-guard-scan.ts',
+    src,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TS,
+  );
+  // keep[i] === 1 iff source char i belongs to a real executable leaf token.
+  const keep = new Uint8Array(src.length);
+  const markLeafRanges = (node: ts.Node): void => {
+    // JSDoc nodes are comments the parser attached to declarations; their inner
+    // text (which may legitimately say "no database writes") is NOT executable
+    // source and must not be scanned. Drop the whole JSDoc subtree.
+    if (node.kind >= ts.SyntaxKind.FirstJSDocNode && node.kind <= ts.SyntaxKind.LastJSDocNode) {
+      return;
+    }
+    const children = node.getChildren(sf);
+    if (children.length === 0) {
+      // Leaf token: keep its EXACT source range. getStart(sf, false) excludes
+      // leading trivia (whitespace + comments); getEnd() is the token end. The
+      // full text of string/template/regex literals is a single token range, so
+      // a `//` inside a literal is preserved, never read as a comment.
+      const start = node.getStart(sf, /*includeJsDocComment*/ false);
+      const end = node.getEnd();
+      for (let i = start; i < end; i++) keep[i] = 1;
+      return;
+    }
+    for (const child of children) markLeafRanges(child);
+  };
+  markLeafRanges(sf);
+  // Emit kept token chars verbatim; replace every other non-whitespace char
+  // (i.e. comment trivia) with a space so token boundaries are preserved and no
+  // two real tokens are ever fused across a stripped comment.
+  let out = '';
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i]!;
+    out += keep[i] === 1 || /\s/.test(ch) ? ch : ' ';
+  }
+  return out;
+}
+
+/** The durable-write denylist (Patch 2 of the earlier 33N audit). Shared by the
+ *  spike-source guard and the Patch-1 scanner regression tests below. */
+const DURABLE_WRITE_DENYLIST: Array<[string, RegExp]> = [
+  ['INSERT', /\bINSERT\b/i],
+  ['INSERT INTO', /\bINSERT\s+INTO\b/i],
+  ['UPDATE', /\bUPDATE\b/i],
+  ['DELETE', /\bDELETE\b/i],
+  ['CREATE TABLE', /\bCREATE\s+TABLE\b/i],
+  ['ALTER TABLE', /\bALTER\s+TABLE\b/i],
+  ['DROP TABLE', /\bDROP\s+TABLE\b/i],
+  ['pool.query', /\bpool\.query\b/],
+  ['.query(', /\.query\s*\(/],
+  ['query(', /\bquery\s*\(/],
+  ['.execute(', /\.execute\s*\(/],
+  ['execute(', /\bexecute\s*\(/],
+  ['sql`` tagged template', /\bsql\s*`/],
+  ['db.', /\bdb\./],
+  ['database', /\bdatabase\b/i],
+  ['pg', /\bpg\b/],
+  ['postgres', /\bpostgres\b/i],
+  ['migration', /\bmigration\b/i],
+  ['migrate', /\bmigrate\b/i],
+];
+
+/** Names of every denylist token that matches the (already comment-stripped)
+ *  code — used by the regression tests to prove the scanner does not let a
+ *  literal hide a durable-write token, and does strip real comments. */
+function durableWriteHits(strippedCode: string): string[] {
+  return DURABLE_WRITE_DENYLIST.filter(([, re]) => re.test(strippedCode)).map(([name]) => name);
+}
+
+function allImportSpecifiers(src: string): string[] {
+  const stripped = src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  const out: string[] = [];
+  for (const m of stripped.matchAll(ANY_IMPORT_RE)) out.push(m[1]!);
+  for (const m of stripped.matchAll(BARE_IMPORT_RE)) out.push(m[1]!);
+  return out;
+}
+
+describe('Phase 33N scope guards — spike source files exist', () => {
+  it('the spike service dir and route file are present', () => {
+    expect(SPIKE_FILES.length).toBeGreaterThanOrEqual(5);
+    expect(existsSync(SPIKE_ROUTE_FILE)).toBe(true);
+  });
+});
+
+describe('Phase 33N scope guards — no forbidden imports in the spike path', () => {
+  it('no Freeside import', () => {
+    for (const f of SPIKE_FILES) {
+      const imports = allImportSpecifiers(readFileSync(f, 'utf8'));
+      const offenders = imports.filter((i) => /freeside/i.test(i));
+      expect({ file: f, offenders }).toEqual({ file: f, offenders: [] });
+    }
+  });
+
+  it('no @loa/straylight import (runtime or type)', () => {
+    for (const f of SPIKE_FILES) {
+      const imports = allImportSpecifiers(readFileSync(f, 'utf8'));
+      const offenders = imports.filter((i) => i.startsWith('@loa/straylight'));
+      expect({ file: f, offenders }).toEqual({ file: f, offenders: [] });
+    }
+  });
+
+  it('no production storage / DB / migration / pg import reachable from the spike', () => {
+    for (const f of SPIKE_FILES) {
+      const imports = allImportSpecifiers(readFileSync(f, 'utf8'));
+      const offenders = imports.filter(
+        (i) =>
+          i === 'pg' ||
+          /\/db\/(client|pool|migrate|transaction)/.test(i) ||
+          /\/db\/migrations\//.test(i) ||
+          /-store(\.js)?$/.test(i) ||
+          /BoundedEstateStore|bounded-estate-store/.test(i),
+      );
+      expect({ file: f, offenders }).toEqual({ file: f, offenders: [] });
+    }
+  });
+
+  it('the spike source contains no SQL / migration / DB-execution / durable-write tokens', () => {
+    // Patch 2 (Phase 33N audit): the original guard only caught `INSERT INTO`,
+    // `CREATE TABLE`, `pool.query`, and `migrate(`, so it could not PROVE the
+    // "no durable write / no SQL execution" invariant — it missed UPDATE,
+    // DELETE, ALTER/DROP TABLE, bare `query(`/`.query(`, `execute(`/`.execute(`,
+    // tagged `sql\`` templates, `db.`, and the pg/postgres/database/migration
+    // family. The full denylist below proves the invariant.
+    //
+    // CODE-ONLY scoping: this spike intentionally DOCUMENTS its non-goals in
+    // prose ("NO database writes, NO migrations"), so a raw-text scan would
+    // false-positive on comments. We strip block and line comments first (via a
+    // syntax-aware scanner — see stripComments + Patch 1 regression tests), so
+    // the guard asserts the absence of these tokens in executable source —
+    // exactly what the invariant requires. (Verified: every spike source file
+    // is clean under this denylist after comment-stripping.)
+    for (const f of SPIKE_FILES) {
+      const code = stripComments(readFileSync(f, 'utf8'));
+      for (const [name, re] of DURABLE_WRITE_DENYLIST) {
+        const offender = code.match(re);
+        // Report the file + token + matched text so a future regression is
+        // immediately legible instead of a bare boolean failure.
+        expect({ file: f, token: name, matched: offender ? offender[0] : null }).toEqual({
+          file: f,
+          token: name,
+          matched: null,
+        });
+      }
+    }
+  });
+});
+
+describe('Phase 33N scope guards — comment stripper is parser-backed & sound (Patch 1)', () => {
+  // The hand-rolled scanners (both rounds) truncated a line at a `//` they
+  // wrongly treated as a comment, hiding any durable-write token that followed.
+  // These prove the parser-backed stripper (a) does NOT let a string, template
+  // (incl. nested `${`//`}`), or regex literal (incl. char classes `/[//]/`)
+  // hide a token, and (b) DOES strip real line, block, and JSDoc comments.
+
+  // --- Codex round-2 counterexamples (the two valid-TS bypasses) ---
+  // Both parsed with zero TypeScript diagnostics yet produced ZERO denylist
+  // hits under the old hand-rolled scanner. The parser-backed stripper keeps
+  // the literal text intact, so `pool.query` and `UPDATE` after it stay visible.
+
+  it('a NESTED template substitution `${`//`}` does NOT hide a later pool.query/UPDATE', () => {
+    // Codex counterexample #1. The inner template `${`//`}` must not be read as
+    // closing the outer template + starting a `//` line comment.
+    const src = 'const marker = `${`//`}`; pool.query("UPDATE records SET x = 1");';
+    const hits = durableWriteHits(stripComments(src));
+    expect(hits).toEqual(expect.arrayContaining(['pool.query', 'UPDATE']));
+  });
+
+  it('a regex literal `/[//]/` after `throw` does NOT hide a later pool.query/UPDATE', () => {
+    // Codex counterexample #2. The `/` after `throw` legally begins a regex
+    // whose char class `[//]` contains literal slashes — never a line comment.
+    const src = 'function f() { throw /[//]/; } pool.query("UPDATE records SET x = 1");';
+    const hits = durableWriteHits(stripComments(src));
+    expect(hits).toEqual(expect.arrayContaining(['pool.query', 'UPDATE']));
+  });
+
+  // --- Earlier mutation suite (must keep passing under the new stripper) ---
+
+  it('a `//` inside a double-quoted string does NOT hide a later pool.query/UPDATE', () => {
+    const src = 'const marker = "//"; pool.query("UPDATE records SET x = 1");';
+    const hits = durableWriteHits(stripComments(src));
+    // The string content is preserved, so pool.query, query(, .query( and
+    // UPDATE all remain visible to the denylist.
+    expect(hits).toEqual(expect.arrayContaining(['pool.query', 'UPDATE']));
+  });
+
+  it('a `/*` inside a string does NOT hide a later execute(...)/DELETE in the file', () => {
+    const src = 'const marker = "/*"; execute("DELETE FROM records");';
+    const hits = durableWriteHits(stripComments(src));
+    expect(hits).toEqual(expect.arrayContaining(['execute(', 'DELETE']));
+  });
+
+  it('a `//` inside a TEMPLATE literal does NOT hide a later query/UPDATE', () => {
+    const src = 'const marker = `//`; query("UPDATE records SET x = 1");';
+    const hits = durableWriteHits(stripComments(src));
+    expect(hits).toEqual(expect.arrayContaining(['query(', 'UPDATE']));
+  });
+
+  it('a REAL line comment containing pool.query("UPDATE ...") is stripped/ignored', () => {
+    const src = 'const ok = true; // pool.query("UPDATE records SET x = 1")\nconst y = 2;';
+    const stripped = stripComments(src);
+    expect(stripped).not.toContain('pool.query');
+    expect(durableWriteHits(stripped)).toEqual([]);
+  });
+
+  it('a REAL block comment containing execute("DELETE ...") is stripped/ignored', () => {
+    const src = 'const ok = true;\n/* execute("DELETE FROM records") */\nconst y = 2;';
+    const stripped = stripComments(src);
+    expect(stripped).not.toContain('execute(');
+    expect(durableWriteHits(stripped)).toEqual([]);
+  });
+
+  it('a REAL JSDoc comment containing SQL/db prose is stripped/ignored', () => {
+    // The parser promotes `/** ... *␣/` to a JSDoc AST node; the stripper must
+    // drop it (it is prose: the spike documents "no database writes" etc.).
+    const src =
+      '/**\n * No database writes; no migration; never pool.query("UPDATE x").\n */\nfunction f() { return 1; }';
+    const stripped = stripComments(src);
+    expect(stripped).not.toContain('pool.query');
+    expect(stripped).not.toContain('database');
+    expect(durableWriteHits(stripped)).toEqual([]);
+  });
+
+  it('regex literals with internal slashes are preserved (not read as comments)', () => {
+    // A `/\/\//` regex must not be mistaken for a `//` line comment; the code
+    // after it (here a UPDATE token) must remain visible.
+    const src = 'const re = /\\/\\//g; query("UPDATE x SET a = 1");';
+    const hits = durableWriteHits(stripComments(src));
+    expect(hits).toEqual(expect.arrayContaining(['query(', 'UPDATE']));
+  });
+});
+
+describe('Phase 33N scope guards — no package export of the spike', () => {
+  it('app/package.json declares no exports map (the spike adds no package export)', () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_APP, 'package.json'), 'utf8'));
+    // The dixie-bff app is a private application, not a published package; it
+    // has no `exports` field, so the spike cannot be a package export. If a
+    // future change adds an `exports` map, it MUST NOT export the spike.
+    if (pkg.exports) {
+      const exportsStr = JSON.stringify(pkg.exports);
+      expect(exportsStr).not.toMatch(/admission-wedge-spike|admission-intake/);
+    } else {
+      expect(pkg.exports).toBeUndefined();
+    }
+  });
+
+  it('no src/index.ts barrel re-exports the spike (server-mounted only)', () => {
+    // The application entrypoint is src/index.ts (a runnable server, not a
+    // library barrel). Assert it does not re-export the spike service/route.
+    const indexPath = join(REPO_APP, 'src', 'index.ts');
+    const src = readFileSync(indexPath, 'utf8');
+    expect(src).not.toMatch(/admission-wedge-spike/);
+    expect(src).not.toMatch(/admission-intake/);
+  });
+});
+
+describe('Phase 33N scope guards — Phase 33L docs validator stays isolated', () => {
+  const VALIDATOR = join(
+    REPO_ROOT,
+    'docs',
+    'admission-wedge',
+    'route-contract-test-vectors',
+    'validate-route-contract-test-vectors.mjs',
+  );
+
+  it('the route-contract validator imports only node built-ins, nothing from app/ or straylight', () => {
+    const src = readFileSync(VALIDATOR, 'utf8');
+    const imports = allImportSpecifiers(src);
+    // Every import specifier must be a node: built-in — proving the docs
+    // validator imports nothing from app/, from @loa/straylight, or from the
+    // sibling probe validator (it stays Node-built-ins-only, NOT runtime-wired).
+    expect(imports.length).toBeGreaterThan(0);
+    for (const i of imports) {
+      expect({ specifier: i, isNodeBuiltin: i.startsWith('node:') }).toEqual({
+        specifier: i,
+        isNodeBuiltin: true,
+      });
+    }
+    expect(imports.some((i) => i.includes('app/'))).toBe(false);
+    expect(imports.some((i) => i.startsWith('@loa/straylight'))).toBe(false);
+  });
+});

--- a/docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md
+++ b/docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md
@@ -759,3 +759,66 @@ This phase succeeds if:
   acceptance; its mirror/adapter proof is a pure, fixture-bound semantic mapping layer
   with **no live Dixie call**, test-only, not exported, not runtime-wired (§8, §18).
   **Not edited by this phase.**
+
+---
+
+## 21. Phase 33N implementation status note (added later)
+
+> **Phase 33N — dev/operator-only Admission Wedge route spike implementation.**
+> Implemented locally under the strict §7–§15 constraints of this gate. This note
+> records what was built; it does **not** relax any block in §8 / §17 / §18.
+
+- **What it is.** A single **dev/operator-only**, **disabled-by-default**,
+  **NON-PRODUCTION** route spike at `POST /api/admission/intake` (the Phase 33G
+  draft path — unchanged), distinct from the live `POST /api/recall/intake` seam.
+- **Disabled by default / explicit env gate.** The route is **not registered at
+  all** unless `DIXIE_ADMISSION_INTAKE_ENABLED === 'true'` (conditional mount in
+  `app/src/server.ts`, mirroring the recall route's default-off mount). All spike
+  config defaults to off/empty (`app/src/config.ts`).
+- **Dev/operator gate (NOT production auth).** A service token
+  (`DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN`, checked constant-time against the
+  dedicated `x-admission-service-token` header — deliberately **not**
+  `Authorization`, to avoid colliding with the global `/api/*` allowlist gate
+  that already consumes `Authorization` and is not exempt for `/api/admission`)
+  and/or an operator-id allowlist (`DIXIE_ADMISSION_INTAKE_OPERATOR_IDS`, checked
+  against the `x-admission-operator-id` header). **With both empty, the enabled
+  spike rejects all calls** (fail-closed; no production default). The route also
+  sits behind the global allowlist gate, so the dev/operator gate is layered on
+  top of it (defense-in-depth). No token/operator-id is logged or echoed
+  publicly; refusals never reveal which gate failed or whether a credential
+  almost matched.
+- **Storage Option A (no durable storage).** No durable Admission Wedge storage,
+  **no database writes, no migrations**. The handler is a pure classifier +
+  public-response builder that returns **safe future-intent receipts / public-safe
+  outcomes only**. Rollback is trivial: there is no durable state to roll back.
+- **Five frozen Phase 33L scenarios.** The classifier recognizes only the five
+  `transition_intent` forms carried by the Phase 33L route-contract vectors
+  (pending / accept / reject / supersede / malformed) behind a synthetic
+  non-production marker, and **fails closed** for any unsupported shape. No sixth
+  scenario.
+- **No-leak boundary.** The public response is built purely from the classified
+  scenario plus fixed synthetic placeholders (so it can carry no request-controlled
+  material), and a runtime no-leak guard mirroring this gate's §14 / the Phase 33L
+  validator denylist deep-walks every public body as defense-in-depth.
+- **Partial-failure posture (§13.1).** Any internal partial failure fails closed to
+  the stable `ingress.invalid_request` refusal — no recallable assertion, no
+  duplicate, no partially-admitted residue (there is no durable state under Option
+  A), and no leak.
+- **Files (local edits only; not staged/committed/pushed; no PR).**
+  `app/src/config.ts` (env gate + parsing), `app/src/server.ts` (conditional
+  mount), `app/src/routes/admission-intake.ts` (route handler), and
+  `app/src/services/admission-wedge-spike/` (`classifier.ts`, `public-response.ts`,
+  `no-leak.ts`, `auth-gate.ts`, `index.ts`), plus tests under
+  `app/tests/unit/admission-wedge-spike/` and
+  `app/tests/integration/admission-intake/`. A runbook note is at
+  `docs/admission-wedge/PHASE-33N-DEV-SPIKE-RUNBOOK.md`.
+- **What Phase 33N still does NOT do (unchanged from §8 / §17 / §18).** It does
+  **not** authorize or implement production admission, production
+  storage/auth/consent, Freeside runtime/client integration, Discord ingestion,
+  user chat becoming memory, a public `remember-this`, package exports, or LLM /
+  voice / Finn wiring; it does **not** freeze a final schema; it does **not**
+  complete the Straylight primitive review (A–O remain unresolved; E, G, H, K, N, O
+  and review-dependent J are carried forward as draft markers); it makes **no**
+  final idempotency / signer / authority / production identity-binding claim; and
+  it is **not** production-ready. The Phase 33E probe JSONs, the Phase 33L route
+  vector JSONs, and both docs validators were **not** mutated.

--- a/docs/admission-wedge/PHASE-33N-DEV-SPIKE-RUNBOOK.md
+++ b/docs/admission-wedge/PHASE-33N-DEV-SPIKE-RUNBOOK.md
@@ -1,0 +1,95 @@
+# Phase 33N — Admission Wedge dev/operator-only route spike: enable/disable runbook
+
+> **Status:** dev/operator-only route **spike**. **Disabled by default.**
+> **NON-PRODUCTION.** Uses **Storage Option A** — no durable Admission Wedge
+> storage, no database writes, no migrations; safe future-intent receipts /
+> public-safe outcomes only.
+>
+> Authorized **narrowly** by Phase 33M
+> ([`../ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md`](../ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md)
+> §7–§15). This spike does **not** authorize production admission, production
+> storage/auth/consent, Freeside runtime/client integration, Discord ingestion,
+> user chat becoming memory, a public `remember-this`, a final schema, or a
+> completed Straylight primitive review.
+
+## What it is
+
+A single dev/operator-only route at `POST /api/admission/intake`, distinct from
+the live `POST /api/recall/intake` seam. When enabled and authorized, it returns
+a deterministic, public-safe outcome for one of the five Phase 33L route-contract
+scenarios (pending / accept / reject / supersede / malformed). It mints nothing
+durable.
+
+## Default (off)
+
+With `DIXIE_ADMISSION_INTAKE_ENABLED` unset or not exactly `"true"`, the route is
+**not registered at all** — there is no `/api/admission/intake` endpoint.
+
+## Enable (dev/operator only)
+
+Set the env gate and **at least one** dev/operator credential gate. With the
+gate enabled but **both** credential gates empty, the route rejects **all** calls
+(fail-closed; no production default).
+
+```bash
+# Required to mount the route at all.
+export DIXIE_ADMISSION_INTAKE_ENABLED=true
+
+# Provide a dev/operator service token, an operator-id allowlist, or BOTH.
+# (If BOTH are set, BOTH must match on each request.)
+export DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN='<synthetic-dev-operator-token>'
+export DIXIE_ADMISSION_INTAKE_OPERATOR_IDS='op-alice,op-bob'
+```
+
+Do **not** commit real tokens/ids — provide them via env/secret. The token is a
+synthetic dev/operator credential; it is **not** production auth and carries no
+production signer/authority semantics.
+
+## Disable / rollback
+
+Unset `DIXIE_ADMISSION_INTAKE_ENABLED` (or set it to anything other than
+`"true"`) and restart. Because the spike uses **Storage Option A (no durable
+storage)**, there is **no durable state to roll back** — disabling fully removes
+the endpoint.
+
+## Calling it (dev/operator example)
+
+The body carries only a synthetic non-production marker and the draft transition
+discriminator (one of the five Phase 33L `transition_intent` values). No
+free-form memory/candidate payload is accepted; any other shape fails closed.
+
+The dev/operator service token is presented in a **dedicated**
+`x-admission-service-token` header (NOT `Authorization`) so it does not collide
+with the global `/api/*` allowlist/JWT gate, which is not exempt for
+`/api/admission`. Note the route also sits behind that global allowlist gate, so
+a real (non-test) caller must additionally satisfy the allowlist (e.g. a JWT
+wallet or `Bearer dxk_` api key) — the dev/operator gate is layered on top.
+
+```bash
+curl -sS -X POST http://localhost:3001/api/admission/intake \
+  -H 'content-type: application/json' \
+  -H 'x-admission-service-token: <synthetic-dev-operator-token>' \
+  -H 'x-admission-operator-id: op-alice' \
+  -d '{"spike":"admission_intake_dev_spike_v0","transition_intent":"admit_assertion_accept_draft"}'
+```
+
+| `transition_intent` | Scenario | Public outcome | Recall-eligible |
+|---------------------|----------|----------------|:---------------:|
+| `none_candidate_write_only_draft` | A pending | `accepted_as_proposed` (200) | no |
+| `admit_assertion_accept_draft` | B accept | `admitted` (200) | yes (future-intent, draft) |
+| `admit_assertion_deny_draft` | C reject | `denied` (200) | no |
+| `supersede_with_correction_draft` | D supersede | `superseded_with_correction` (200) | yes (corrected active only) |
+| `none_refused_at_ingress_before_transition_draft` | E malformed | `refused` (400, `ingress.invalid_request`) | no |
+
+Anything else (missing marker, unknown intent, extra keys, free-form payload,
+invalid JSON) fails closed with `400 ingress.invalid_request`. A disabled spike
+returns a safe disabled refusal; an unauthorized caller returns a safe
+`403 admission.unauthorized_dev_operator`.
+
+## No-leak guarantee
+
+Every public response is built purely from the classified scenario plus fixed
+synthetic placeholders, then deep-walked by a runtime no-leak guard that mirrors
+the Phase 33L route-contract validator denylist. Public responses carry no raw
+candidate payload, source material, tokens, operator ids, idempotency keys,
+UUIDs, long opaque ids, stack traces, or storage internals.

--- a/docs/admission-wedge/route-contract-test-vectors/README.md
+++ b/docs/admission-wedge/route-contract-test-vectors/README.md
@@ -283,6 +283,40 @@ Phase 33K did **not** implement storage/auth/consent.
 > not** authorize production / public rollout / Freeside runtime integration, and
 > **does not** freeze a schema. **Phase 33N remains not implemented.**
 
+> **Phase 33N status note (added later).** Phase 33N implemented the
+> dev/operator-only, **disabled-by-default**, **NON-PRODUCTION** route spike that
+> Phase 33M authorized (see
+> [`../../ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md`](../../ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md)
+> §21 and [`../PHASE-33N-DEV-SPIKE-RUNBOOK.md`](../PHASE-33N-DEV-SPIKE-RUNBOOK.md)).
+> It uses **these five route vectors as the fixture contract evidence**: the
+> spike's classifier reads each vector's `request_vector.transition_intent` and is
+> tested against each vector's `expected_public_response` /
+> `expected_recall_projection`. It reads these vectors **read-only as test
+> fixtures** — it **mutates no vector JSON** and does **not** change this
+> validator (which stays Node-built-ins-only, not imported into runtime). It uses
+> **Storage Option A** (no durable storage / no DB writes / no migrations), adds
+> **no** package export, performs **no** Freeside or `@loa/straylight` import, and
+> claims **no** final schema, completed Straylight primitive review, final
+> idempotency, or production admission/auth/consent. The unresolved rows
+> (E, G, H, K, N, O) and review-dependent row (J) are carried forward as draft
+> markers.
+>
+> **Phase 33N current-state corrections (vs. the Phase 33L-era statements
+> above).** Some statements earlier in this document describe the Phase 33L
+> world and are no longer literally current; they are preserved as accurate
+> *Phase 33L-time* history. For the avoidance of doubt, as of Phase 33N:
+> (1) Dixie now has a disabled-by-default, dev/operator-only admission route
+> spike (`POST /api/admission/intake`) — it did **not** exist at Phase 33L, is
+> **not** enabled by default, and is **not** production-ready; (2) `app/src/config.ts`
+> and `app/src/server.ts` are now **modified by Phase 33N** for the gated
+> dev-spike wiring (they were unmodified at Phase 33L); (3) Phase 33N still does
+> **not** authorize production admission / storage / auth / consent; (4) Phase
+> 33N still does **not** mutate the Phase 33L vector JSONs or the Phase 33L
+> validator; and (5) these route-contract vectors remain **non-final / draft
+> evidence** — Phase 33N consumes them read-only as test fixtures and freezes no
+> schema. Phase 33L itself implemented **no** route; the route spike is solely
+> Phase 33N's, authorized narrowly by Phase 33M.
+
 ---
 
 ## 12. Provenance / cross-references
@@ -307,14 +341,20 @@ Phase 33K did **not** implement storage/auth/consent.
   mutated). These vectors stay aligned to those five scenarios.
 - [`../../integration/phase-32e-recall-wedge-route-contract.md`](../../integration/phase-32e-recall-wedge-route-contract.md)
   — the Recall Wedge route contract these gates are modelled on structurally;
-  `POST /api/recall/intake` is the live seam the proposed (non-existent) admission
-  route must stay distinct from.
+  `POST /api/recall/intake` is the live seam from which the admission route
+  (which, **at Phase 33L time**, did not yet exist) must stay distinct. (Phase
+  33N has since added a disabled-by-default dev/operator-only admission route
+  spike — see the §11 Phase 33N status note below.)
 - `app/src/routes/recall-intake.ts`,
   `app/src/services/straylight-recall-intake/refusal-mapping.ts`,
-  `app/src/config.ts`, `app/src/server.ts` — inspected **read-only** to ground the
-  route seam (there is **no** `/api/admission` route in Dixie today) and the
-  stable refusal code `ingress.invalid_request` the fail-closed vector reuses.
-  None is modified.
+  `app/src/config.ts`, `app/src/server.ts` — inspected **read-only** at Phase 33L
+  time to ground the route seam (**at Phase 33L there was no `/api/admission`
+  route in Dixie**, and `config.ts` / `server.ts` were unmodified by Phase 33L)
+  and the stable refusal code `ingress.invalid_request` the fail-closed vector
+  reuses. **Phase 33L modified none of these.** (Phase 33N has since modified
+  `config.ts` and `server.ts` to wire the gated dev-spike — see the §11 Phase
+  33N status note below; the recall-intake and refusal-mapping files remain
+  unmodified.)
 - `@loa/straylight` — canonical primitive/substrate owner of the assertion
   lifecycle. **No completed Straylight Admission-Wedge primitive review exists**
   (Phase 33J §4). Not edited.


### PR DESCRIPTION
## Summary

Phase 33N implements the disabled-by-default dev/operator-only Admission Wedge route spike authorized by Phase 33M.

This adds a narrow `POST /api/admission/intake` dev spike behind explicit gates. It is non-production, disabled by default, and uses Storage Option A: no durable Admission Wedge storage, no database writes, no migrations, and future-intent receipts / safe public outcomes only.

## Files

Runtime/config:

- `.env.example`
- `app/src/config.ts`
- `app/src/server.ts`
- `app/src/routes/admission-intake.ts`
- `app/src/services/admission-wedge-spike/auth-gate.ts`
- `app/src/services/admission-wedge-spike/classifier.ts`
- `app/src/services/admission-wedge-spike/index.ts`
- `app/src/services/admission-wedge-spike/no-leak.ts`
- `app/src/services/admission-wedge-spike/public-response.ts`

Tests:

- `app/tests/unit/admission-wedge-spike/auth-gate.test.ts`
- `app/tests/unit/admission-wedge-spike/classifier-scenarios.test.ts`
- `app/tests/unit/admission-wedge-spike/config-gate.test.ts`
- `app/tests/unit/admission-wedge-spike/no-leak.test.ts`
- `app/tests/unit/admission-wedge-spike/scope-guards.test.ts`
- `app/tests/integration/admission-intake/full-stack.test.ts`
- `app/tests/integration/admission-intake/registration.test.ts`
- `app/tests/integration/admission-intake/route-gate.test.ts`

Docs:

- `docs/ADMISSION-WEDGE-DEV-OPERATOR-ROUTE-SPIKE-AUTHORIZATION-GATE.md`
- `docs/admission-wedge/PHASE-33N-DEV-SPIKE-RUNBOOK.md`
- `docs/admission-wedge/route-contract-test-vectors/README.md`

## Route and gates

Adds a dev/operator-only route spike:

- `POST /api/admission/intake`
- distinct from `POST /api/recall/intake`
- mounted only when `DIXIE_ADMISSION_INTAKE_ENABLED === "true"`
- disabled by default
- defense-in-depth disabled check in handler
- no production defaults
- empty service token and empty operator allowlist reject all

Admission-specific gate:

- `DIXIE_ADMISSION_INTAKE_ENABLED`
- `DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN`
- `DIXIE_ADMISSION_INTAKE_OPERATOR_IDS`

The admission service token uses the dedicated `x-admission-service-token` header, not `Authorization: Bearer`, because the global `/api/*` allowlist owns `Authorization`. The admission dev gate is layered behind the global allowlist rather than replacing it.

## Scenario behavior

The route accepts only a strict synthetic dev-spike request shape and maps to the five Phase 33L route-vector scenarios:

- pending candidate / not recallable
- accept candidate to admitted assertion
- reject candidate / no assertion
- supersede with corrected assertion
- malformed or unsafe payload fail-closed

Unsupported or production-like shapes fail closed.

The route does not accept arbitrary freeform memory admission.

## Storage and rollback posture

This PR uses Phase 33M Storage Option A:

- no durable Admission Wedge storage
- no database writes
- no migrations
- no raw candidate payload persistence
- no production receipts
- no production storage model
- future-intent public outcomes only

Rollback / partial-failure behavior is spike-scoped:

- partial failure fails closed
- no recallable admitted assertion on partial failure
- no partially-admitted residue
- no duplicate admitted/corrected assertion
- no premature recallability of pending/rejected/malformed candidates
- stable public-safe refusal code

## Public no-leak boundary

All public responses go through a single guarded send path.

The runtime no-leak guard covers:

- disabled
- unauthorized
- oversized
- malformed / parse-error
- classifier error / default
- partial failure
- all five classified outcomes

Guard failure returns a fixed `admission.fail_closed` fallback body and does not expose guard findings.

Tests cover:

- guard invocation for every path
- forced guard finding for every path
- throwing guard for every path
- exact fallback-body equality
- no poison / tenant_id / forbidden key / token / operator / body marker / stack / secret / intended-body residue in wire response
- exact audit event behavior

## Scope guards

Added regression guards proving Phase 33N spike source has:

- no Freeside import
- no `@loa/straylight` import
- no DB / pg / store / migration import
- no SQL / durable-write execution tokens
- no package export
- no `src/index.ts` re-export
- docs validator isolation remains intact

The SQL / durable-write guard is parser-backed using the existing TypeScript compiler API and scans only executable Phase 33N route/service source files.

## Audit history

Codex initially returned PATCH for:

- runtime no-leak guard coverage not applying to every public response path
- incomplete SQL/durable-write regression guard
- config docstring naming `Authorization: Bearer` instead of `x-admission-service-token`

Claude patched those issues.

Codex then returned PATCH for:

- SQL scanner bypasses involving nested template expressions and regex literals
- forced-leak client/wire response assertions not covering every listed sentinel on every path
- stale Phase 33L README current-state wording

Claude patched those issues.

Codex then returned PATCH for:

- remaining parser/scanner bypass counterexamples
- forced-leak proof still missing exact wire fallback assertions for every path

Claude patched those issues with a TypeScript-parser-backed scanner and exact fallback-body / sentinel wire assertions.

Final Codex verdict: ACCEPT. No required patches.

## Results

Validated locally:

- `git diff --check`
- untracked no-index whitespace checks
- `node docs/admission-wedge/fixtures/validate-fixtures.mjs`
- `node docs/admission-wedge/route-contract-test-vectors/validate-route-contract-test-vectors.mjs`
- `cd app && npx tsc --noEmit`
- focused patch tests: 39/39
- targeted Phase 33N tests: 137/137
- scoped ESLint
- full app suite: 2,799 passed, 22 skipped

Codex confirmed:

- Phase 33E validator: 5/5
- Phase 33L validator: 5/5, no sixth vector
- health test passes in isolation and in final full suite
- worktree scope is exactly expected
- nothing staged before PR preparation

## Non-goals

This PR does not authorize or add:

- production admission
- production storage/auth/consent
- durable Admission Wedge storage
- database writes
- migrations
- public remember-this
- Discord command/history ingestion
- user chat becoming memory
- Freeside Characters runtime/client integration
- package exports
- LLM/voice
- Finn production wiring
- forget/revoke/correction UI
- final schema freeze
- production route deployment
- completed Straylight primitive review claim
- final idempotency semantics
- production signer/authority semantics
- production tenant/estate/actor identity binding
- final route contract
- production implementation readiness
