### PR TITLE
Phase 33Q feat: add admission bounded assertion ledger

### DIFF
--- a/app/src/routes/admission-intake.ts
+++ b/app/src/routes/admission-intake.ts
@@ -31,6 +31,8 @@ import {
   ADMISSION_SPIKE_SHAPE_REFUSAL_CODE,
   type AdmissionSpikeClassification,
   type AdmissionSpikeGateConfig,
+  type AdmittedAssertionLedger,
+  type SyntheticAdmissionTransition,
 } from '../services/admission-wedge-spike/index.js';
 
 /** Header carrying the dev/operator id (checked against the allowlist). */
@@ -80,6 +82,89 @@ export interface AdmissionSpikeRouteDeps {
    *  tests can prove the guard is invoked on every response path and that a
    *  forced leak fails closed without leaking the guard's own findings. */
   noLeakGuard?: (body: unknown) => string[];
+  /** Phase 33Q — OPTIONAL dev-only synthetic admitted-assertion ledger (DI seam).
+   *  Disabled-by-default: when undefined (the production/server default — server.ts
+   *  injects NO ledger), the route behaves EXACTLY as the Phase 33N no-store
+   *  Option A spike. When injected (tests only), an accepted/superseded synthetic
+   *  candidate is recorded into the bounded, process-local, NON-DURABLE ledger so
+   *  the candidate → admitted-assertion → recall transition's stateful effect can
+   *  be proven over SYNTHETIC material (Phase 33P §7–§12). The ledger's records
+   *  and ids are NEVER surfaced in the public body; any ledger throw fails closed
+   *  to the same stable public-safe refusal as a partial failure.
+   *
+   *  The ledger write is attempted ONLY when BOTH a ledger AND a synthetic
+   *  (tenant, estate) scope are injected (`admittedAssertionTenantId` +
+   *  `admittedAssertionEstateId`); a partial injection (missing either) records
+   *  nothing — the route stays the no-store Option A path. */
+  admittedAssertionLedger?: AdmittedAssertionLedger;
+  /** Synthetic tenant id the spike records under when a ledger is injected. The
+   *  spike request body carries NO tenant/estate/candidate ids, so the tenant is
+   *  a fixed synthetic dev constant (never request-derived). The ledger binds
+   *  every access to BOTH this tenant and the estate below; this is a SPIKE
+   *  isolation constant, NOT the final production tenant-binding semantics
+   *  (Phase 33P §12 — those stay unresolved). */
+  admittedAssertionTenantId?: string;
+  /** Synthetic estate id the spike records into when a ledger is injected. The
+   *  spike request body carries NO tenant/estate/candidate ids, so the estate is
+   *  a fixed synthetic dev constant (never request-derived). */
+  admittedAssertionEstateId?: string;
+}
+
+/** Fixed synthetic identity constants for the dev-only ledger seam. These are
+ *  short synthetic labels — never request-derived, never UUID/long-opaque. The
+ *  spike body carries only `spike` + `transition_intent`, so the transition is
+ *  built from these constants alone; no request-controlled material is placed in
+ *  it. The ledger ALSO validates every field to a bounded synthetic shape before
+ *  storing it, so this no-raw-payload property is enforced, not merely assumed
+ *  (Phase 33P §8 no-raw-payload; §11 no-leak). */
+const SYNTH_SOURCE_CANDIDATE_ID = 'cand-synthetic-dev';
+const SYNTH_ADMIT_TRANSITION_ID = 'txn-admit-synthetic-dev';
+const SYNTH_ADMITTED_ASSERTION_ID = 'assn-active-synthetic-dev';
+const SYNTH_SUPERSEDE_TRANSITION_ID = 'txn-supersede-synthetic-dev';
+const SYNTH_CORRECTED_ASSERTION_ID = 'assn-corrected-synthetic-dev';
+const SYNTH_ASSERTION_CLASS = 'preference';
+
+/**
+ * Derive a SYNTHETIC admission transition from a classified scenario plus fixed
+ * synthetic constants — NEVER from request-controlled material (the spike body
+ * carries only `spike` + `transition_intent`). Returns null for any scenario
+ * that mints no admitted assertion (pending / reject / malformed), so the route
+ * only touches the ledger for `accept` and `supersede` (Phase 33P §9 cases 1–6).
+ *
+ * For `supersede` the transition references a prior synthetic active assertion
+ * (the one an earlier `accept` would have minted) so the ledger can repoint
+ * recall to the corrected active assertion while preserving the prior's
+ * audit/provenance.
+ */
+function synthTransitionFor(
+  classification: AdmissionSpikeClassification,
+): SyntheticAdmissionTransition | null {
+  switch (classification.scenario) {
+    case 'accept':
+      return {
+        kind: 'admit',
+        source_candidate_id: SYNTH_SOURCE_CANDIDATE_ID,
+        admission_transition_id: SYNTH_ADMIT_TRANSITION_ID,
+        admitted_assertion_id: SYNTH_ADMITTED_ASSERTION_ID,
+        assertion_class: SYNTH_ASSERTION_CLASS,
+        replay_key: `admit:${SYNTH_SOURCE_CANDIDATE_ID}`,
+      };
+    case 'supersede':
+      return {
+        kind: 'supersede',
+        source_candidate_id: SYNTH_SOURCE_CANDIDATE_ID,
+        admission_transition_id: SYNTH_SUPERSEDE_TRANSITION_ID,
+        admitted_assertion_id: SYNTH_CORRECTED_ASSERTION_ID,
+        assertion_class: SYNTH_ASSERTION_CLASS,
+        replay_key: `supersede:${SYNTH_SOURCE_CANDIDATE_ID}`,
+        supersedes_assertion_id: SYNTH_ADMITTED_ASSERTION_ID,
+      };
+    case 'pending':
+    case 'reject':
+    case 'malformed':
+    default:
+      return null;
+  }
 }
 
 /** Stable public-safe refusal body for the disabled gate. Leaks nothing. */
@@ -247,13 +332,37 @@ export function createAdmissionIntakeRoutes(deps: AdmissionSpikeRouteDeps): Hono
       return sendPublicResponse(c, 400, failClosedRefusalBody(), requestId, refused);
     }
 
-    // (4) Partial-failure posture (Phase 33M §13.1). Any internal partial
-    // failure during finalization fails closed: under Option A there is NO
-    // durable state to roll back, NO recallable assertion is created, and NO
-    // duplicate/partially-admitted residue can exist. The response collapses
-    // to the stable public-safe refusal.
+    // (4) Partial-failure posture (Phase 33M §13.1; Phase 33Q ledger seam). Any
+    // internal partial failure during finalization fails closed. With NO ledger
+    // injected (the production/server default) this is the Phase 33N Option A
+    // path verbatim: nothing durable to roll back, no recallable assertion, no
+    // duplicate/partially-admitted residue. With the OPTIONAL dev-only synthetic
+    // ledger injected (tests only), an accept/supersede records into the
+    // bounded, process-local, NON-DURABLE ledger here — inside the SAME guarded
+    // try, so a ledger throw (capacity / scope / replay-conflict) collapses to
+    // the identical stable public-safe refusal and the bounded ledger is left
+    // exactly as it was (atomic; no partially-admitted / recallable residue —
+    // Phase 33P §9 case-8). The ledger result is intentionally discarded: it is
+    // NEVER surfaced in the public body, which stays the deterministic
+    // public-safe response built in step (5).
     try {
       deps.beforeFinalize?.(classification);
+      if (
+        deps.admittedAssertionLedger &&
+        deps.admittedAssertionTenantId &&
+        deps.admittedAssertionEstateId
+      ) {
+        const transition = synthTransitionFor(classification);
+        if (transition) {
+          deps.admittedAssertionLedger.record(
+            {
+              tenant_id: deps.admittedAssertionTenantId,
+              estate_id: deps.admittedAssertionEstateId,
+            },
+            transition,
+          );
+        }
+      }
     } catch {
       return sendPublicResponse(c, 400, failClosedRefusalBody(), requestId, refused);
     }

--- a/app/src/services/admission-wedge-spike/admitted-assertion-ledger.ts
+++ b/app/src/services/admission-wedge-spike/admitted-assertion-ledger.ts
@@ -1,0 +1,1049 @@
+// Phase 33Q — dev/operator-only Admission Wedge: bounded, process-local,
+// SYNTHETIC admitted-assertion ledger.
+//
+// Authorized NARROWLY by the Phase 33P storage/receipt hardening decision gate
+// (docs/ADMISSION-WEDGE-STORAGE-RECEIPT-HARDENING-GATE.md §7–§12), which selected
+// Option B: a dev-only, disabled-by-default, NON-PRODUCTION, bounded SYNTHETIC
+// admitted-assertion store, and explicitly REJECTED production-like durable
+// storage (Option D).
+//
+// This module is an in-process, capacity-bounded, tenant+estate-scoped,
+// NON-DURABLE, fail-closed instrument for proving the candidate →
+// admitted-assertion → recall transition's STATEFUL effect against SYNTHETIC,
+// VALIDATED material only. Its safety is SPIKE-SCOPED and validation-enforced —
+// it is NOT a production-safety guarantee. It:
+//   * accepts only SYNTHETIC, bounded-label identity/status/provenance/
+//     receipt-like-audit references that are validated BEFORE any mutation. The
+//     validation rejects (fail closed) anything that is not a narrow synthetic
+//     label — whitespace, uppercase, or free-form-punctuated values (which is
+//     the shape real raw payloads / source material / raw reasons take), plus
+//     over-long values, payload-shaped EXTRA fields, and a named unsafe-marker /
+//     payload-shaped substring denylist (`unsafe_marker`, `candidate_payload`,
+//     `source_material`, `raw_reason`, …). It does NOT claim to recognize every
+//     conceivable raw string: a deliberately snake-cased short token off the
+//     denylist would pass the shape check. This is sufficient here because the
+//     ONLY caller (the route) builds transitions from fixed synthetic constants,
+//     never request material (33P §8); the validation is a defense-in-depth
+//     floor, not an exhaustive raw-material classifier;
+//   * opens NO database connection, NO file handle, NO socket, NO timer, and runs
+//     NO background task — its entire state is JS Maps captured in a factory
+//     closure, so a process restart leaves NO durable admitted-assertion residue;
+//   * performs NO durable write and NO migration of any kind;
+//   * is bound to a (tenant_id, estate_id) pair on every access: one tenant's
+//     synthetic estate is structurally unreachable from another tenant, and an
+//     estate_id can be owned by exactly one tenant for the life of the process.
+//
+// PRECEDENT, NOT REUSE. This mirrors ONLY the OPERATIONAL PROPERTIES of the
+// Recall-path bounded estate store (process-local, capacity-bounded,
+// tenant-scoped, non-durable, fail-closed, testable without production storage —
+// 33P §6). It reuses NO Recall code, type, adapter, or schema, imports NOTHING
+// from `straylight-recall-intake/`, and inherits NO Recall semantics. The
+// identity / status / provenance / receipt semantics here remain governed by the
+// still-unresolved Straylight primitive review (A–O); this ledger freezes NO
+// schema and decides NO final idempotency / signer / authority / tenant-estate-
+// actor binding semantics (33P §8, §12). The tenant+estate binding here is a
+// SPIKE isolation mechanism, NOT the final production binding semantics.
+//
+// Filename note: this file is deliberately named `*-ledger.ts`, NOT `*-store.ts`.
+// The Phase 33N scope guards reject any spike-path import specifier matching
+// `/-store(.js)?$/` as a forbidden production-storage import; a `-ledger` name
+// stays inside the authorized envelope without weakening that guard.
+
+/** Per-estate capacity bounds. Inserts beyond either dimension fail closed by
+ *  throwing — the ledger never grows unbounded and never evicts existing
+ *  synthetic state (bounded REJECTION, 33P §9 case-8 capacity bullet).
+ *
+ *  Both bounds are validated at ledger creation (see `validateCapConfig`): each
+ *  must be a finite, positive INTEGER within a dev/test ceiling. `Infinity`,
+ *  `NaN`, zero, negative, fractional, and non-number values are rejected, so the
+ *  ledger cannot be configured to grow unbounded. */
+export interface AdmittedAssertionLedgerConfig {
+  /** Max synthetic admitted assertions per estate. */
+  maxAssertionsPerEstate: number;
+  /** Max JSON byte budget of synthetic records per estate. This budget accounts
+   *  for ALL retained synthetic metadata — assertions, audit records, AND the
+   *  retained replay-de-dup metadata (replay keys + fingerprints). */
+  maxAssertionBytesPerEstate: number;
+}
+
+/** A (tenant_id, estate_id) scope. EVERY read and write is bound to a scope: an
+ *  estate is reachable ONLY by the tenant that owns it. Both ids must be bounded
+ *  synthetic labels (validated before use). */
+export interface AdmittedScope {
+  tenant_id: string;
+  estate_id: string;
+}
+
+/**
+ * A SYNTHETIC admitted-assertion record. Carries synthetic identity / status /
+ * provenance references ONLY. There is no field NAMED for a raw payload, AND
+ * every string written here is validated to a bounded synthetic-label shape
+ * before mutation, so a raw candidate payload, source material, or raw reason is
+ * rejected (not merely undeclared) (33P §8 no-raw-payload prohibition; §9 case-8
+ * final bullet: identity/status/provenance observable WITHOUT raw payload
+ * persistence).
+ *
+ * `assertion_status` is canonical-aligned: `active` (or `superseded`), NEVER a
+ * coined `admitted` status (33P §9.1 / probe note: admission is the canonical
+ * `admit_assertion` transition; the resulting STATUS is canonical `active`).
+ */
+export interface SyntheticAdmittedAssertion {
+  // Readonly at the type level: internal assertion records are never mutated in
+  // place (a supersession replaces the map entry with a fresh object) and are
+  // never handed out as live references (Codex blocker 3).
+  readonly admitted_assertion_id: string;
+  readonly tenant_id: string;
+  readonly estate_id: string;
+  readonly source_candidate_id: string;
+  readonly admission_transition_id: string;
+  readonly assertion_class: string;
+  readonly assertion_status: 'active' | 'superseded';
+  readonly recall_eligible: boolean;
+  /** Set on the corrected assertion of a supersession; points at the prior. */
+  readonly supersedes_assertion_id?: string;
+  /** Set on the prior assertion once superseded; points at the corrected. */
+  readonly superseded_by_assertion_id?: string;
+  /** Private synthetic receipt-like reference (short label, never public). */
+  readonly receipt_ref: string;
+}
+
+/**
+ * A SYNTHETIC, explicitly NON-FINAL audit record. It EXPLAINS what synthetic
+ * transition occurred without claiming to be — or becoming — a production
+ * receipt (33P §9 case 9, §10). Both privacy markers are carried so the
+ * public/private split (33K §6.6/§6.7) is provable: `audit_private: true` AND
+ * `public_audit_detail: false`. This record is NEVER serialized to a public
+ * response, and (because every accepted field is validated synthetic) it can
+ * never carry a raw payload or unsafe marker.
+ */
+export interface SyntheticAuditRecord {
+  // All fields are readonly: an audit record returned by `auditTrail()` is a
+  // detached, frozen copy, and readonly at the type level reflects (and helps
+  // enforce) that callers must not mutate it (Codex blocker 3).
+  readonly audit_event: 'assertion_admitted' | 'assertion_superseded';
+  readonly admission_transition_id: string;
+  readonly source_candidate_id: string;
+  readonly admitted_assertion_id: string;
+  readonly receipt_ref: string;
+  readonly audit_private: true;
+  readonly public_audit_detail: false;
+}
+
+/**
+ * The SYNTHETIC transition the route derives from a classified scenario and
+ * fixed synthetic constants — NEVER from request-controlled material (the spike
+ * request body carries only `spike` + `transition_intent`). It carries NO
+ * candidate payload. Every string field is validated to a bounded synthetic
+ * label before any mutation; payload-shaped EXTRA fields are rejected.
+ */
+export interface SyntheticAdmissionTransition {
+  /** `admit` mints one active assertion; `supersede` corrects a prior one. */
+  kind: 'admit' | 'supersede';
+  source_candidate_id: string;
+  admission_transition_id: string;
+  /** The synthetic id to mint as the (corrected) active assertion. */
+  admitted_assertion_id: string;
+  assertion_class: string;
+  /** Spike-scoped de-duplication key. Synthetic; NOT request-derived; bounded in
+   *  length and shape (validated before use), and ACCOUNTED for in the per-estate
+   *  byte budget. Final production idempotency semantics remain UNRESOLVED
+   *  (33P §12). */
+  replay_key: string;
+  /** Required for `supersede`: the prior assertion this transition corrects. */
+  supersedes_assertion_id?: string;
+}
+
+/** Outcome of a `record` call. `replayed` means a prior idempotent result was
+ *  returned and NO second assertion was minted (33P §9 case-8 replay bullet). */
+export interface RecordOutcome {
+  outcome: 'recorded' | 'replayed';
+  admitted_assertion_id: string;
+  assertion_status: 'active';
+  superseded_assertion_id?: string;
+}
+
+/** Read-only, estate-scoped footprint snapshot (synthetic counts only). The
+ *  returned value is a freshly-built, frozen object (Codex blocker 3). */
+export interface EstateFootprint {
+  readonly assertions: number;
+  readonly bytes: number;
+}
+
+/** Internal recall-eligibility projection over the estate's synthetic state.
+ *  `includes` are ordinarily-recallable active assertion ids; `excludes` are
+ *  superseded (audit/provenance-only) ids. This is an INTERNAL observability
+ *  surface — it is NEVER placed in a public response (the public
+ *  `recall_projection` is built separately, from fixed placeholders). */
+export interface RecallProjection {
+  // Freshly-built, frozen arrays of synthetic ids — never internal references
+  // (Codex blocker 3).
+  readonly includes: readonly string[];
+  readonly excludes: readonly string[];
+}
+
+/** A view bound to ONE (tenant, estate) pair at construction. It can only
+ *  observe (and record into) its own tenant's estate — it cannot reach another
+ *  tenant's or another estate's synthetic state. */
+export interface ScopedAdmittedView {
+  readonly tenant_id: string;
+  readonly estate_id: string;
+  record(transition: SyntheticAdmissionTransition): RecordOutcome;
+  projectRecall(): RecallProjection;
+  inspectEstate(): EstateFootprint;
+  auditTrail(): readonly SyntheticAuditRecord[];
+}
+
+export interface AdmittedAssertionLedger {
+  /** Establish a synthetic estate slot owned by a tenant. Idempotent for the
+   *  SAME (tenant, estate) pair (never destroys synthetic state). Re-seeding the
+   *  same estate_id under a DIFFERENT tenant_id fails closed
+   *  (`AdmittedAssertionTenantConflictError`) — an estate cannot be silently
+   *  re-homed to another tenant. */
+  seedEstate(scope: AdmittedScope): void;
+  /** Record a synthetic admit/supersede transition into a seeded estate owned by
+   *  the scope's tenant. Validates the transition (exact keys, bounded synthetic
+   *  labels, no unsafe markers / payload-shaped fields) BEFORE any mutation, then
+   *  fails closed (throws) on unseeded/foreign estate, capacity overflow,
+   *  missing/invalid prior, or conflicting replay. Idempotent on a matching
+   *  replay key. */
+  record(scope: AdmittedScope, transition: SyntheticAdmissionTransition): RecordOutcome;
+  /** Tenant+estate-scoped view bound at construction time. */
+  forEstate(scope: AdmittedScope): ScopedAdmittedView;
+  /** Internal recall-eligibility projection for a tenant's seeded estate (empty
+   *  for an unseeded estate OR a foreign tenant — reads fail closed without
+   *  throwing). */
+  projectRecall(scope: AdmittedScope): RecallProjection;
+  /** Per-estate synthetic footprint for the owning tenant (zeros for an
+   *  unseeded estate or a foreign tenant). */
+  inspectEstate(scope: AdmittedScope): EstateFootprint;
+  /** Private synthetic audit trail for a tenant's seeded estate (empty for an
+   *  unseeded estate or a foreign tenant). */
+  auditTrail(scope: AdmittedScope): readonly SyntheticAuditRecord[];
+}
+
+/** Thrown when a per-estate capacity bound would be exceeded. Carries only
+ *  short synthetic fields — NO long opaque id, UUID, or payload — so the message
+ *  stays public-safe even if it were ever surfaced. */
+export class AdmittedAssertionCapExceededError extends Error {
+  readonly estate_id: string;
+  readonly dimension: 'assertion_count' | 'byte_budget';
+  readonly cap: number;
+  readonly observed: number;
+  constructor(opts: {
+    estate_id: string;
+    dimension: 'assertion_count' | 'byte_budget';
+    cap: number;
+    observed: number;
+  }) {
+    super(`admitted-assertion ledger capacity exceeded [${opts.dimension}]`);
+    this.name = 'AdmittedAssertionCapExceededError';
+    this.estate_id = opts.estate_id;
+    this.dimension = opts.dimension;
+    this.cap = opts.cap;
+    this.observed = opts.observed;
+  }
+}
+
+/** Thrown when a write targets an estate that is not in the caller's scope: an
+ *  unseeded estate, an estate owned by a DIFFERENT tenant (foreign_tenant), or a
+ *  supersession whose prior assertion is not in the target estate (one estate
+ *  cannot reach into another's synthetic state). */
+export class AdmittedAssertionScopeViolationError extends Error {
+  readonly estate_id: string;
+  readonly reason: 'unseeded_estate' | 'prior_not_in_estate' | 'foreign_tenant';
+  constructor(opts: {
+    estate_id: string;
+    reason: 'unseeded_estate' | 'prior_not_in_estate' | 'foreign_tenant';
+  }) {
+    super(`admitted-assertion ledger scope violation [${opts.reason}]`);
+    this.name = 'AdmittedAssertionScopeViolationError';
+    this.estate_id = opts.estate_id;
+    this.reason = opts.reason;
+  }
+}
+
+/** Thrown when a replay CONFLICTS with prior synthetic state: a reused replay
+ *  key with different synthetic content, a synthetic id collision, or a
+ *  supersession of an already-superseded prior. The ledger fails closed rather
+ *  than overwrite, fork, or corrupt existing synthetic state (33P §9 case-8
+ *  conflicting-replay bullet). */
+export class AdmittedAssertionReplayConflictError extends Error {
+  readonly estate_id: string;
+  readonly reason: 'replay_key_content_mismatch' | 'assertion_id_collision' | 'prior_not_active';
+  constructor(opts: {
+    estate_id: string;
+    reason: 'replay_key_content_mismatch' | 'assertion_id_collision' | 'prior_not_active';
+  }) {
+    super(`admitted-assertion ledger replay conflict [${opts.reason}]`);
+    this.name = 'AdmittedAssertionReplayConflictError';
+    this.estate_id = opts.estate_id;
+    this.reason = opts.reason;
+  }
+}
+
+/** Thrown at ledger CREATION when a capacity bound is not a finite positive
+ *  integer within the dev/test ceiling. Rejects `Infinity`, `NaN`, zero,
+ *  negative, fractional, non-number, and out-of-range values. Carries only the
+ *  config field name and a short reason — never a payload. */
+export class AdmittedAssertionInvalidConfigError extends Error {
+  readonly field: 'maxAssertionsPerEstate' | 'maxAssertionBytesPerEstate';
+  readonly reason:
+    | 'not_a_number'
+    | 'not_finite'
+    | 'not_integer'
+    | 'not_positive'
+    | 'exceeds_dev_ceiling';
+  constructor(opts: {
+    field: 'maxAssertionsPerEstate' | 'maxAssertionBytesPerEstate';
+    reason:
+      | 'not_a_number'
+      | 'not_finite'
+      | 'not_integer'
+      | 'not_positive'
+      | 'exceeds_dev_ceiling';
+  }) {
+    super(`admitted-assertion ledger invalid config [${opts.reason}]`);
+    this.name = 'AdmittedAssertionInvalidConfigError';
+    this.field = opts.field;
+    this.reason = opts.reason;
+  }
+}
+
+/** Thrown BEFORE any mutation when a scope or transition carries non-synthetic
+ *  material: a non-string/empty/over-long field, an out-of-shape (non-bounded-
+ *  synthetic-label) value, a payload-shaped EXTRA field, an unsafe marker /
+ *  raw-material substring, or an invalid transition kind. The error carries a
+ *  fixed (safe) field token and a short reason — it NEVER echoes the rejected
+ *  value, so a rejected unsafe transition leaves zero residue (no ledger / audit
+ *  / recall / error-message trace of the raw material). */
+export class AdmittedAssertionInvalidInputError extends Error {
+  readonly field: string;
+  readonly reason:
+    | 'not_an_object'
+    | 'invalid_kind'
+    | 'extra_field'
+    | 'not_a_string'
+    | 'empty'
+    | 'too_long'
+    | 'invalid_format'
+    | 'unsafe_value';
+  constructor(opts: {
+    field: string;
+    reason:
+      | 'not_an_object'
+      | 'invalid_kind'
+      | 'extra_field'
+      | 'not_a_string'
+      | 'empty'
+      | 'too_long'
+      | 'invalid_format'
+      | 'unsafe_value';
+  }) {
+    super(`admitted-assertion ledger invalid input [${opts.reason}]`);
+    this.name = 'AdmittedAssertionInvalidInputError';
+    this.field = opts.field;
+    this.reason = opts.reason;
+  }
+}
+
+/** Thrown by `seedEstate` when an estate_id already owned by one tenant is
+ *  re-seeded under a DIFFERENT tenant. Prevents an estate being silently
+ *  re-homed across tenants (Codex blocker 1). */
+export class AdmittedAssertionTenantConflictError extends Error {
+  readonly estate_id: string;
+  constructor(opts: { estate_id: string }) {
+    super('admitted-assertion ledger tenant conflict [estate_owned_by_other_tenant]');
+    this.name = 'AdmittedAssertionTenantConflictError';
+    this.estate_id = opts.estate_id;
+  }
+}
+
+interface EstateSlot {
+  tenant_id: string;
+  estate_id: string;
+  assertions: Map<string, SyntheticAdmittedAssertion>;
+  audit: SyntheticAuditRecord[];
+  /** replay_key → { assertion_id, fingerprint } for spike-scoped de-dup. Both
+   *  the keys and the values are accounted for in `bytes` (see below). */
+  replays: Map<string, { admitted_assertion_id: string; fingerprint: string }>;
+  bytes: number;
+}
+
+// ── Bounded synthetic-label discipline (Codex blocker 3) ──────────────────────
+
+/** Max length for any externally supplied string-like field. Bounds the replay
+ *  key and every identity/provenance label so a 1 MB key (or any over-long
+ *  value) is rejected before it can be retained or accounted (Codex blocker 2). */
+const MAX_FIELD_LEN = 128;
+
+/** Identity/provenance label shape: lowercase snake/kebab plus digits. Narrow
+ *  and synthetic — deliberately excludes whitespace, uppercase, `:`, and any
+ *  punctuation that could carry raw/free-form material. Linear-time (no
+ *  backtracking). */
+const SYNTH_LABEL_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+/** Replay-key shape: as above, additionally allowing `:` so a synthetic replay
+ *  key composed of labels (e.g. `admit:cand-synth-1`) is accepted. Still narrow
+ *  and synthetic; still length-bounded. */
+const SYNTH_REPLAY_RE = /^[a-z0-9][a-z0-9_:-]*$/;
+
+/** Raw-material / unsafe-marker substrings rejected in EVERY accepted string
+ *  field (defense-in-depth, mirroring the no-leak intent WITHOUT importing the
+ *  no-leak module). These catch payload-shaped values that would otherwise slip
+ *  past the label shape (e.g. `candidate_payload` is all-lowercase-snake and
+ *  would match `SYNTH_LABEL_RE`), and unsafe markers in `replay_key` (where `:`
+ *  is allowed by shape). Checked case-insensitively. */
+const UNSAFE_FIELD_SUBSTRINGS = [
+  'unsafe_marker',
+  'candidate_payload',
+  'corrected_candidate_payload',
+  'source_material',
+  'source_ref',
+  'raw_candidate',
+  'raw_reason',
+  'policy_reason',
+  'sentinel',
+  'secret',
+  'token',
+];
+
+/** Dev/test ceilings — a config above these is rejected as not bounded for
+ *  dev/test use. Generous enough for every spike/test config, far below any
+ *  production scale. */
+const MAX_ASSERTIONS_CEILING = 100_000;
+const MAX_BYTES_CEILING = 10_000_000;
+
+/** Validate one externally supplied string-like field to a bounded synthetic
+ *  shape BEFORE any mutation. Order: type → emptiness → length (short-circuits
+ *  before scanning an over-long value) → unsafe-marker substring → label shape.
+ *  Throws `AdmittedAssertionInvalidInputError` (never echoing the value). */
+function assertSyntheticField(
+  value: unknown,
+  field: string,
+  kind: 'label' | 'replay',
+): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new AdmittedAssertionInvalidInputError({ field, reason: 'not_a_string' });
+  }
+  if (value.length === 0) {
+    throw new AdmittedAssertionInvalidInputError({ field, reason: 'empty' });
+  }
+  if (value.length > MAX_FIELD_LEN) {
+    throw new AdmittedAssertionInvalidInputError({ field, reason: 'too_long' });
+  }
+  const lower = value.toLowerCase();
+  for (const marker of UNSAFE_FIELD_SUBSTRINGS) {
+    if (lower.includes(marker)) {
+      throw new AdmittedAssertionInvalidInputError({ field, reason: 'unsafe_value' });
+    }
+  }
+  const re = kind === 'replay' ? SYNTH_REPLAY_RE : SYNTH_LABEL_RE;
+  if (!re.test(value)) {
+    throw new AdmittedAssertionInvalidInputError({ field, reason: 'invalid_format' });
+  }
+}
+
+/** The exact transition keys accepted for each kind. Any other key is a
+ *  payload-shaped EXTRA field and is rejected before mutation. */
+const ADMIT_TRANSITION_KEYS = new Set<string>([
+  'kind',
+  'source_candidate_id',
+  'admission_transition_id',
+  'admitted_assertion_id',
+  'assertion_class',
+  'replay_key',
+]);
+const SUPERSEDE_TRANSITION_KEYS = new Set<string>([
+  ...ADMIT_TRANSITION_KEYS,
+  'supersedes_assertion_id',
+]);
+
+/** True only for a PLAIN record: a direct object whose prototype is exactly
+ *  `Object.prototype` or `null`. Rejects arrays, class instances, `Date`, `Map`,
+ *  `Set`, `RegExp`, boxed primitives, and any object carrying a non-standard
+ *  prototype — so a `candidate_payload` (or any unexpected field) reachable only
+ *  through an inherited prototype is rejected outright, never read (Codex
+ *  blocker 4). */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Reflect.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/** Reject any own key (string OR symbol, enumerable OR not) that is not in the
+ *  allowed set. Uses `Reflect.ownKeys` — NOT `Object.keys` — so a non-enumerable
+ *  or symbol-keyed `candidate_payload` (or any payload-shaped extra field) is
+ *  caught and rejected before any mutation, leaving zero residue (Codex
+ *  blocker 4). Symbols are never an allowed key, so any symbol own key is an
+ *  extra field. The offending key is never echoed onto the error. */
+function assertExactOwnKeys(record: Record<string, unknown>, allowed: ReadonlySet<string>): void {
+  for (const key of Reflect.ownKeys(record)) {
+    if (typeof key === 'symbol' || !allowed.has(key)) {
+      throw new AdmittedAssertionInvalidInputError({ field: 'transition', reason: 'extra_field' });
+    }
+  }
+}
+
+/** Validate a transition's plain-record shape, EXACT own-key set (enumerable,
+ *  non-enumerable, AND symbol), kind, and every string field BEFORE any mutation
+ *  or replay lookup, then return a FROZEN, closure-owned SNAPSHOT built from the
+ *  values read exactly once during validation.
+ *
+ *  Returning a snapshot (rather than asserting over the caller's object) closes
+ *  two bypasses at once:
+ *    * non-plain / inherited / non-enumerable / symbol-keyed payload tricks are
+ *      rejected up front (Codex blocker 4); and
+ *    * downstream code (fingerprint, capacity, commit) reads ONLY this frozen
+ *      snapshot, so a caller-owned accessor getter cannot return one value at
+ *      validation and a different value at commit (TOCTOU). Pure (no state). */
+function validateTransition(transition: unknown): SyntheticAdmissionTransition {
+  if (!isPlainRecord(transition)) {
+    throw new AdmittedAssertionInvalidInputError({ field: 'transition', reason: 'not_an_object' });
+  }
+  // Read `kind` exactly once.
+  const kind = transition.kind;
+  if (kind !== 'admit' && kind !== 'supersede') {
+    throw new AdmittedAssertionInvalidInputError({ field: 'kind', reason: 'invalid_kind' });
+  }
+  const allowed = kind === 'supersede' ? SUPERSEDE_TRANSITION_KEYS : ADMIT_TRANSITION_KEYS;
+  assertExactOwnKeys(transition, allowed);
+
+  // Read every field exactly once, validate, then snapshot from the read value —
+  // never re-read the caller-owned object after this point.
+  const source_candidate_id = transition.source_candidate_id;
+  assertSyntheticField(source_candidate_id, 'source_candidate_id', 'label');
+  const admission_transition_id = transition.admission_transition_id;
+  assertSyntheticField(admission_transition_id, 'admission_transition_id', 'label');
+  const admitted_assertion_id = transition.admitted_assertion_id;
+  assertSyntheticField(admitted_assertion_id, 'admitted_assertion_id', 'label');
+  const assertion_class = transition.assertion_class;
+  assertSyntheticField(assertion_class, 'assertion_class', 'label');
+  const replay_key = transition.replay_key;
+  assertSyntheticField(replay_key, 'replay_key', 'replay');
+
+  if (kind === 'supersede') {
+    const supersedes_assertion_id = transition.supersedes_assertion_id;
+    assertSyntheticField(supersedes_assertion_id, 'supersedes_assertion_id', 'label');
+    return Object.freeze({
+      kind,
+      source_candidate_id,
+      admission_transition_id,
+      admitted_assertion_id,
+      assertion_class,
+      replay_key,
+      supersedes_assertion_id,
+    });
+  }
+  return Object.freeze({
+    kind,
+    source_candidate_id,
+    admission_transition_id,
+    admitted_assertion_id,
+    assertion_class,
+    replay_key,
+  });
+}
+
+/** A validated, frozen, closure-owned copy of the capacity limits. Once built at
+ *  ledger creation, these numbers are the ONLY caps the ledger ever reads — the
+ *  caller-owned config object is never read again, so mutating it (e.g. to
+ *  `Infinity`) after construction cannot widen a configured cap (Codex
+ *  blocker 2). */
+interface ValidatedCaps {
+  readonly maxAssertionsPerEstate: number;
+  readonly maxAssertionBytesPerEstate: number;
+}
+
+/** Validate the capacity config at ledger creation: each bound must be a finite,
+ *  positive INTEGER within the dev/test ceiling. Rejects Infinity, NaN, zero,
+ *  negative, fractional, non-number, and out-of-range values. Returns a FROZEN
+ *  copy of the validated numeric limits — the values are read exactly once here
+ *  and never re-read from the caller-owned config afterward (Codex blocker 2). */
+function validateCapConfig(config: AdmittedAssertionLedgerConfig): ValidatedCaps {
+  // Read each bound exactly once, into a local, before validating it — so even a
+  // caller-owned accessor getter is observed a single time and the validated
+  // value is the same one frozen into the closure-owned caps below.
+  const rawAssertions: unknown = config.maxAssertionsPerEstate;
+  const rawBytes: unknown = config.maxAssertionBytesPerEstate;
+  const checks: Array<[
+    'maxAssertionsPerEstate' | 'maxAssertionBytesPerEstate',
+    unknown,
+    number,
+  ]> = [
+    ['maxAssertionsPerEstate', rawAssertions, MAX_ASSERTIONS_CEILING],
+    ['maxAssertionBytesPerEstate', rawBytes, MAX_BYTES_CEILING],
+  ];
+  for (const [field, raw, ceiling] of checks) {
+    if (typeof raw !== 'number') {
+      throw new AdmittedAssertionInvalidConfigError({ field, reason: 'not_a_number' });
+    }
+    if (!Number.isFinite(raw)) {
+      // Catches Infinity, -Infinity, and NaN.
+      throw new AdmittedAssertionInvalidConfigError({ field, reason: 'not_finite' });
+    }
+    if (!Number.isInteger(raw)) {
+      throw new AdmittedAssertionInvalidConfigError({ field, reason: 'not_integer' });
+    }
+    if (raw <= 0) {
+      throw new AdmittedAssertionInvalidConfigError({ field, reason: 'not_positive' });
+    }
+    if (raw > ceiling) {
+      throw new AdmittedAssertionInvalidConfigError({ field, reason: 'exceeds_dev_ceiling' });
+    }
+  }
+  return Object.freeze({
+    maxAssertionsPerEstate: rawAssertions as number,
+    maxAssertionBytesPerEstate: rawBytes as number,
+  });
+}
+
+/** Local synthetic byte accounting. Reimplemented here on purpose — it does NOT
+ *  reuse any Recall byte-accounting helper (33P §8 no-code-reuse boundary). */
+function syntheticBytes(record: unknown): number {
+  return Buffer.byteLength(JSON.stringify(record) ?? '', 'utf8');
+}
+
+/** Stable content fingerprint over a transition's identity-defining synthetic
+ *  fields. Used to decide whether a reused replay key is an idempotent retry
+ *  (same fingerprint) or a conflict (different fingerprint). Bounded in length
+ *  because every input field is length-validated before this is computed. */
+function transitionFingerprint(t: SyntheticAdmissionTransition): string {
+  return [
+    t.kind,
+    t.source_candidate_id,
+    t.admission_transition_id,
+    t.admitted_assertion_id,
+    t.assertion_class,
+    t.supersedes_assertion_id ?? '',
+  ].join('|');
+}
+
+/** Byte footprint of one retained replay-de-dup entry: the replay key PLUS the
+ *  retained value (assertion id + fingerprint). Counting this closes the Codex
+ *  blocker-2 gap where a large replay key was retained but excluded from byte
+ *  accounting. */
+function replayEntryBytes(replay_key: string, admitted_assertion_id: string, fingerprint: string): number {
+  return syntheticBytes({ replay_key, admitted_assertion_id, fingerprint });
+}
+
+/** Validate a caller-owned scope and return a FROZEN, closure-owned SNAPSHOT of
+ *  the validated ids. Each id is read EXACTLY ONCE (into a local) before
+ *  validation, so a caller-owned accessor getter is observed a single time and
+ *  the value validated is the value frozen. Callers that retain this snapshot
+ *  (e.g. `forEstate`) are immune to later mutation of the original scope object:
+ *  mutating the caller's object after construction cannot re-home the binding to
+ *  a different tenant/estate (Codex blocker 1). */
+function snapshotScope(scope: AdmittedScope): AdmittedScope {
+  const tenant_id = scope.tenant_id;
+  assertSyntheticField(tenant_id, 'tenant_id', 'label');
+  const estate_id = scope.estate_id;
+  assertSyntheticField(estate_id, 'estate_id', 'label');
+  return Object.freeze({ tenant_id, estate_id });
+}
+
+/** Build a FROZEN, detached copy of one audit record. Every field is a primitive
+ *  (string / boolean literal), so a shallow copy fully detaches the result from
+ *  the internal record — a caller mutating the returned copy cannot reach the
+ *  ledger's own audit state (Codex blocker 3). */
+function detachAuditRecord(record: SyntheticAuditRecord): SyntheticAuditRecord {
+  return Object.freeze({
+    audit_event: record.audit_event,
+    admission_transition_id: record.admission_transition_id,
+    source_candidate_id: record.source_candidate_id,
+    admitted_assertion_id: record.admitted_assertion_id,
+    receipt_ref: record.receipt_ref,
+    audit_private: record.audit_private,
+    public_audit_detail: record.public_audit_detail,
+  });
+}
+
+/**
+ * Create a bounded, process-local, synthetic admitted-assertion ledger.
+ *
+ * The capacity config is validated immediately (see `validateCapConfig`), so an
+ * unbounded / malformed config fails closed at construction rather than at first
+ * write.
+ *
+ * All state lives in the Maps below, captured in this closure. There is no
+ * durable backend: a second `createAdmittedAssertionLedger(...)` call yields a
+ * fresh, empty ledger, which is exactly how "process restart leaves no durable
+ * admitted-assertion residue" is proven (33P §9 case-8 ephemerality/restart
+ * bullets).
+ */
+export function createAdmittedAssertionLedger(
+  config: AdmittedAssertionLedgerConfig,
+): AdmittedAssertionLedger {
+  // Validate once, then copy the validated numeric limits into a frozen,
+  // closure-owned constant. The caller-owned `config` object is NEVER read again
+  // after this line — mutating it afterward (e.g. setting either cap to
+  // `Infinity`) cannot change the bounds the ledger enforces (Codex blocker 2).
+  const caps = validateCapConfig(config);
+
+  /** Keyed by estate_id; each slot records the OWNING tenant_id. An estate_id is
+   *  owned by exactly one tenant for the life of the process (enforced in
+   *  `seedEstate`); every access checks the scope's tenant against the slot. */
+  const estates = new Map<string, EstateSlot>();
+
+  /**
+   * Resolve the slot the scope is entitled to. Validates both scope labels
+   * first (fail closed on malformed input). Then:
+   *   * unseeded estate → write throws `unseeded_estate`; read returns null
+   *     (caller maps null to an empty projection / zero footprint);
+   *   * estate owned by a DIFFERENT tenant → write throws `foreign_tenant`; read
+   *     returns null (a foreign tenant sees NOTHING — no cross-tenant read).
+   */
+  function resolveOwnedSlot(scope: AdmittedScope, forWrite: boolean): EstateSlot | null {
+    // Snapshot the validated scope ONCE, then read ONLY the snapshot below — a
+    // caller-owned accessor getter cannot return one tenant/estate at validation
+    // and a different one at lookup (TOCTOU; Codex blocker 1).
+    const { tenant_id, estate_id } = snapshotScope(scope);
+    const slot = estates.get(estate_id);
+    if (!slot) {
+      if (forWrite) {
+        throw new AdmittedAssertionScopeViolationError({
+          estate_id,
+          reason: 'unseeded_estate',
+        });
+      }
+      return null;
+    }
+    if (slot.tenant_id !== tenant_id) {
+      if (forWrite) {
+        throw new AdmittedAssertionScopeViolationError({
+          estate_id,
+          reason: 'foreign_tenant',
+        });
+      }
+      return null;
+    }
+    return slot;
+  }
+
+  function nextReceiptRef(slot: EstateSlot): string {
+    // Short, synthetic, per-estate sequence — never a UUID or long opaque run.
+    return `rcpt-priv-${slot.audit.length + 1}`;
+  }
+
+  function recordInternal(scope: AdmittedScope, rawTransition: unknown): RecordOutcome {
+    // (0) Validate the transition shape/markers BEFORE touching any state, so an
+    // unsafe / payload-shaped / over-long transition is rejected with zero
+    // ledger/audit/recall residue (Codex blocker 3, 4). validateTransition
+    // returns a FROZEN, closure-owned snapshot; every line below reads ONLY this
+    // snapshot, never the caller-owned object, so a caller accessor getter cannot
+    // return a safe value at validation and a different one at commit (TOCTOU).
+    const transition = validateTransition(rawTransition);
+
+    // (1) Resolve the tenant-owned, seeded slot (fail closed on foreign/unseeded).
+    const slot = resolveOwnedSlot(scope, /*forWrite*/ true)!;
+    const fingerprint = transitionFingerprint(transition);
+
+    // (2) Spike-scoped replay handling — BEFORE any mutation or capacity work.
+    const priorReplay = slot.replays.get(transition.replay_key);
+    if (priorReplay) {
+      if (priorReplay.fingerprint === fingerprint) {
+        // Idempotent retry: return the prior result, mint nothing new.
+        const existing = slot.assertions.get(priorReplay.admitted_assertion_id);
+        return {
+          outcome: 'replayed',
+          admitted_assertion_id: priorReplay.admitted_assertion_id,
+          assertion_status: 'active',
+          superseded_assertion_id: existing?.supersedes_assertion_id,
+        };
+      }
+      // Same key, different synthetic content → fail closed.
+      throw new AdmittedAssertionReplayConflictError({
+        estate_id: slot.estate_id,
+        reason: 'replay_key_content_mismatch',
+      });
+    }
+
+    if (transition.kind === 'admit') {
+      return applyAdmit(slot, transition, fingerprint);
+    }
+    return applySupersede(slot, transition, fingerprint);
+  }
+
+  function applyAdmit(
+    slot: EstateSlot,
+    transition: SyntheticAdmissionTransition,
+    fingerprint: string,
+  ): RecordOutcome {
+    if (slot.assertions.has(transition.admitted_assertion_id)) {
+      // A fresh replay key minting over an existing synthetic id is a conflict.
+      throw new AdmittedAssertionReplayConflictError({
+        estate_id: slot.estate_id,
+        reason: 'assertion_id_collision',
+      });
+    }
+
+    const receipt_ref = nextReceiptRef(slot);
+    // Internal records are frozen at creation (defense-in-depth, matching the
+    // readonly types) so internal state cannot be mutated in place. Reads still
+    // hand out detached copies (Codex blocker 3).
+    const assertion = Object.freeze<SyntheticAdmittedAssertion>({
+      admitted_assertion_id: transition.admitted_assertion_id,
+      tenant_id: slot.tenant_id,
+      estate_id: slot.estate_id,
+      source_candidate_id: transition.source_candidate_id,
+      admission_transition_id: transition.admission_transition_id,
+      assertion_class: transition.assertion_class,
+      assertion_status: 'active',
+      recall_eligible: true,
+      receipt_ref,
+    });
+    const auditRecord = Object.freeze<SyntheticAuditRecord>({
+      audit_event: 'assertion_admitted',
+      admission_transition_id: transition.admission_transition_id,
+      source_candidate_id: transition.source_candidate_id,
+      admitted_assertion_id: transition.admitted_assertion_id,
+      receipt_ref,
+      audit_private: true,
+      public_audit_detail: false,
+    });
+
+    // Capacity is checked against the FULLY-COMPUTED record — including the
+    // retained replay-de-dup metadata (key + fingerprint) — BEFORE any mutation,
+    // so an over-capacity write leaves the estate exactly as it was, and a large
+    // replay key counts against the budget (Codex blocker 2).
+    const replayBytes = replayEntryBytes(
+      transition.replay_key,
+      assertion.admitted_assertion_id,
+      fingerprint,
+    );
+    const byteDelta = syntheticBytes(assertion) + syntheticBytes(auditRecord) + replayBytes;
+    enforceCaps(slot, /*countDelta*/ 1, byteDelta);
+
+    // Atomic synchronous commit — no `await` between these mutations.
+    slot.assertions.set(assertion.admitted_assertion_id, assertion);
+    slot.audit.push(auditRecord);
+    slot.bytes += byteDelta;
+    slot.replays.set(transition.replay_key, {
+      admitted_assertion_id: assertion.admitted_assertion_id,
+      fingerprint,
+    });
+
+    return { outcome: 'recorded', admitted_assertion_id: assertion.admitted_assertion_id, assertion_status: 'active' };
+  }
+
+  function applySupersede(
+    slot: EstateSlot,
+    transition: SyntheticAdmissionTransition,
+    fingerprint: string,
+  ): RecordOutcome {
+    const priorId = transition.supersedes_assertion_id;
+    if (!priorId) {
+      // A supersession with no prior is invalid synthetic input → fail closed.
+      throw new AdmittedAssertionScopeViolationError({
+        estate_id: slot.estate_id,
+        reason: 'prior_not_in_estate',
+      });
+    }
+    const prior = slot.assertions.get(priorId);
+    if (!prior) {
+      // The prior is not in THIS estate — one estate cannot supersede another's.
+      throw new AdmittedAssertionScopeViolationError({
+        estate_id: slot.estate_id,
+        reason: 'prior_not_in_estate',
+      });
+    }
+    if (prior.assertion_status !== 'active') {
+      // Cannot supersede an already-superseded prior — fail closed.
+      throw new AdmittedAssertionReplayConflictError({
+        estate_id: slot.estate_id,
+        reason: 'prior_not_active',
+      });
+    }
+    if (slot.assertions.has(transition.admitted_assertion_id)) {
+      throw new AdmittedAssertionReplayConflictError({
+        estate_id: slot.estate_id,
+        reason: 'assertion_id_collision',
+      });
+    }
+
+    const receipt_ref = nextReceiptRef(slot);
+    // Internal records are frozen at creation (defense-in-depth, matching the
+    // readonly types). The prior is REPLACED with a fresh frozen object rather
+    // than mutated in place.
+    const corrected = Object.freeze<SyntheticAdmittedAssertion>({
+      admitted_assertion_id: transition.admitted_assertion_id,
+      tenant_id: slot.tenant_id,
+      estate_id: slot.estate_id,
+      source_candidate_id: transition.source_candidate_id,
+      admission_transition_id: transition.admission_transition_id,
+      assertion_class: transition.assertion_class,
+      assertion_status: 'active',
+      recall_eligible: true,
+      supersedes_assertion_id: priorId,
+      receipt_ref,
+    });
+    // The prior moves to canonical `superseded`, retained for audit/provenance,
+    // and dropped from ordinary recall.
+    const priorSuperseded = Object.freeze<SyntheticAdmittedAssertion>({
+      ...prior,
+      assertion_status: 'superseded',
+      recall_eligible: false,
+      superseded_by_assertion_id: corrected.admitted_assertion_id,
+    });
+    const auditRecord = Object.freeze<SyntheticAuditRecord>({
+      audit_event: 'assertion_superseded',
+      admission_transition_id: transition.admission_transition_id,
+      source_candidate_id: transition.source_candidate_id,
+      admitted_assertion_id: corrected.admitted_assertion_id,
+      receipt_ref,
+      audit_private: true,
+      public_audit_detail: false,
+    });
+
+    // Compute the net deltas for BOTH mutations — plus the retained replay-de-dup
+    // metadata — and check caps before either is applied, so a partial
+    // supersession can never be left half-committed and the replay key counts
+    // against the budget (Codex blocker 2).
+    const replayBytes = replayEntryBytes(
+      transition.replay_key,
+      corrected.admitted_assertion_id,
+      fingerprint,
+    );
+    const countDelta = 1; // one new corrected assertion; the prior stays counted
+    const byteDelta =
+      syntheticBytes(corrected) +
+      syntheticBytes(auditRecord) +
+      replayBytes +
+      (syntheticBytes(priorSuperseded) - syntheticBytes(prior));
+    enforceCaps(slot, countDelta, byteDelta);
+
+    // Atomic synchronous commit of both mutations.
+    slot.assertions.set(priorSuperseded.admitted_assertion_id, priorSuperseded);
+    slot.assertions.set(corrected.admitted_assertion_id, corrected);
+    slot.audit.push(auditRecord);
+    slot.bytes += byteDelta;
+    slot.replays.set(transition.replay_key, {
+      admitted_assertion_id: corrected.admitted_assertion_id,
+      fingerprint,
+    });
+
+    return {
+      outcome: 'recorded',
+      admitted_assertion_id: corrected.admitted_assertion_id,
+      assertion_status: 'active',
+      superseded_assertion_id: priorSuperseded.admitted_assertion_id,
+    };
+  }
+
+  function enforceCaps(slot: EstateSlot, countDelta: number, byteDelta: number): void {
+    // Reads ONLY the frozen, closure-owned `caps` — never the caller-owned config
+    // object — so a post-construction config mutation cannot widen a cap.
+    const projectedCount = slot.assertions.size + countDelta;
+    if (projectedCount > caps.maxAssertionsPerEstate) {
+      throw new AdmittedAssertionCapExceededError({
+        estate_id: slot.estate_id,
+        dimension: 'assertion_count',
+        cap: caps.maxAssertionsPerEstate,
+        observed: projectedCount,
+      });
+    }
+    const projectedBytes = slot.bytes + byteDelta;
+    if (projectedBytes > caps.maxAssertionBytesPerEstate) {
+      throw new AdmittedAssertionCapExceededError({
+        estate_id: slot.estate_id,
+        dimension: 'byte_budget',
+        cap: caps.maxAssertionBytesPerEstate,
+        observed: projectedBytes,
+      });
+    }
+  }
+
+  function projectRecallInternal(scope: AdmittedScope): RecallProjection {
+    const slot = resolveOwnedSlot(scope, /*forWrite*/ false);
+    if (!slot) return Object.freeze({ includes: Object.freeze([]), excludes: Object.freeze([]) });
+    const includes: string[] = [];
+    const excludes: string[] = [];
+    for (const a of slot.assertions.values()) {
+      if (a.assertion_status === 'active' && a.recall_eligible) {
+        includes.push(a.admitted_assertion_id);
+      } else {
+        excludes.push(a.admitted_assertion_id);
+      }
+    }
+    // Freshly-built arrays of primitive string ids — frozen so a caller cannot
+    // mutate the returned projection (and could never reach internal state
+    // through it anyway, since the ids are primitives, not references). (Codex
+    // blocker 3.)
+    return Object.freeze({ includes: Object.freeze(includes), excludes: Object.freeze(excludes) });
+  }
+
+  function footprint(scope: AdmittedScope): EstateFootprint {
+    const slot = resolveOwnedSlot(scope, /*forWrite*/ false);
+    if (!slot) return Object.freeze({ assertions: 0, bytes: 0 });
+    // Freshly-built, frozen snapshot of primitive counts — never a live
+    // reference to slot internals (Codex blocker 3).
+    return Object.freeze({ assertions: slot.assertions.size, bytes: slot.bytes });
+  }
+
+  function auditFor(scope: AdmittedScope): readonly SyntheticAuditRecord[] {
+    const slot = resolveOwnedSlot(scope, /*forWrite*/ false);
+    if (!slot) return Object.freeze([]);
+    // Detach: map each internal record to a FROZEN shallow copy, then freeze the
+    // outer array. The caller receives copies — mutating a returned record (or
+    // the array) cannot reach the internal audit records, so an externally
+    // mutated `unsafe_marker`, `audit_private`, or `public_audit_detail` never
+    // persists internally (Codex blocker 3). The internal records are themselves
+    // frozen at creation as defense-in-depth.
+    return Object.freeze(slot.audit.map(detachAuditRecord));
+  }
+
+  return {
+    seedEstate(scope) {
+      // Snapshot the validated scope ONCE into closure-owned ids; read only the
+      // snapshot below.
+      const { tenant_id, estate_id } = snapshotScope(scope);
+      const existing = estates.get(estate_id);
+      if (existing) {
+        if (existing.tenant_id !== tenant_id) {
+          // Re-seeding an estate under a different tenant fails closed — an
+          // estate cannot be silently re-homed across tenants (Codex blocker 1).
+          throw new AdmittedAssertionTenantConflictError({ estate_id });
+        }
+        return; // idempotent for the same (tenant, estate): never destroys state
+      }
+      estates.set(estate_id, {
+        tenant_id,
+        estate_id,
+        assertions: new Map(),
+        audit: [],
+        replays: new Map(),
+        bytes: 0,
+      });
+    },
+    record(scope, transition) {
+      return recordInternal(scope, transition);
+    },
+    forEstate(scope) {
+      // Validate the binding scope eagerly AND snapshot it into a FROZEN,
+      // closure-owned object. EVERY view method below closes over `bound` — never
+      // the caller-owned `scope` — so mutating the original scope object AFTER
+      // this call cannot re-home the view to a different tenant/estate. The view
+      // reads and writes ONLY the (tenant, estate) it was constructed for (Codex
+      // blocker 1).
+      const bound = snapshotScope(scope);
+      return {
+        tenant_id: bound.tenant_id,
+        estate_id: bound.estate_id,
+        record: (transition) => recordInternal(bound, transition),
+        projectRecall: () => projectRecallInternal(bound),
+        inspectEstate: () => footprint(bound),
+        auditTrail: () => auditFor(bound),
+      };
+    },
+    projectRecall(scope) {
+      return projectRecallInternal(scope);
+    },
+    inspectEstate(scope) {
+      return footprint(scope);
+    },
+    auditTrail(scope) {
+      return auditFor(scope);
+    },
+  };
+}

--- a/app/src/services/admission-wedge-spike/index.ts
+++ b/app/src/services/admission-wedge-spike/index.ts
@@ -39,3 +39,34 @@ export {
   type AdmissionSpikeGateConfig,
   type AdmissionSpikeCredentials,
 } from './auth-gate.js';
+
+// Phase 33Q — bounded, process-local, SYNTHETIC admitted-assertion ledger
+// (dev-only, disabled-by-default, NON-PRODUCTION; authorized by Phase 33P §7–§12).
+// This stays on the internal service barrel ONLY — it is NOT re-exported from
+// any package entrypoint (no `src/index.ts` re-export, no package `exports`),
+// exactly like the rest of the spike (Phase 33M §8 / 33P §8 no package export).
+//
+// The ledger's safety is SPIKE-SCOPED and validation-enforced — bounded
+// capacity (validated at creation), tenant+estate scoping, and synthetic-only
+// input validation. It is NOT a claim of complete production safety: final
+// tenant/estate/actor binding, idempotency, signer/authority, schema, receipt
+// semantics, and durable storage all remain UNRESOLVED (Phase 33P §8, §12).
+export {
+  createAdmittedAssertionLedger,
+  AdmittedAssertionCapExceededError,
+  AdmittedAssertionScopeViolationError,
+  AdmittedAssertionReplayConflictError,
+  AdmittedAssertionInvalidConfigError,
+  AdmittedAssertionInvalidInputError,
+  AdmittedAssertionTenantConflictError,
+  type AdmittedAssertionLedger,
+  type AdmittedAssertionLedgerConfig,
+  type AdmittedScope,
+  type ScopedAdmittedView,
+  type SyntheticAdmittedAssertion,
+  type SyntheticAuditRecord,
+  type SyntheticAdmissionTransition,
+  type RecordOutcome,
+  type EstateFootprint,
+  type RecallProjection,
+} from './admitted-assertion-ledger.js';

--- a/app/tests/integration/admission-intake/store-coupled.test.ts
+++ b/app/tests/integration/admission-intake/store-coupled.test.ts
@@ -1,0 +1,346 @@
+// Phase 33Q — integration proof that wiring the dev-only synthetic
+// admitted-assertion ledger into the route via the OPTIONAL DI seam:
+//   (a) leaves the public response byte-IDENTICAL to the Phase 33N no-store
+//       Option A path when no ledger is injected (production/server default);
+//   (b) records internally on accept/supersede but NEVER changes the public body
+//       and NEVER leaks ledger ids / private audit fields;
+//   (c) does not record for pending / reject / malformed;
+//   (d) fails closed to the stable public-safe refusal when the ledger throws,
+//       with no recallable residue.
+//
+// Authorized by the Phase 33P storage/receipt hardening decision gate
+// (docs/ADMISSION-WEDGE-STORAGE-RECEIPT-HARDENING-GATE.md §7–§12). The handler is
+// mounted directly (mirroring route-gate.test.ts), so this exercises the route
+// logic + the DI seam, not the global middleware stack. server.ts injects NO
+// ledger — the ledger here is a test-only injection.
+//
+// SCOPE BINDING (Codex blocker 1): the route is injected with BOTH a synthetic
+// tenant id and a synthetic estate id; the ledger binds every access to that
+// (tenant, estate) pair. Inspection in these tests uses the same scope.
+//
+// CONFLICT NOTE (Phase 33P §12): a genuine conflicting replay is NOT reachable
+// through the public route — the route always derives an IDENTICAL fixed
+// synthetic transition per scenario, so it can only ever produce an idempotent
+// replay, never a conflict. The conflicting-replay-fails-closed proof therefore
+// lives at the unit layer (admitted-assertion-ledger.test.ts). Here we prove the
+// route's fail-closed-on-throw behavior with a stub ledger whose record() throws.
+
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { createAdmissionIntakeRoutes } from '../../../src/routes/admission-intake.js';
+import {
+  ADMISSION_TRANSITION_INTENTS,
+  createAdmittedAssertionLedger,
+  findAdmissionPublicLeaks,
+  type AdmittedAssertionLedger,
+  type AdmittedScope,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+const TOKEN = 'dev-operator-token-synthetic-store-001';
+const OPERATOR = 'op-store-test';
+const SYNTH_ESTATE = 'estate-synthetic-dev';
+const SYNTH_TENANT = 'tenant-synthetic-dev';
+const SCOPE: AdmittedScope = { tenant_id: SYNTH_TENANT, estate_id: SYNTH_ESTATE };
+
+// The fixed synthetic ids the route mints (must match admission-intake.ts).
+const SYNTH_ADMITTED_ASSERTION_ID = 'assn-active-synthetic-dev';
+const SYNTH_CORRECTED_ASSERTION_ID = 'assn-corrected-synthetic-dev';
+const SYNTH_SOURCE_CANDIDATE_ID = 'cand-synthetic-dev';
+
+function authHeaders(extra?: Record<string, string>) {
+  return {
+    'content-type': 'application/json',
+    'x-admission-service-token': TOKEN,
+    'x-admission-operator-id': OPERATOR,
+    ...extra,
+  };
+}
+
+function spikeBody(transition_intent: string) {
+  return JSON.stringify({ spike: 'admission_intake_dev_spike_v0', transition_intent });
+}
+
+/** Build a route app. When `withLedger` is true, a real seeded ledger is
+ *  injected and returned for post-request inspection. */
+function buildApp(opts?: { withLedger?: boolean; ledger?: AdmittedAssertionLedger }) {
+  let ledger: AdmittedAssertionLedger | undefined;
+  if (opts?.ledger) {
+    ledger = opts.ledger;
+  } else if (opts?.withLedger) {
+    ledger = createAdmittedAssertionLedger({
+      maxAssertionsPerEstate: 100,
+      maxAssertionBytesPerEstate: 1_000_000,
+    });
+    ledger.seedEstate(SCOPE);
+  }
+  const app = new Hono();
+  app.route(
+    '/api/admission/intake',
+    createAdmissionIntakeRoutes({
+      enabled: true,
+      gate: { serviceToken: TOKEN, operatorIds: [OPERATOR] },
+      admittedAssertionLedger: ledger,
+      admittedAssertionTenantId: ledger ? SYNTH_TENANT : undefined,
+      admittedAssertionEstateId: ledger ? SYNTH_ESTATE : undefined,
+    }),
+  );
+  return { app, ledger };
+}
+
+async function post(app: Hono, intent: string, headers = authHeaders()) {
+  return app.request('/api/admission/intake', { method: 'POST', headers, body: spikeBody(intent) });
+}
+
+// ── (a) Default (no ledger) is byte-equivalent to Option A ────────────────────
+//
+// For scenarios whose ledger write SUCCEEDS, the public body is byte-identical
+// with and without the ledger seam. `supersede` requires a prior active
+// assertion to correct, so for that scenario BOTH apps are primed with a
+// preceding accept first (priming the stateless no-ledger app is harmless). The
+// distinct case of a STANDALONE supersede against an empty ledger (which
+// correctly fails closed) is proven separately below.
+
+describe('Phase 33Q route — ledger seam does not change the public body when the write succeeds', () => {
+  for (const [name, intent] of Object.entries(ADMISSION_TRANSITION_INTENTS)) {
+    it(`${name}: public response identical with and without the ledger seam`, async () => {
+      const { app: noLedger } = buildApp();
+      const { app: withLedger } = buildApp({ withLedger: true });
+
+      // Precondition: a supersede needs a prior active assertion in the estate.
+      if (name === 'supersede') {
+        await post(noLedger, ADMISSION_TRANSITION_INTENTS.accept);
+        await post(withLedger, ADMISSION_TRANSITION_INTENTS.accept);
+      }
+
+      const r1 = await post(noLedger, intent);
+      const r2 = await post(withLedger, intent);
+
+      expect(r1.status).toBe(r2.status);
+      const [t1, t2] = [await r1.text(), await r2.text()];
+      // The injected ledger must not change a single byte of the public body.
+      expect(t2).toBe(t1);
+      expect(findAdmissionPublicLeaks(JSON.parse(t2))).toEqual([]);
+    });
+  }
+
+  it('no-ledger is the production default: server.ts injects no ledger, behavior unchanged', async () => {
+    // The no-ledger app IS the Phase 33N Option A path verbatim — every scenario
+    // returns its deterministic public outcome with no leak.
+    const { app } = buildApp();
+    for (const intent of Object.values(ADMISSION_TRANSITION_INTENTS)) {
+      const res = await post(app, intent);
+      const body = JSON.parse(await res.text());
+      expect(body.spike).toBe('dev_operator_only_non_production');
+      expect(findAdmissionPublicLeaks(body)).toEqual([]);
+    }
+  });
+
+  it('a partial DI injection (ledger but no tenant id) records nothing — stays Option A', async () => {
+    // Defense-in-depth: with a ledger but a MISSING tenant id, the route must NOT
+    // attempt a ledger write (it needs the full synthetic scope), so behavior is
+    // the no-store Option A path and the ledger stays empty.
+    const ledger = createAdmittedAssertionLedger({
+      maxAssertionsPerEstate: 100,
+      maxAssertionBytesPerEstate: 1_000_000,
+    });
+    ledger.seedEstate(SCOPE);
+    const app = new Hono();
+    app.route(
+      '/api/admission/intake',
+      createAdmissionIntakeRoutes({
+        enabled: true,
+        gate: { serviceToken: TOKEN, operatorIds: [OPERATOR] },
+        admittedAssertionLedger: ledger,
+        // admittedAssertionTenantId intentionally omitted.
+        admittedAssertionEstateId: SYNTH_ESTATE,
+      }),
+    );
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    expect(res.status).toBe(200);
+    expect(ledger.inspectEstate(SCOPE).assertions).toBe(0);
+  });
+
+  it('a STANDALONE supersede against an empty ledger fails closed (referential integrity)', async () => {
+    // With the ledger injected but NO prior accept, the synthetic supersede has
+    // no active prior to correct → the ledger fails closed and the route returns
+    // the stable 400 refusal. This is correct, state-driven fail-closed behavior
+    // (NOT a public-schema change): the public body is still the standard refusal
+    // shape, leak-clean, and no synthetic assertion is left behind.
+    const { app, ledger } = buildApp({ withLedger: true });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.supersede);
+    expect(res.status).toBe(400);
+    const body = JSON.parse(await res.text());
+    expect(body.outcome_class).toBe('refused');
+    expect(body.safe_reason_code).toBe('ingress.invalid_request');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(0);
+  });
+});
+
+// ── (b) accept/supersede record internally; public body unchanged & leak-clean ─
+
+describe('Phase 33Q route — accept records internally, public body unchanged (§9.1, §11)', () => {
+  it('accept mints one active synthetic assertion in the ledger without leaking it', async () => {
+    const { app, ledger } = buildApp({ withLedger: true });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    const text = await res.text();
+    const body = JSON.parse(text);
+
+    expect(res.status).toBe(200);
+    expect(body.outcome_class).toBe('admitted');
+    expect(body.recall_eligible).toBe(true);
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+
+    // Internal effect: one active assertion recorded.
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(1);
+    expect(ledger!.projectRecall(SCOPE).includes).toEqual([SYNTH_ADMITTED_ASSERTION_ID]);
+
+    // The synthetic ledger ids / private audit fields NEVER appear on the wire.
+    expect(text).not.toContain(SYNTH_ADMITTED_ASSERTION_ID);
+    expect(text).not.toContain(SYNTH_SOURCE_CANDIDATE_ID);
+    expect(text).not.toContain('assertion_admitted');
+    expect(text).not.toContain('audit_private');
+    expect(text).not.toContain('rcpt-priv-');
+  });
+
+  it('supersede (after an accept) repoints recall to corrected active, prior preserved', async () => {
+    const { app, ledger } = buildApp({ withLedger: true });
+    await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.supersede);
+    const text = await res.text();
+    const body = JSON.parse(text);
+
+    expect(res.status).toBe(200);
+    expect(body.outcome_class).toBe('superseded_with_correction');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+
+    // Internal effect: corrected active recallable; prior superseded but kept.
+    expect(ledger!.projectRecall(SCOPE)).toEqual({
+      includes: [SYNTH_CORRECTED_ASSERTION_ID],
+      excludes: [SYNTH_ADMITTED_ASSERTION_ID],
+    });
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(2);
+
+    // No ledger id leaks on the wire.
+    expect(text).not.toContain(SYNTH_CORRECTED_ASSERTION_ID);
+    expect(text).not.toContain(SYNTH_ADMITTED_ASSERTION_ID);
+  });
+
+  it('replaying the same accept does not mint a duplicate (spike-scoped de-dup, §12)', async () => {
+    const { app, ledger } = buildApp({ withLedger: true });
+    const r1 = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    const r2 = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    expect(await r1.text()).toBe(await r2.text());
+    // Only one synthetic assertion despite two identical accepts.
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(1);
+  });
+});
+
+// ── (c) pending / reject / malformed never record an admitted assertion ───────
+
+describe('Phase 33Q route — pending/reject/malformed leave no admitted assertion (§9.3–§9.5)', () => {
+  it('pending records nothing and is not recallable', async () => {
+    const { app, ledger } = buildApp({ withLedger: true });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.pending);
+    expect(res.status).toBe(200);
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(0);
+    expect(ledger!.projectRecall(SCOPE)).toEqual({ includes: [], excludes: [] });
+    expect(ledger!.auditTrail(SCOPE)).toEqual([]);
+  });
+
+  it('reject records no admitted assertion', async () => {
+    const { app, ledger } = buildApp({ withLedger: true });
+    await post(app, ADMISSION_TRANSITION_INTENTS.reject);
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(0);
+    expect(ledger!.projectRecall(SCOPE).includes).toEqual([]);
+  });
+
+  it('malformed fails closed before the ledger is reached', async () => {
+    const { app, ledger } = buildApp({ withLedger: true });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.malformed);
+    expect(res.status).toBe(400);
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(0);
+  });
+
+  it('an unsupported/garbage shape fails closed and reaches no ledger write', async () => {
+    const { app, ledger } = buildApp({ withLedger: true });
+    const res = await app.request('/api/admission/intake', {
+      method: 'POST',
+      headers: authHeaders(),
+      body: '{ not json',
+    });
+    expect(res.status).toBe(400);
+    expect(ledger!.inspectEstate(SCOPE).assertions).toBe(0);
+  });
+});
+
+// ── (d) ledger throw → stable fail-closed refusal, no recallable residue ──────
+
+describe('Phase 33Q route — ledger throw fails closed to the stable refusal (§9 case-8)', () => {
+  it('a throwing ledger collapses an accept to the stable 400 refusal, leaking nothing', async () => {
+    // Stub ledger whose record() throws (simulating capacity/scope/conflict).
+    // Its inspect/project/audit methods report empty, proving no residue.
+    let recordCalls = 0;
+    const throwingLedger: AdmittedAssertionLedger = {
+      seedEstate: () => undefined,
+      record: () => {
+        recordCalls += 1;
+        throw new Error('synthetic ledger record failure');
+      },
+      forEstate: (scope) => ({
+        tenant_id: scope.tenant_id,
+        estate_id: scope.estate_id,
+        record: () => {
+          throw new Error('synthetic ledger record failure');
+        },
+        projectRecall: () => ({ includes: [], excludes: [] }),
+        inspectEstate: () => ({ assertions: 0, bytes: 0 }),
+        auditTrail: () => [],
+      }),
+      projectRecall: () => ({ includes: [], excludes: [] }),
+      inspectEstate: () => ({ assertions: 0, bytes: 0 }),
+      auditTrail: () => [],
+    };
+    const { app } = buildApp({ ledger: throwingLedger });
+
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    expect(res.status).toBe(400);
+    const body = JSON.parse(await res.text());
+    expect(body.outcome_class).toBe('refused');
+    expect(body.safe_reason_code).toBe('ingress.invalid_request');
+    expect(body.recall_eligible).toBe(false);
+    expect(body.public_receipt_ref ?? null).toBeNull();
+    expect(body.recall_projection?.ordinary_recall_includes ?? []).toEqual([]);
+    // The synthetic error text never leaks.
+    expect(JSON.stringify(body)).not.toContain('synthetic ledger record failure');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+    // The route DID attempt the ledger write for the accept scenario.
+    expect(recordCalls).toBe(1);
+  });
+
+  it('a throwing ledger does NOT affect pending (ledger never invoked for pending)', async () => {
+    let recordCalls = 0;
+    const throwingLedger: AdmittedAssertionLedger = {
+      seedEstate: () => undefined,
+      record: () => {
+        recordCalls += 1;
+        throw new Error('should not be called for pending');
+      },
+      forEstate: (scope) => ({
+        tenant_id: scope.tenant_id,
+        estate_id: scope.estate_id,
+        record: () => ({ outcome: 'recorded', admitted_assertion_id: 'x', assertion_status: 'active' }),
+        projectRecall: () => ({ includes: [], excludes: [] }),
+        inspectEstate: () => ({ assertions: 0, bytes: 0 }),
+        auditTrail: () => [],
+      }),
+      projectRecall: () => ({ includes: [], excludes: [] }),
+      inspectEstate: () => ({ assertions: 0, bytes: 0 }),
+      auditTrail: () => [],
+    };
+    const { app } = buildApp({ ledger: throwingLedger });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.pending);
+    expect(res.status).toBe(200);
+    expect(recordCalls).toBe(0);
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/admitted-assertion-ledger.test.ts
+++ b/app/tests/unit/admission-wedge-spike/admitted-assertion-ledger.test.ts
@@ -1,0 +1,1133 @@
+// Phase 33Q — unit proof of the bounded, process-local, SYNTHETIC
+// admitted-assertion ledger.
+//
+// Authorized by the Phase 33P storage/receipt hardening decision gate
+// (docs/ADMISSION-WEDGE-STORAGE-RECEIPT-HARDENING-GATE.md §7–§12). These tests
+// exercise the ledger API DIRECTLY (not through the route), proving the §9
+// proof cases that are stateful and the §9 case-8 bounded-store safety set over
+// SYNTHETIC material only. Nothing here touches a database, file, socket, timer,
+// migration, or any durable backend — the ledger is JS Maps in a closure.
+//
+// SCOPE BINDING (Codex blocker 1): every read/write is bound to BOTH a
+// synthetic tenant_id AND a synthetic estate_id. One tenant's estate is
+// unreachable from another tenant; an estate_id cannot be re-homed to a second
+// tenant.
+//
+// SYNTHETIC-ONLY DISCIPLINE (Codex blocker 3): every externally supplied
+// string-like field is validated to a bounded synthetic-label shape BEFORE any
+// mutation; unsafe markers, payload-shaped extra fields, and over-long values
+// are rejected with zero ledger/audit/recall residue.
+//
+// STRICT CAPACITY (Codex blocker 2): the capacity config is validated at ledger
+// creation (finite, positive, integer, dev-bounded), and retained replay
+// metadata (keys + fingerprints) is included in the byte budget.
+//
+// IDEMPOTENCY BOUNDARY (Phase 33P §12): the replay/de-duplication and
+// conflicting-replay proofs below are SPIKE-SCOPED ONLY. They do NOT settle
+// final production idempotency semantics, which remain explicitly UNRESOLVED.
+
+import { describe, expect, it } from 'vitest';
+import {
+  createAdmittedAssertionLedger,
+  AdmittedAssertionCapExceededError,
+  AdmittedAssertionScopeViolationError,
+  AdmittedAssertionReplayConflictError,
+  AdmittedAssertionInvalidConfigError,
+  AdmittedAssertionInvalidInputError,
+  AdmittedAssertionTenantConflictError,
+  findAdmissionPublicLeaks,
+  type AdmittedAssertionLedger,
+  type AdmittedScope,
+  type SyntheticAdmissionTransition,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+// ── Synthetic builders (short labels only; never UUID / long-opaque) ──────────
+
+const SCOPE_A: AdmittedScope = { tenant_id: 'tenant-synth-a', estate_id: 'estate-synth-a' };
+
+function freshLedger(
+  overrides?: Partial<{ maxAssertionsPerEstate: number; maxAssertionBytesPerEstate: number }>,
+): AdmittedAssertionLedger {
+  return createAdmittedAssertionLedger({
+    maxAssertionsPerEstate: overrides?.maxAssertionsPerEstate ?? 100,
+    maxAssertionBytesPerEstate: overrides?.maxAssertionBytesPerEstate ?? 1_000_000,
+  });
+}
+
+function seededLedger(
+  scope: AdmittedScope = SCOPE_A,
+  cfg?: Partial<{ maxAssertionsPerEstate: number; maxAssertionBytesPerEstate: number }>,
+): AdmittedAssertionLedger {
+  const ledger = freshLedger(cfg);
+  ledger.seedEstate(scope);
+  return ledger;
+}
+
+function admitTransition(
+  overrides?: Partial<SyntheticAdmissionTransition>,
+): SyntheticAdmissionTransition {
+  return {
+    kind: 'admit',
+    source_candidate_id: 'cand-synth-1',
+    admission_transition_id: 'txn-admit-1',
+    admitted_assertion_id: 'assn-active-1',
+    assertion_class: 'preference',
+    replay_key: 'admit:cand-synth-1',
+    ...overrides,
+  };
+}
+
+function supersedeTransition(
+  overrides?: Partial<SyntheticAdmissionTransition>,
+): SyntheticAdmissionTransition {
+  return {
+    kind: 'supersede',
+    source_candidate_id: 'cand-synth-2',
+    admission_transition_id: 'txn-supersede-1',
+    admitted_assertion_id: 'assn-corrected-1',
+    assertion_class: 'preference',
+    replay_key: 'supersede:cand-synth-1',
+    supersedes_assertion_id: 'assn-active-1',
+    ...overrides,
+  };
+}
+
+/**
+ * Zero-residue proof for a REJECTED adversarial transition. A transition that
+ * fails validation must leave the estate EXACTLY as it was — no stored
+ * assertion, no retained bytes, no audit record, and nothing recallable. We
+ * assert all four surfaces so a regression that half-applies (or partially
+ * accounts) a rejected input is caught immediately after THAT input, rather than
+ * being masked by a single count check at the end of an adversarial loop.
+ */
+function expectZeroResidue(
+  ledger: AdmittedAssertionLedger,
+  scope: AdmittedScope = SCOPE_A,
+): void {
+  expect(ledger.inspectEstate(scope)).toEqual({ assertions: 0, bytes: 0 });
+  expect(ledger.auditTrail(scope)).toEqual([]);
+  expect(ledger.projectRecall(scope)).toEqual({ includes: [], excludes: [] });
+}
+
+// ── §9 proof case 1 & 2 — accept → admitted assertion exists, with audit ──────
+
+describe('Phase 33Q ledger — accept mints one active recall-eligible assertion + private audit (§9.1, §9.2)', () => {
+  it('records exactly one active, recall-eligible synthetic admitted assertion', () => {
+    const ledger = seededLedger();
+    const outcome = ledger.record(SCOPE_A, admitTransition());
+
+    expect(outcome.outcome).toBe('recorded');
+    expect(outcome.admitted_assertion_id).toBe('assn-active-1');
+    expect(outcome.assertion_status).toBe('active');
+
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+    // The active assertion is ordinarily recallable (identity/status/provenance
+    // observable — §9 case-8 final bullet).
+    expect(ledger.projectRecall(SCOPE_A)).toEqual({
+      includes: ['assn-active-1'],
+      excludes: [],
+    });
+  });
+
+  it('attaches a synthetic, explicitly NON-FINAL audit record with BOTH privacy markers (§10)', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+
+    const audit = ledger.auditTrail(SCOPE_A);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]!.audit_event).toBe('assertion_admitted');
+    expect(audit[0]!.admission_transition_id).toBe('txn-admit-1');
+    expect(audit[0]!.source_candidate_id).toBe('cand-synth-1');
+    // Receipt/audit split discipline (§10): the record is private AND carries no
+    // public audit detail. It explains the outcome; it never claims to be a
+    // production receipt.
+    expect(audit[0]!.audit_private).toBe(true);
+    expect(audit[0]!.public_audit_detail).toBe(false);
+  });
+});
+
+// ── §9 case-8 final bullet — identity/status/provenance WITHOUT raw payload ───
+
+describe('Phase 33Q ledger — identity/status/provenance observable WITHOUT raw payload persistence (§9 case-8)', () => {
+  it('exposes id, active status, and provenance link while storing NO raw payload', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+
+    const view = ledger.forEstate(SCOPE_A);
+    // Identity + status observable.
+    expect(view.projectRecall().includes).toEqual(['assn-active-1']);
+    // Provenance observable via the private audit trail (transition → candidate).
+    const audit = view.auditTrail();
+    expect(audit[0]!.admitted_assertion_id).toBe('assn-active-1');
+    expect(audit[0]!.source_candidate_id).toBe('cand-synth-1');
+
+    // No raw payload, source material, or unsafe marker anywhere in the stored
+    // synthetic state. We serialize the whole private surface and assert the
+    // absence of payload-shaped content (we do NOT run findAdmissionPublicLeaks
+    // here — these PRIVATE records legitimately carry forbidden public KEYS like
+    // admitted_assertion_id, so the public-leak guard belongs only on the public
+    // projection, asserted separately below).
+    const serializedPrivate = JSON.stringify({
+      audit: view.auditTrail(),
+      recall: view.projectRecall(),
+      footprint: view.inspectEstate(),
+    });
+    expect(serializedPrivate).not.toContain('unsafe_marker:');
+    expect(serializedPrivate).not.toContain('candidate_payload');
+    expect(serializedPrivate).not.toContain('source_ref');
+    expect(serializedPrivate).not.toContain('source_material');
+    expect(serializedPrivate).not.toContain('raw_reason');
+  });
+});
+
+// ── §9 proof case 6 — supersession repoints recall, preserves prior provenance ─
+
+describe('Phase 33Q ledger — supersession repoints recall to corrected active, prior preserved (§9.6)', () => {
+  it('marks prior superseded (not recallable) and corrected active (recallable), prior still inspectable', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+    const outcome = ledger.record(SCOPE_A, supersedeTransition());
+
+    expect(outcome.outcome).toBe('recorded');
+    expect(outcome.admitted_assertion_id).toBe('assn-corrected-1');
+    expect(outcome.superseded_assertion_id).toBe('assn-active-1');
+
+    // Ordinary recall now includes ONLY the corrected active assertion; the
+    // prior is excluded but retained for audit/provenance.
+    expect(ledger.projectRecall(SCOPE_A)).toEqual({
+      includes: ['assn-corrected-1'],
+      excludes: ['assn-active-1'],
+    });
+
+    // Both assertions remain present (the prior is retained, not deleted).
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(2);
+
+    // A superseded-event audit record exists, private + non-final.
+    const audit = ledger.auditTrail(SCOPE_A);
+    expect(audit.map((a) => a.audit_event)).toEqual(['assertion_admitted', 'assertion_superseded']);
+    expect(audit.every((a) => a.audit_private === true && a.public_audit_detail === false)).toBe(true);
+  });
+
+  it('fails closed when superseding a prior that is not in the estate (§9 case-8 isolation/atomicity)', () => {
+    const ledger = seededLedger();
+    // No prior admitted; superseding a non-existent prior must fail closed and
+    // leave the estate empty.
+    expect(() => ledger.record(SCOPE_A, supersedeTransition())).toThrow(
+      AdmittedAssertionScopeViolationError,
+    );
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+  });
+
+  it('fails closed when superseding an already-superseded prior (conflict)', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+    ledger.record(SCOPE_A, supersedeTransition());
+    // A second supersession of the now-superseded prior conflicts.
+    expect(() =>
+      ledger.record(
+        SCOPE_A,
+        supersedeTransition({
+          admitted_assertion_id: 'assn-corrected-2',
+          admission_transition_id: 'txn-supersede-2',
+          replay_key: 'supersede:cand-synth-1:again',
+        }),
+      ),
+    ).toThrow(AdmittedAssertionReplayConflictError);
+  });
+});
+
+// ── §9 case-8 — tenant/estate isolation (Codex blocker 1) ─────────────────────
+
+describe('Phase 33Q ledger — tenant/estate isolation (§9 case-8)', () => {
+  it('keeps one estate’s admitted assertions unreachable from another', () => {
+    const ledger = freshLedger();
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const b: AdmittedScope = { tenant_id: 'tenant-b', estate_id: 'estate-b' };
+    ledger.seedEstate(a);
+    ledger.seedEstate(b);
+
+    ledger.record(a, admitTransition({ admitted_assertion_id: 'assn-a-1', replay_key: 'admit:a1' }));
+
+    // estate-b sees nothing of estate-a's synthetic state.
+    expect(ledger.projectRecall(b)).toEqual({ includes: [], excludes: [] });
+    expect(ledger.inspectEstate(b).assertions).toBe(0);
+    expect(ledger.auditTrail(b)).toEqual([]);
+
+    // estate-a's own view is intact.
+    expect(ledger.projectRecall(a).includes).toEqual(['assn-a-1']);
+  });
+
+  it('a one-estate flood to capacity cannot starve another estate', () => {
+    const ledger = freshLedger({ maxAssertionsPerEstate: 2 });
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const b: AdmittedScope = { tenant_id: 'tenant-b', estate_id: 'estate-b' };
+    ledger.seedEstate(a);
+    ledger.seedEstate(b);
+
+    ledger.record(a, admitTransition({ admitted_assertion_id: 'a1', replay_key: 'k:a1' }));
+    ledger.record(a, admitTransition({ admitted_assertion_id: 'a2', replay_key: 'k:a2' }));
+    expect(() =>
+      ledger.record(a, admitTransition({ admitted_assertion_id: 'a3', replay_key: 'k:a3' })),
+    ).toThrow(AdmittedAssertionCapExceededError);
+
+    // estate-b is unaffected by estate-a's overflow.
+    ledger.record(b, admitTransition({ admitted_assertion_id: 'b1', replay_key: 'k:b1' }));
+    expect(ledger.inspectEstate(b).assertions).toBe(1);
+  });
+
+  it('records into an unseeded estate fail closed', () => {
+    const ledger = freshLedger();
+    expect(() =>
+      ledger.record({ tenant_id: 'tenant-x', estate_id: 'estate-missing' }, admitTransition()),
+    ).toThrow(AdmittedAssertionScopeViolationError);
+  });
+});
+
+// ── §9 case-8 — tenant binding & conflict (Codex blocker 1) ───────────────────
+
+describe('Phase 33Q ledger — tenant binding: same estate / different tenant (Codex blocker 1)', () => {
+  it('re-seeding the SAME estate_id under a DIFFERENT tenant fails closed (tenant conflict)', () => {
+    const ledger = seededLedger({ tenant_id: 'tenant-a', estate_id: 'estate-shared' });
+    // Re-seeding the same estate under tenant-a is idempotent (no throw).
+    ledger.seedEstate({ tenant_id: 'tenant-a', estate_id: 'estate-shared' });
+    // Re-seeding the same estate under tenant-b must FAIL CLOSED — an estate
+    // cannot be silently re-homed across tenants.
+    expect(() => ledger.seedEstate({ tenant_id: 'tenant-b', estate_id: 'estate-shared' })).toThrow(
+      AdmittedAssertionTenantConflictError,
+    );
+  });
+
+  it('a conflicting reseed does NOT disturb the original tenant’s state', () => {
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-shared' };
+    const ledger = seededLedger(a);
+    ledger.record(a, admitTransition());
+    expect(() => ledger.seedEstate({ tenant_id: 'tenant-b', estate_id: 'estate-shared' })).toThrow(
+      AdmittedAssertionTenantConflictError,
+    );
+    // tenant-a's assertion is intact; the estate still belongs to tenant-a.
+    expect(ledger.inspectEstate(a).assertions).toBe(1);
+    expect(ledger.projectRecall(a).includes).toEqual(['assn-active-1']);
+  });
+
+  it('a foreign tenant cannot READ another tenant’s estate (reads fail closed to empty)', () => {
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-shared' };
+    const foreign: AdmittedScope = { tenant_id: 'tenant-b', estate_id: 'estate-shared' };
+    const ledger = seededLedger(a);
+    ledger.record(a, admitTransition());
+
+    // The foreign tenant sees NOTHING — no cross-tenant read.
+    expect(ledger.projectRecall(foreign)).toEqual({ includes: [], excludes: [] });
+    expect(ledger.inspectEstate(foreign)).toEqual({ assertions: 0, bytes: 0 });
+    expect(ledger.auditTrail(foreign)).toEqual([]);
+  });
+
+  it('a foreign tenant cannot WRITE into another tenant’s estate (writes fail closed)', () => {
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-shared' };
+    const foreign: AdmittedScope = { tenant_id: 'tenant-b', estate_id: 'estate-shared' };
+    const ledger = seededLedger(a);
+    ledger.record(a, admitTransition());
+
+    // A write under the foreign tenant fails closed and leaves tenant-a intact.
+    try {
+      ledger.record(
+        foreign,
+        admitTransition({ admitted_assertion_id: 'assn-foreign', replay_key: 'admit:foreign' }),
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdmittedAssertionScopeViolationError);
+      expect((err as AdmittedAssertionScopeViolationError).reason).toBe('foreign_tenant');
+    }
+    // tenant-a still has exactly its one original assertion; nothing leaked in.
+    expect(ledger.inspectEstate(a).assertions).toBe(1);
+    expect(ledger.projectRecall(a).includes).toEqual(['assn-active-1']);
+  });
+
+  it('the scoped view is tenant- AND estate-bound', () => {
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-shared' };
+    const ledger = seededLedger(a);
+    const view = ledger.forEstate(a);
+    expect(view.tenant_id).toBe('tenant-a');
+    expect(view.estate_id).toBe('estate-shared');
+    // A view bound to a foreign tenant reads empty even for a populated estate.
+    ledger.record(a, admitTransition());
+    const foreignView = ledger.forEstate({ tenant_id: 'tenant-b', estate_id: 'estate-shared' });
+    expect(foreignView.projectRecall()).toEqual({ includes: [], excludes: [] });
+    expect(foreignView.inspectEstate().assertions).toBe(0);
+  });
+});
+
+// ── Scoped views snapshot an IMMUTABLE scope (Codex blocker 1) ────────────────
+
+describe('Phase 33Q ledger — scoped view snapshots its scope; later mutation of the original cannot re-home it (Codex blocker 1)', () => {
+  it('READ: mutating the original scope object after forEstate() does not change what the view reads', () => {
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const b: AdmittedScope = { tenant_id: 'tenant-b', estate_id: 'estate-b' };
+    const ledger = freshLedger();
+    ledger.seedEstate(a);
+    ledger.seedEstate(b);
+    ledger.record(a, admitTransition({ admitted_assertion_id: 'assn-a-1', replay_key: 'k:a1' }));
+    ledger.record(b, admitTransition({ admitted_assertion_id: 'assn-b-1', replay_key: 'k:b1' }));
+
+    // Build a MUTABLE scope object and a view over A/A.
+    const mutable: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const view = ledger.forEstate(mutable);
+    expect(view.tenant_id).toBe('tenant-a');
+    expect(view.estate_id).toBe('estate-a');
+
+    // Now mutate the ORIGINAL object to point at tenant B / estate B.
+    mutable.tenant_id = 'tenant-b';
+    mutable.estate_id = 'estate-b';
+
+    // The view still reads ONLY A/A — it never followed the mutation to B/B.
+    expect(view.tenant_id).toBe('tenant-a');
+    expect(view.estate_id).toBe('estate-a');
+    expect(view.projectRecall().includes).toEqual(['assn-a-1']);
+    expect(view.inspectEstate().assertions).toBe(1);
+    expect(view.auditTrail().map((r) => r.admitted_assertion_id)).toEqual(['assn-a-1']);
+    // It must NOT have read estate B's state.
+    expect(view.projectRecall().includes).not.toContain('assn-b-1');
+  });
+
+  it('WRITE: mutating the original scope object after forEstate() does not redirect writes to B/B', () => {
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const b: AdmittedScope = { tenant_id: 'tenant-b', estate_id: 'estate-b' };
+    const ledger = freshLedger();
+    ledger.seedEstate(a);
+    ledger.seedEstate(b);
+
+    const mutable: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const view = ledger.forEstate(mutable);
+
+    // Re-home the original object to B/B AFTER binding.
+    mutable.tenant_id = 'tenant-b';
+    mutable.estate_id = 'estate-b';
+
+    // A write through the original view lands in A/A only.
+    view.record(admitTransition({ admitted_assertion_id: 'assn-a-1', replay_key: 'k:a1' }));
+
+    // A/A received the write; B/B is untouched.
+    expect(ledger.inspectEstate(a).assertions).toBe(1);
+    expect(ledger.projectRecall(a).includes).toEqual(['assn-a-1']);
+    expect(ledger.inspectEstate(b).assertions).toBe(0);
+    expect(ledger.projectRecall(b)).toEqual({ includes: [], excludes: [] });
+  });
+
+  it('WRITE fails closed per A/A state (not B/B) — a supersede with no A/A prior fails even though B/B has one', () => {
+    const a: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const b: AdmittedScope = { tenant_id: 'tenant-b', estate_id: 'estate-b' };
+    const ledger = freshLedger();
+    ledger.seedEstate(a);
+    ledger.seedEstate(b);
+    // B/B has a prior active assertion that a supersede COULD correct.
+    ledger.record(b, admitTransition({ admitted_assertion_id: 'assn-active-1', replay_key: 'k:b-admit' }));
+
+    const mutable: AdmittedScope = { tenant_id: 'tenant-a', estate_id: 'estate-a' };
+    const view = ledger.forEstate(mutable);
+    // Re-home the original to B/B.
+    mutable.tenant_id = 'tenant-b';
+    mutable.estate_id = 'estate-b';
+
+    // The view is bound to A/A, where there is NO prior — so a supersede fails
+    // closed according to A/A state, never silently succeeding against B/B.
+    expect(() => view.record(supersedeTransition({ replay_key: 'k:a-supersede' }))).toThrow(
+      AdmittedAssertionScopeViolationError,
+    );
+    // B/B's prior was never touched (still active, still alone).
+    expect(ledger.projectRecall(b).includes).toEqual(['assn-active-1']);
+    expect(ledger.inspectEstate(b).assertions).toBe(1);
+    // A/A remains empty.
+    expect(ledger.inspectEstate(a).assertions).toBe(0);
+  });
+});
+
+// ── §9 case-8 — capacity-limit failure leaves state unchanged ─────────────────
+
+describe('Phase 33Q ledger — capacity-limit failure behavior (§9 case-8)', () => {
+  it('assertion-count overflow throws with dimension/cap/observed, state unchanged', () => {
+    const ledger = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 1 });
+    ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a1', replay_key: 'k1' }));
+
+    try {
+      ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a2', replay_key: 'k2' }));
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdmittedAssertionCapExceededError);
+      const e = err as AdmittedAssertionCapExceededError;
+      expect(e.estate_id).toBe('estate-synth-a');
+      expect(e.dimension).toBe('assertion_count');
+      expect(e.cap).toBe(1);
+      expect(e.observed).toBe(2);
+    }
+    // Bounded REJECTION, not eviction: the original is intact, count unchanged.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+    expect(ledger.projectRecall(SCOPE_A).includes).toEqual(['a1']);
+  });
+
+  it('byte-budget overflow throws and leaves state unchanged', () => {
+    const ledger = seededLedger(SCOPE_A, {
+      maxAssertionsPerEstate: 1_000,
+      maxAssertionBytesPerEstate: 120,
+    });
+    // A long (but still bounded-length, synthetic-shape) assertion_class forces a
+    // single-record byte overflow. 120 bytes is far smaller than one record.
+    expect(() =>
+      ledger.record(
+        SCOPE_A,
+        admitTransition({ assertion_class: 'c'.repeat(120), replay_key: 'k-big' }),
+      ),
+    ).toThrow(AdmittedAssertionCapExceededError);
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+    expect(ledger.inspectEstate(SCOPE_A).bytes).toBe(0);
+  });
+
+  it('retained replay metadata contributes to the byte budget (Codex blocker 2)', () => {
+    // Two ledgers, identical except for replay_key length. The longer replay key
+    // must cost MORE bytes, proving the retained replay metadata is accounted —
+    // a 1 MB key cannot be retained while reported bytes stay small.
+    const shortLedger = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 10 });
+    shortLedger.record(SCOPE_A, admitTransition({ replay_key: 'k1' }));
+    const shortBytes = shortLedger.inspectEstate(SCOPE_A).bytes;
+
+    const longLedger = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 10 });
+    longLedger.record(SCOPE_A, admitTransition({ replay_key: `k-${'x'.repeat(100)}` }));
+    const longBytes = longLedger.inspectEstate(SCOPE_A).bytes;
+
+    expect(longBytes).toBeGreaterThan(shortBytes);
+    // The difference is at least the extra replay-key characters.
+    expect(longBytes - shortBytes).toBeGreaterThanOrEqual(100);
+  });
+
+  it('a write whose retained replay key would breach the byte budget fails closed (Codex blocker 2)', () => {
+    // Sized so the assertion + audit fit but the retained replay key tips the
+    // budget over — proving the replay key is counted in the capacity check, not
+    // retained silently.
+    const baseline = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 10 });
+    baseline.record(SCOPE_A, admitTransition({ replay_key: 'k1' }));
+    const oneRecordBytes = baseline.inspectEstate(SCOPE_A).bytes;
+
+    // Budget that admits the record under a short key but not under a long one.
+    const ledger = seededLedger(SCOPE_A, {
+      maxAssertionsPerEstate: 10,
+      maxAssertionBytesPerEstate: oneRecordBytes + 20,
+    });
+    expect(() =>
+      ledger.record(SCOPE_A, admitTransition({ replay_key: `k-${'y'.repeat(100)}` })),
+    ).toThrow(AdmittedAssertionCapExceededError);
+    // Bounded rejection, not silent retention: nothing was stored.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+    expect(ledger.inspectEstate(SCOPE_A).bytes).toBe(0);
+  });
+});
+
+// ── Strict capacity-config validation at creation (Codex blocker 2) ───────────
+
+describe('Phase 33Q ledger — capacity config is strictly validated at creation (Codex blocker 2)', () => {
+  it('rejects an Infinity assertion cap', () => {
+    expect(() =>
+      createAdmittedAssertionLedger({
+        maxAssertionsPerEstate: Number.POSITIVE_INFINITY,
+        maxAssertionBytesPerEstate: 1_000,
+      }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+  });
+
+  it('rejects an Infinity byte cap', () => {
+    expect(() =>
+      createAdmittedAssertionLedger({
+        maxAssertionsPerEstate: 10,
+        maxAssertionBytesPerEstate: Number.POSITIVE_INFINITY,
+      }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+  });
+
+  it('rejects a NaN cap', () => {
+    expect(() =>
+      createAdmittedAssertionLedger({
+        maxAssertionsPerEstate: Number.NaN,
+        maxAssertionBytesPerEstate: 1_000,
+      }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+  });
+
+  it('rejects zero, negative, fractional, and over-ceiling caps', () => {
+    expect(() =>
+      createAdmittedAssertionLedger({ maxAssertionsPerEstate: 0, maxAssertionBytesPerEstate: 1_000 }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+    expect(() =>
+      createAdmittedAssertionLedger({ maxAssertionsPerEstate: -5, maxAssertionBytesPerEstate: 1_000 }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+    expect(() =>
+      createAdmittedAssertionLedger({ maxAssertionsPerEstate: 1.5, maxAssertionBytesPerEstate: 1_000 }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+    expect(() =>
+      createAdmittedAssertionLedger({
+        maxAssertionsPerEstate: 10,
+        maxAssertionBytesPerEstate: 100_000_000,
+      }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+  });
+
+  it('rejects a non-number cap', () => {
+    expect(() =>
+      createAdmittedAssertionLedger({
+        // @ts-expect-error — proving runtime rejection of a non-number cap.
+        maxAssertionsPerEstate: '10',
+        maxAssertionBytesPerEstate: 1_000,
+      }),
+    ).toThrow(AdmittedAssertionInvalidConfigError);
+  });
+
+  it('carries a safe field/reason and no payload on the config error', () => {
+    try {
+      createAdmittedAssertionLedger({
+        maxAssertionsPerEstate: Number.POSITIVE_INFINITY,
+        maxAssertionBytesPerEstate: 1_000,
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdmittedAssertionInvalidConfigError);
+      const e = err as AdmittedAssertionInvalidConfigError;
+      expect(e.field).toBe('maxAssertionsPerEstate');
+      expect(e.reason).toBe('not_finite');
+      expect(findAdmissionPublicLeaks(e.message)).toEqual([]);
+    }
+  });
+});
+
+// ── Validated caps are copied into closure-owned constants (Codex blocker 2) ──
+
+describe('Phase 33Q ledger — validated caps are closure-owned; mutating the original config cannot widen them (Codex blocker 2)', () => {
+  it('mutating both caps to Infinity AFTER construction does not relax the configured cap of one', () => {
+    // Construct with maxAssertionsPerEstate = 1 (and a small byte budget).
+    const config = { maxAssertionsPerEstate: 1, maxAssertionBytesPerEstate: 100_000 };
+    const ledger = createAdmittedAssertionLedger(config);
+    ledger.seedEstate(SCOPE_A);
+    ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a1', replay_key: 'k1' }));
+
+    // Mutate the ORIGINAL config object to Infinity on BOTH dimensions.
+    config.maxAssertionsPerEstate = Number.POSITIVE_INFINITY;
+    config.maxAssertionBytesPerEstate = Number.POSITIVE_INFINITY;
+
+    // The second assertion still fails closed under the ORIGINAL cap of one —
+    // the ledger reads only its frozen, closure-owned caps.
+    try {
+      ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a2', replay_key: 'k2' }));
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdmittedAssertionCapExceededError);
+      const e = err as AdmittedAssertionCapExceededError;
+      expect(e.dimension).toBe('assertion_count');
+      // The cap reported is still 1 — proving the closure-owned copy, not the
+      // mutated config (which now reads Infinity).
+      expect(e.cap).toBe(1);
+      expect(e.observed).toBe(2);
+    }
+
+    // No residue from the failed write: still exactly one assertion, one audit
+    // record, and only a1 is recallable; the failed key was never consumed.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+    expect(ledger.auditTrail(SCOPE_A)).toHaveLength(1);
+    expect(ledger.projectRecall(SCOPE_A).includes).toEqual(['a1']);
+  });
+
+  it('mutating the byte cap to Infinity AFTER construction does not relax the original byte budget', () => {
+    const config = { maxAssertionsPerEstate: 1_000, maxAssertionBytesPerEstate: 120 };
+    const ledger = createAdmittedAssertionLedger(config);
+    ledger.seedEstate(SCOPE_A);
+
+    // Widen the original config's byte cap after construction.
+    config.maxAssertionBytesPerEstate = Number.POSITIVE_INFINITY;
+
+    // A single record that overflows the ORIGINAL 120-byte budget still fails.
+    expect(() =>
+      ledger.record(SCOPE_A, admitTransition({ assertion_class: 'c'.repeat(120), replay_key: 'k-big' })),
+    ).toThrow(AdmittedAssertionCapExceededError);
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+    expect(ledger.inspectEstate(SCOPE_A).bytes).toBe(0);
+  });
+});
+
+// ── Synthetic-only / raw-material rejection (Codex blocker 3) ─────────────────
+
+describe('Phase 33Q ledger — synthetic-only transition validation rejects unsafe/raw material (Codex blocker 3)', () => {
+  it('rejects an unsafe marker in any accepted field, with zero residue', () => {
+    const ledger = seededLedger();
+    // An unsafe marker smuggled into the source_candidate_id is rejected before
+    // any mutation.
+    expect(() =>
+      ledger.record(SCOPE_A, admitTransition({ source_candidate_id: 'unsafe_marker:raw-candidate' })),
+    ).toThrow(AdmittedAssertionInvalidInputError);
+    // …and into the replay_key (where `:` is shape-allowed) is also rejected.
+    expect(() =>
+      ledger.record(SCOPE_A, admitTransition({ replay_key: 'unsafe_marker:raw-candidate' })),
+    ).toThrow(AdmittedAssertionInvalidInputError);
+    // Zero residue: nothing stored, no audit, nothing recallable.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+    expect(ledger.auditTrail(SCOPE_A)).toEqual([]);
+    expect(ledger.projectRecall(SCOPE_A)).toEqual({ includes: [], excludes: [] });
+  });
+
+  it('rejects payload-shaped values (candidate_payload, source_material, raw_reason) in any field', () => {
+    const ledger = seededLedger();
+    for (const bad of ['candidate_payload', 'source_material', 'raw_reason', 'source_ref']) {
+      expect(() =>
+        ledger.record(SCOPE_A, admitTransition({ assertion_class: bad })),
+      ).toThrow(AdmittedAssertionInvalidInputError);
+    }
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+  });
+
+  it('rejects a payload-shaped EXTRA field (strict key set), with zero residue', () => {
+    const ledger = seededLedger();
+    expect(() =>
+      ledger.record(
+        SCOPE_A,
+        // @ts-expect-error — proving runtime rejection of an extra payload field.
+        admitTransition({ candidate_payload: 'arbitrary raw material here' }),
+      ),
+    ).toThrow(AdmittedAssertionInvalidInputError);
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+    expect(ledger.auditTrail(SCOPE_A)).toEqual([]);
+  });
+
+  it('rejects an over-long field (e.g. a 1 MB string) before it can be stored or accounted', () => {
+    const ledger = seededLedger();
+    const huge = 'a'.repeat(1_000_000);
+    expect(() => ledger.record(SCOPE_A, admitTransition({ replay_key: huge }))).toThrow(
+      AdmittedAssertionInvalidInputError,
+    );
+    // No residue and the byte budget was never touched by the oversized value.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+    expect(ledger.inspectEstate(SCOPE_A).bytes).toBe(0);
+  });
+
+  it('rejects an out-of-shape (free-form / whitespace / uppercase) identity label', () => {
+    const ledger = seededLedger();
+    for (const bad of ['Free Form Text', 'has whitespace', 'UPPER', 'punc!tuation', '']) {
+      expect(() =>
+        ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: bad })),
+      ).toThrow(AdmittedAssertionInvalidInputError);
+    }
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+  });
+
+  it('rejects an invalid transition kind', () => {
+    const ledger = seededLedger();
+    expect(() =>
+      // @ts-expect-error — proving runtime rejection of an invalid kind.
+      ledger.record(SCOPE_A, admitTransition({ kind: 'delete_everything' })),
+    ).toThrow(AdmittedAssertionInvalidInputError);
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(0);
+  });
+
+  it('rejects a malformed scope (non-synthetic tenant/estate id)', () => {
+    const ledger = freshLedger();
+    expect(() => ledger.seedEstate({ tenant_id: 'Tenant With Spaces', estate_id: 'estate-ok' })).toThrow(
+      AdmittedAssertionInvalidInputError,
+    );
+    expect(() => ledger.seedEstate({ tenant_id: 'tenant-ok', estate_id: 'unsafe_marker:x' })).toThrow(
+      AdmittedAssertionInvalidInputError,
+    );
+  });
+
+  it('no raw payload / unsafe marker survives a rejected transition in audit or inspection output', () => {
+    const ledger = seededLedger();
+    const sentinel = 'unsafe_marker:raw-candidate';
+    try {
+      ledger.record(SCOPE_A, admitTransition({ source_candidate_id: sentinel }));
+    } catch {
+      // expected
+    }
+    const serialized = JSON.stringify({
+      audit: ledger.auditTrail(SCOPE_A),
+      recall: ledger.projectRecall(SCOPE_A),
+      footprint: ledger.inspectEstate(SCOPE_A),
+    });
+    expect(serialized).not.toContain(sentinel);
+    expect(serialized).not.toContain('unsafe_marker');
+    expect(serialized).not.toContain('raw-candidate');
+  });
+});
+
+// ── §9 case-8 — atomic partial-failure / no residue ───────────────────────────
+
+describe('Phase 33Q ledger — atomic partial-failure, no residue (§9 case-8)', () => {
+  it('a pre-mutation failure leaves NO partially-admitted residue and NO recallable state', () => {
+    const ledger = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 1 });
+    ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a1', replay_key: 'k1' }));
+
+    // This second record overflows and must be rejected BEFORE any mutation.
+    expect(() =>
+      ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a2', replay_key: 'k2' })),
+    ).toThrow(AdmittedAssertionCapExceededError);
+
+    // No half-applied assertion, no orphan audit record, no recallable residue,
+    // and the replay key for the failed write was never registered.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+    expect(ledger.auditTrail(SCOPE_A)).toHaveLength(1);
+    expect(ledger.projectRecall(SCOPE_A)).toEqual({ includes: ['a1'], excludes: [] });
+    // Re-issuing the failed write under freed capacity proves its key was not
+    // silently consumed by the failed attempt.
+    const ledger2 = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 2 });
+    ledger2.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a1', replay_key: 'k1' }));
+    const out = ledger2.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a2', replay_key: 'k2' }));
+    expect(out.outcome).toBe('recorded');
+  });
+
+  it('a failed supersession leaves the prior active and recallable (no half-applied supersession)', () => {
+    const ledger = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 1 });
+    ledger.record(SCOPE_A, admitTransition());
+    // Supersession would need a 2nd assertion slot but the cap is 1 → overflow
+    // before either mutation. The prior must stay active + recallable.
+    expect(() => ledger.record(SCOPE_A, supersedeTransition())).toThrow(
+      AdmittedAssertionCapExceededError,
+    );
+    expect(ledger.projectRecall(SCOPE_A)).toEqual({ includes: ['assn-active-1'], excludes: [] });
+    expect(ledger.auditTrail(SCOPE_A)).toHaveLength(1); // only the admit
+  });
+});
+
+// ── §9 case-8 / §12 — replay de-dup and conflicting replay ────────────────────
+
+describe('Phase 33Q ledger — spike-scoped replay/de-dup (§9 case-8, §12)', () => {
+  it('replaying the SAME synthetic transition mints no duplicate (idempotent)', () => {
+    const ledger = seededLedger();
+    const first = ledger.record(SCOPE_A, admitTransition());
+    const second = ledger.record(SCOPE_A, admitTransition());
+
+    expect(first.outcome).toBe('recorded');
+    expect(second.outcome).toBe('replayed');
+    expect(second.admitted_assertion_id).toBe(first.admitted_assertion_id);
+    // Exactly one assertion and one audit record — no second mint.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+    expect(ledger.auditTrail(SCOPE_A)).toHaveLength(1);
+  });
+
+  it('a CONFLICTING replay (same key, different content) fails closed, original intact', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+    expect(() =>
+      ledger.record(
+        SCOPE_A,
+        // Same replay_key, different synthetic content.
+        admitTransition({ admitted_assertion_id: 'assn-active-other', assertion_class: 'claim' }),
+      ),
+    ).toThrow(AdmittedAssertionReplayConflictError);
+
+    // No overwrite, no fork, no corruption.
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+    expect(ledger.projectRecall(SCOPE_A).includes).toEqual(['assn-active-1']);
+  });
+
+  it('a fresh replay key minting over an existing synthetic id is a conflict', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+    expect(() =>
+      ledger.record(SCOPE_A, admitTransition({ replay_key: 'different-key' })),
+    ).toThrow(AdmittedAssertionReplayConflictError);
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+  });
+});
+
+// ── §9 case-8 — process-local ephemerality / restart-no-residue ───────────────
+
+describe('Phase 33Q ledger — process-local ephemerality & restart-no-residue (§9 case-8)', () => {
+  it('a freshly-created ledger is empty (no durable admitted-assertion residue survives a "restart")', () => {
+    // First "process": record an assertion.
+    const ledgerA = seededLedger();
+    ledgerA.record(SCOPE_A, admitTransition());
+    expect(ledgerA.inspectEstate(SCOPE_A).assertions).toBe(1);
+
+    // Second "process": a brand-new ledger instance shares NO state — the synthetic
+    // admitted assertion is gone. (The ledger holds only closure-captured Maps;
+    // there is no durable backend to survive a restart.)
+    const ledgerB = freshLedger();
+    expect(ledgerB.inspectEstate(SCOPE_A)).toEqual({ assertions: 0, bytes: 0 });
+    expect(ledgerB.projectRecall(SCOPE_A)).toEqual({ includes: [], excludes: [] });
+    expect(ledgerB.auditTrail(SCOPE_A)).toEqual([]);
+  });
+
+  it('seedEstate is idempotent and never destroys existing synthetic state', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+    // Re-seeding the same (tenant, estate) must NOT wipe the recorded assertion.
+    ledger.seedEstate(SCOPE_A);
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+  });
+});
+
+// ── §11 — the public recall projection is leak-clean ──────────────────────────
+
+describe('Phase 33Q ledger — public recall projection is no-leak clean (§11)', () => {
+  it('projectRecall output carries only short synthetic ids and passes findAdmissionPublicLeaks', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+    ledger.record(SCOPE_A, supersedeTransition());
+
+    const projection = ledger.projectRecall(SCOPE_A);
+    // The projection (the only ledger surface a public response could ever
+    // derive from) is leak-clean: no forbidden keys, no UUID/long-opaque ids.
+    expect(findAdmissionPublicLeaks(projection)).toEqual([]);
+    expect(findAdmissionPublicLeaks(projection.includes)).toEqual([]);
+    expect(findAdmissionPublicLeaks(projection.excludes)).toEqual([]);
+  });
+});
+
+// ── Returned audit / inspect / projection are detached from internals (blocker 3) ─
+
+describe('Phase 33Q ledger — auditTrail() returns detached, frozen records; mutating them cannot alter internal state (Codex blocker 3)', () => {
+  it('mutating a returned audit record with unsafe_marker:raw-candidate does not persist internally', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+
+    const returned = ledger.auditTrail(SCOPE_A);
+    // Attempt to smuggle an unsafe marker onto the returned record. The record is
+    // frozen, so this throws in a module with implicit strict mode (ESM); we
+    // tolerate either a throw OR a silent no-op, then prove no internal effect.
+    try {
+      (returned[0] as unknown as Record<string, unknown>).unsafe_marker = 'raw-candidate';
+    } catch {
+      // expected for a frozen object under strict mode
+    }
+
+    // A FRESH read must not contain the injected marker anywhere.
+    const after = ledger.auditTrail(SCOPE_A);
+    const serialized = JSON.stringify(after);
+    expect(serialized).not.toContain('unsafe_marker');
+    expect(serialized).not.toContain('raw-candidate');
+    expect((after[0] as unknown as Record<string, unknown>).unsafe_marker).toBeUndefined();
+  });
+
+  it('mutating a returned audit record with a 1 MB value does not change internal footprint/bytes', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+    const bytesBefore = ledger.inspectEstate(SCOPE_A).bytes;
+
+    const returned = ledger.auditTrail(SCOPE_A);
+    try {
+      (returned[0] as unknown as Record<string, unknown>).receipt_ref = 'z'.repeat(1_000_000);
+    } catch {
+      // expected for a frozen object
+    }
+
+    // The internal footprint is unchanged — the returned copy is detached.
+    expect(ledger.inspectEstate(SCOPE_A).bytes).toBe(bytesBefore);
+    const after = ledger.auditTrail(SCOPE_A);
+    expect(after[0]!.receipt_ref).toBe('rcpt-priv-1');
+    expect(after[0]!.receipt_ref.length).toBeLessThan(100);
+  });
+
+  it('mutating returned audit_private/public_audit_detail does not flip the internal privacy markers', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+
+    const returned = ledger.auditTrail(SCOPE_A);
+    // Attempt EACH privacy-marker mutation INDEPENDENTLY. A shared `try` block
+    // would let the first frozen-write abort before the second was even
+    // attempted, hiding a regression where one marker is mutable. `Reflect.set`
+    // never throws on a frozen target — it returns `false` — so both writes are
+    // always attempted and we additionally assert each was actually refused.
+    const mutated = returned[0] as unknown as Record<string, unknown>;
+    const privateFlipped = Reflect.set(mutated, 'audit_private', false);
+    const publicFlipped = Reflect.set(mutated, 'public_audit_detail', true);
+    expect(privateFlipped).toBe(false);
+    expect(publicFlipped).toBe(false);
+
+    // A fresh read still shows the correct, private markers.
+    const after = ledger.auditTrail(SCOPE_A);
+    expect(after[0]!.audit_private).toBe(true);
+    expect(after[0]!.public_audit_detail).toBe(false);
+  });
+
+  it('pushing onto the returned audit array does not grow the internal trail', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+
+    const returned = ledger.auditTrail(SCOPE_A);
+    try {
+      (returned as SyntheticAuditRecord[]).push({
+        audit_event: 'assertion_admitted',
+        admission_transition_id: 'txn-injected',
+        source_candidate_id: 'cand-injected',
+        admitted_assertion_id: 'assn-injected',
+        receipt_ref: 'rcpt-injected',
+        audit_private: true,
+        public_audit_detail: false,
+      });
+    } catch {
+      // expected for a frozen array
+    }
+    // The internal trail still has exactly the one real record.
+    expect(ledger.auditTrail(SCOPE_A)).toHaveLength(1);
+    expect(ledger.auditTrail(SCOPE_A)[0]!.admission_transition_id).toBe('txn-admit-1');
+  });
+
+  it('inspectEstate() / projectRecall() return detached objects; mutating them cannot alter internal state', () => {
+    const ledger = seededLedger();
+    ledger.record(SCOPE_A, admitTransition());
+
+    const footprint = ledger.inspectEstate(SCOPE_A);
+    try {
+      (footprint as unknown as Record<string, unknown>).assertions = 999;
+    } catch {
+      // expected for a frozen object
+    }
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+
+    const projection = ledger.projectRecall(SCOPE_A);
+    try {
+      (projection.includes as string[]).push('assn-injected');
+    } catch {
+      // expected for a frozen array
+    }
+    // A fresh projection is unaffected by the mutation of a prior returned one.
+    expect(ledger.projectRecall(SCOPE_A).includes).toEqual(['assn-active-1']);
+    expect(ledger.projectRecall(SCOPE_A).includes).not.toContain('assn-injected');
+  });
+});
+
+// ── Plain-record / exact-key validation (Codex blocker 4) ─────────────────────
+
+describe('Phase 33Q ledger — exact-key/plain-record validation rejects non-enumerable, inherited, symbol, and prototype tricks (Codex blocker 4)', () => {
+  it('rejects a transition with a NON-ENUMERABLE candidate_payload own property before any mutation', () => {
+    const ledger = seededLedger();
+    const t = admitTransition();
+    // Hide a payload-shaped own property behind non-enumerability — Object.keys
+    // would miss it, Reflect.ownKeys does not.
+    Object.defineProperty(t, 'candidate_payload', {
+      value: 'arbitrary raw material here',
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+    expect(() => ledger.record(SCOPE_A, t)).toThrow(AdmittedAssertionInvalidInputError);
+    // Zero residue across ALL surfaces (count + bytes + audit + recall).
+    expectZeroResidue(ledger);
+  });
+
+  it('rejects a transition with an INHERITED candidate_payload (non-Object.prototype prototype) before mutation', () => {
+    const ledger = seededLedger();
+    const proto = { candidate_payload: 'arbitrary raw material here' };
+    const t = Object.assign(Object.create(proto), admitTransition());
+    expect(() => ledger.record(SCOPE_A, t)).toThrow(AdmittedAssertionInvalidInputError);
+    expectZeroResidue(ledger);
+  });
+
+  it('rejects a transition with a SYMBOL own key before mutation', () => {
+    const ledger = seededLedger();
+    const t = admitTransition();
+    (t as unknown as Record<symbol, unknown>)[Symbol('candidate_payload')] = 'raw';
+    expect(() => ledger.record(SCOPE_A, t)).toThrow(AdmittedAssertionInvalidInputError);
+    expectZeroResidue(ledger);
+  });
+
+  it('rejects a transition carried on an UNEXPECTED prototype (class instance) before mutation', () => {
+    const ledger = seededLedger();
+    class TransitionLike {
+      kind = 'admit' as const;
+      source_candidate_id = 'cand-synth-1';
+      admission_transition_id = 'txn-admit-1';
+      admitted_assertion_id = 'assn-active-1';
+      assertion_class = 'preference';
+      replay_key = 'admit:cand-synth-1';
+    }
+    const t = new TransitionLike();
+    expect(() => ledger.record(SCOPE_A, t as unknown as SyntheticAdmissionTransition)).toThrow(
+      AdmittedAssertionInvalidInputError,
+    );
+    expectZeroResidue(ledger);
+  });
+
+  it('rejects an array, Date, and Map as a transition (non-plain records), each leaving zero residue', () => {
+    const ledger = seededLedger();
+    const cases: Array<[string, unknown]> = [
+      ['array', []],
+      ['Date', new Date(0)],
+      ['Map', new Map()],
+    ];
+    for (const [label, bad] of cases) {
+      expect(
+        () => ledger.record(SCOPE_A, bad as SyntheticAdmissionTransition),
+        `non-plain ${label} must be rejected`,
+      ).toThrow(AdmittedAssertionInvalidInputError);
+      // Prove zero residue IMMEDIATELY after EACH rejected input, not once at
+      // the end — so a regression that half-applies one specific case is caught.
+      expectZeroResidue(ledger);
+    }
+  });
+
+  it('accepts a legitimate null-prototype plain record (explicitly allowed)', () => {
+    const ledger = seededLedger();
+    const t = Object.assign(Object.create(null), admitTransition());
+    const out = ledger.record(SCOPE_A, t);
+    expect(out.outcome).toBe('recorded');
+    expect(ledger.inspectEstate(SCOPE_A).assertions).toBe(1);
+  });
+
+  it('an accessor getter cannot return a safe value at validation and a different one at commit (TOCTOU)', () => {
+    const ledger = seededLedger();
+    let reads = 0;
+    const t = admitTransition();
+    // Replace admitted_assertion_id with a getter that flips after the first read.
+    Object.defineProperty(t, 'admitted_assertion_id', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        reads += 1;
+        return reads === 1 ? 'assn-active-1' : 'unsafe_marker:raw-candidate';
+      },
+    });
+    // The ledger reads each field exactly once into a frozen snapshot, so the
+    // toggling getter cannot smuggle the unsafe second value into stored state.
+    ledger.record(SCOPE_A, t);
+    const serialized = JSON.stringify({
+      audit: ledger.auditTrail(SCOPE_A),
+      recall: ledger.projectRecall(SCOPE_A),
+    });
+    expect(serialized).not.toContain('unsafe_marker');
+    expect(serialized).not.toContain('raw-candidate');
+    expect(ledger.projectRecall(SCOPE_A).includes).toEqual(['assn-active-1']);
+  });
+});
+
+// ── No-leak of error text ─────────────────────────────────────────────────────
+
+describe('Phase 33Q ledger — error messages are public-safe (no long/opaque ids)', () => {
+  it('cap / scope / conflict / invalid-input error messages carry no UUID or >=24-char opaque run', () => {
+    const ledger = seededLedger(SCOPE_A, { maxAssertionsPerEstate: 1 });
+    ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a1', replay_key: 'k1' }));
+
+    const messages: string[] = [];
+    try {
+      ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a2', replay_key: 'k2' }));
+    } catch (e) {
+      messages.push((e as Error).message);
+    }
+    try {
+      ledger.record({ tenant_id: 'tenant-x', estate_id: 'estate-missing' }, admitTransition({ replay_key: 'k3' }));
+    } catch (e) {
+      messages.push((e as Error).message);
+    }
+    try {
+      ledger.record(SCOPE_A, admitTransition({ admitted_assertion_id: 'a-x', replay_key: 'k1' }));
+    } catch (e) {
+      messages.push((e as Error).message);
+    }
+    // A rejected unsafe field must NOT echo the raw value into the message.
+    try {
+      ledger.record(SCOPE_A, admitTransition({ source_candidate_id: 'unsafe_marker:raw-candidate' }));
+    } catch (e) {
+      messages.push((e as Error).message);
+    }
+
+    expect(messages.length).toBeGreaterThanOrEqual(4);
+    for (const m of messages) {
+      // Run the same leak detector the route uses over the raw message string.
+      expect(findAdmissionPublicLeaks(m)).toEqual([]);
+      // The unsafe marker text never reaches the error message.
+      expect(m).not.toContain('unsafe_marker');
+      expect(m).not.toContain('raw-candidate');
+    }
+  });
+});

--- a/docs/admission-wedge/PHASE-33Q-DEV-STORE-RUNBOOK.md
+++ b/docs/admission-wedge/PHASE-33Q-DEV-STORE-RUNBOOK.md
@@ -1,0 +1,268 @@
+# Phase 33Q — Admission Wedge dev-only bounded admitted-assertion ledger: runbook
+
+> **Status:** dev/operator-only, **test-seam-only** bounded **synthetic**
+> admitted-assertion ledger. **NON-PRODUCTION.** **Not server-wired** — there is
+> no runtime env flag and no dev-reachable route path to the ledger; it exists to
+> prove the candidate → admitted-assertion → recall transition's *stateful effect*
+> against **synthetic material only**, exercised through the route's
+> dependency-injection seam in tests.
+>
+> Authorized **narrowly** by the Phase 33P storage/receipt hardening decision
+> gate ([`../ADMISSION-WEDGE-STORAGE-RECEIPT-HARDENING-GATE.md`](../ADMISSION-WEDGE-STORAGE-RECEIPT-HARDENING-GATE.md)
+> §7–§12), which selected **Option B** (a dev-only, disabled-by-default,
+> bounded **synthetic** store) and **rejected Option D** (production-like durable
+> storage). This phase authorizes **no** production admission, durable storage,
+> migration, production auth/consent, Freeside runtime/client integration,
+> Discord ingestion, user chat becoming memory, public `remember-this`, package
+> export, final schema freeze, or completed Straylight primitive review.
+
+## 1. What it is
+
+A bounded, **process-local**, **non-durable**, fail-closed **synthetic**
+admitted-assertion ledger:
+
+- `app/src/services/admission-wedge-spike/admitted-assertion-ledger.ts`
+
+Its entire state is JS `Map`s captured in a factory closure. It opens **no**
+database connection, **no** file handle, **no** socket, **no** timer, and runs
+**no** background task. It performs **no** durable write and **no** migration.
+
+It records **only** synthetic identity / status / provenance / receipt-like-audit
+references. Within the spike envelope this is **enforced at ingress, not merely
+undeclared**: every externally supplied string-like field (`tenant_id`,
+`estate_id`, `source_candidate_id`, `admission_transition_id`,
+`admitted_assertion_id`, `assertion_class`, `replay_key`,
+`supersedes_assertion_id`) is validated to a **bounded synthetic label**
+(lowercase snake/kebab + digits, length-capped; `replay_key` also allows `:`)
+**before any mutation**. A transition must be a **plain record** (prototype
+`Object.prototype` or `null` only — arrays, class instances, `Date`, `Map`, etc.
+are rejected); its **exact** own-key set is enforced with `Reflect.ownKeys`
+(**not** `Object.keys`), so a payload-shaped **extra field** that is
+non-enumerable, symbol-keyed, or reachable only through an inherited prototype is
+rejected, not silently accepted. Its `kind` is validated, and every field is
+scanned for a named **unsafe-marker / payload-shaped substring** denylist
+(`unsafe_marker`, `candidate_payload`, `source_material`, `raw_reason`, …). Each
+field is read **exactly once** into a **frozen, closure-owned snapshot** that all
+downstream work (fingerprint, capacity, commit) reads from — so a caller-owned
+accessor getter cannot return a safe value at validation and a different one at
+commit (TOCTOU). So raw material in its natural shape (free-form text —
+whitespace, uppercase, sentence punctuation), an over-long value (e.g. a 1 MB
+replay key), a payload-shaped extra field (enumerable or not), or a denylisted
+marker is **rejected fail-closed with zero ledger/audit/recall residue** — not
+stored.
+
+> This validation is a **defense-in-depth floor, not an exhaustive raw-material
+> classifier**: a deliberately snake-cased short token that is off the denylist
+> would pass the shape check. That is acceptable because the **only** caller (the
+> route) builds the transition from fixed synthetic constants and never from
+> request material (Phase 33P §8) — request-controlled data never reaches a
+> ledger field. The validation hardens the seam against accidental/raw input; it
+> does **not** claim to recognize every conceivable raw string and is **not** an
+> exhaustive raw-material classifier.
+
+> **Scope of the safety claim.** The hardening described here is **spike-scoped
+> and bounded to this synthetic ledger proof** — bounded capacity validated at
+> creation, tenant+estate scoping with immutable bound scopes, synthetic-only
+> ingress validation, and detached/frozen reads. It is **not** a claim of
+> production safety. Final production tenant/estate/actor identity binding,
+> idempotency semantics, signer/authority, schema, receipt semantics, durable
+> storage, and production readiness all remain **unresolved** (Phase 33P §8, §12)
+> and are **out of scope** for this phase.
+
+It is exposed **only** on the internal spike service barrel
+(`admission-wedge-spike/index.ts`). It is **not** re-exported from any package
+entrypoint and adds **no** package export (Phase 33P §8).
+
+### Operational-property precedent, not reuse
+
+The ledger mirrors **only the operational properties** of the Recall-path
+bounded estate store (process-local, capacity-bounded, tenant/estate-scoped,
+non-durable, fail-closed, testable without production storage — Phase 33P §6).
+It reuses **no** Recall code, type, adapter, or schema, imports **nothing** from
+`straylight-recall-intake/`, and inherits **no** Recall semantics. Its identity /
+status / provenance / receipt semantics remain governed by the still-unresolved
+Straylight primitive review (A–O). This phase freezes **no** schema and decides
+**no** final idempotency / signer / authority / tenant-estate-actor binding
+semantics (Phase 33P §8, §12).
+
+## 2. Implementation boundary
+
+| Decision | Choice |
+|----------|--------|
+| Reachability | **Test-seam-only.** The ledger is injected only via the route's optional DI fields in tests. |
+| `server.ts` wiring | **None.** `server.ts` is not changed; it injects no ledger. Production stays exactly the Phase 33N no-store Option A path. |
+| Env flag | **None.** No `DIXIE_ADMISSION_STORE_SEAM_ENABLED` (or any) flag is added. The ledger cannot be enabled at runtime. |
+| Durable storage | **None.** No DB, file, socket, timer, or migration. |
+| Tenant/estate binding | **Tenant + estate bound (spike isolation).** Every read/write is bound to BOTH a synthetic `tenant_id` AND `estate_id`; an estate is owned by exactly one tenant for the process life. A foreign-tenant read returns empty; a foreign-tenant write and a conflicting reseed fail closed. A scoped view (`forEstate`) **snapshots an immutable, frozen, closure-owned scope** at construction, so mutating the caller's original scope object afterward cannot re-home the view to a different tenant/estate. **Not** the final production binding semantics (still unresolved, Phase 33P §12). |
+| Capacity config | **Validated once at creation; caps then closure-owned.** Both caps must be finite, positive integers within a dev/test ceiling; `Infinity`, `NaN`, zero, negative, fractional, non-number, and over-ceiling values are rejected. The validated numeric limits are copied into a **frozen, closure-owned** constant and the caller-owned config object is **never read again**, so mutating it to `Infinity` after construction cannot widen a configured cap. The byte budget accounts for **all** retained synthetic metadata, **including retained replay keys + fingerprints**. |
+| Raw candidate payload | **Rejected at ingress (spike-scoped), not merely undeclared.** No record type has a payload field, AND every accepted field is validated to a bounded synthetic shape before mutation: plain-record check, **exact own-key set via `Reflect.ownKeys`** (rejecting non-enumerable / symbol-keyed / inherited extra fields), unsafe-marker rejection, and length cap. Fields are snapshotted once (TOCTOU-safe). Raw/unsafe input fails closed with zero residue. This is a **defense-in-depth floor**, not an exhaustive raw-material classifier. |
+| Returned reads | **Detached and frozen.** `auditTrail()` returns frozen, detached copies of the audit records (not live internal references); `inspectEstate()` and `projectRecall()` return freshly-built, frozen objects/arrays. Mutating any returned value cannot alter internal ledger state. Internal records are also frozen at creation as defense-in-depth. |
+| Public response | **Unchanged.** Still produced by `buildAdmissionSpikePublicResponse`; ledger ids/audit never enter the public body. |
+| Idempotency semantics | **Spike-scoped only.** `idempotency_final` stays `false`; final production semantics remain UNRESOLVED (Phase 33P §12). |
+
+When **no** ledger is injected (the production/server default), the route is
+**byte-equivalent** to Phase 33N Option A.
+
+## 3. Files
+
+**Created**
+- `app/src/services/admission-wedge-spike/admitted-assertion-ledger.ts` — the ledger.
+- `app/tests/unit/admission-wedge-spike/admitted-assertion-ledger.test.ts` — unit proofs.
+- `app/tests/integration/admission-intake/store-coupled.test.ts` — route-DI-seam proofs.
+- `docs/admission-wedge/PHASE-33Q-DEV-STORE-RUNBOOK.md` — this runbook.
+
+**Modified (additive only)**
+- `app/src/services/admission-wedge-spike/index.ts` — internal-barrel exports for the ledger (no package export).
+- `app/src/routes/admission-intake.ts` — optional DI fields (`admittedAssertionLedger`, `admittedAssertionTenantId`, `admittedAssertionEstateId`), a route-local `synthTransitionFor()` helper deriving a synthetic transition from the classification + fixed synthetic constants, and a guarded `record({ tenant_id, estate_id }, transition)` call inside the **existing** `beforeFinalize` partial-failure try/catch. The write is attempted only when a ledger AND the full synthetic (tenant, estate) scope are injected; a partial injection records nothing. Default (no ledger) behavior is unchanged.
+
+**Not changed:** `server.ts`, `config.ts`, `package.json`, lockfiles, CI, migrations, fixture JSON, route-vector JSON, validators, generated files, scope guards.
+
+## 4. Ledger API (synthetic only)
+
+All reads and writes take a `{ tenant_id, estate_id }` **scope** — there is no
+estate-only access path. The capacity config is validated at creation.
+
+```
+createAdmittedAssertionLedger({ maxAssertionsPerEstate, maxAssertionBytesPerEstate })
+  // ↑ both caps validated: finite, positive, integer, dev-bounded
+  seedEstate({ tenant_id, estate_id })                     // idempotent per (tenant,estate); reseed under a different tenant fails closed
+  record({ tenant_id, estate_id }, SyntheticAdmissionTransition) // admit | supersede; validates input then fail-closed throws
+  forEstate({ tenant_id, estate_id }) -> ScopedAdmittedView      // bound to BOTH tenant and estate
+  projectRecall({ tenant_id, estate_id }) -> { includes, excludes }  // empty for unseeded/foreign-tenant
+  inspectEstate({ tenant_id, estate_id }) -> { assertions, bytes }   // zeros for unseeded/foreign-tenant
+  auditTrail({ tenant_id, estate_id }) -> readonly SyntheticAuditRecord[]  // empty for unseeded/foreign-tenant
+```
+
+Errors (all fail-closed, public-safe messages with no long/opaque ids and no
+echo of the rejected value):
+`AdmittedAssertionCapExceededError`, `AdmittedAssertionScopeViolationError`
+(reasons `unseeded_estate` / `prior_not_in_estate` / `foreign_tenant`),
+`AdmittedAssertionReplayConflictError`, `AdmittedAssertionTenantConflictError`
+(reseed under a different tenant), `AdmittedAssertionInvalidConfigError`
+(bad capacity config at creation), and `AdmittedAssertionInvalidInputError`
+(non-synthetic / payload-shaped / over-long / unsafe-marker field, or invalid
+transition kind / extra field).
+
+`SyntheticAdmittedAssertion` status is canonical-aligned `active` / `superseded`
+— **never** a coined `admitted` status. `SyntheticAuditRecord` carries **both**
+`audit_private: true` **and** `public_audit_detail: false` (Phase 33P §10).
+
+## 5. Phase 33P §9 proof-case → test mapping
+
+| §9 proof case | Where proven | Test(s) |
+|---------------|--------------|---------|
+| 1. Accept → admitted assertion exists | unit + integration | unit "accept mints one active…"; integration "accept records internally…" |
+| 2. Carries status / provenance / receipt-like audit | unit | unit "attaches a synthetic … audit record with BOTH privacy markers" |
+| 3. Pending stays not-admitted / not-recallable | integration | integration "pending records nothing and is not recallable" |
+| 4. Reject creates nothing, not recallable | integration | integration "reject records no admitted assertion" |
+| 5. Malformed fails closed, creates nothing | integration | integration "malformed fails closed before the ledger is reached" |
+| 6. Supersession repoints recall, preserves prior | unit + integration | unit "marks prior superseded … corrected active"; integration "supersede … repoints recall" |
+| 7. No-leak over the public response | unit + integration | every integration test asserts `findAdmissionPublicLeaks(body) === []` + wire-id sweep; existing `route-gate.test.ts` proves the guarded send path is unchanged |
+| 8. Bounded-store safety (10 bullets) | mostly unit | see §6 |
+| 9. Receipt/audit explains, not a production receipt | unit | unit "BOTH privacy markers"; public body keeps `production_admission:false` etc. (built by the unchanged public-response path) |
+
+> Note: the public response schema and its draft markers
+> (`production_admission`, `schema_final`, `idempotency_final`,
+> `straylight_primitive_review_complete`, …) are produced by the **unchanged**
+> Phase 33N `buildAdmissionSpikePublicResponse` path and remain `false` on every
+> route response — the integration tests assert the body is byte-identical to the
+> no-ledger Option A path, so those non-claims are preserved by construction.
+
+## 6. Phase 33P §9 case-8 bounded-store safety proof mapping (10 bullets)
+
+| Bullet | Layer | Test |
+|--------|-------|------|
+| tenant/estate isolation | unit | "keeps one estate's admitted assertions unreachable from another"; "one-estate flood … cannot starve another"; **tenant binding:** "re-seeding the SAME estate_id under a DIFFERENT tenant fails closed"; "a foreign tenant cannot READ another tenant's estate"; "a foreign tenant cannot WRITE into another tenant's estate"; "the scoped view is tenant- AND estate-bound"; **immutable bound scope (Codex blocker 1):** "READ: mutating the original scope object after forEstate() does not change what the view reads"; "WRITE: … does not redirect writes to B/B"; "WRITE fails closed per A/A state (not B/B)" |
+| capacity-limit failure behavior | unit | "assertion-count overflow throws with dimension/cap/observed"; "byte-budget overflow throws"; **strict config:** "rejects an Infinity assertion/byte cap"; "rejects a NaN cap"; "rejects zero, negative, fractional, and over-ceiling caps"; "rejects a non-number cap"; **closure-owned caps (Codex blocker 2):** "mutating both caps to Infinity AFTER construction does not relax the configured cap of one"; "mutating the byte cap to Infinity AFTER construction does not relax the original byte budget"; **replay accounting:** "retained replay metadata contributes to the byte budget"; "a write whose retained replay key would breach the byte budget fails closed" |
+| atomic partial-failure handling | unit | "a pre-mutation failure leaves NO partially-admitted residue"; "a failed supersession leaves the prior active" |
+| no partially admitted residue | unit | same atomic partial-failure tests + synthetic-only "rejects … with zero residue" tests (assertion count + audit length unchanged) |
+| no residual recallable state after failed writes | unit | atomic partial-failure tests assert `projectRecall` unchanged |
+| synthetic-only input / no raw material persisted | unit | "rejects an unsafe marker in any accepted field, with zero residue"; "rejects payload-shaped values …"; "rejects a payload-shaped EXTRA field"; "rejects an over-long field (e.g. a 1 MB string)"; "rejects an out-of-shape … identity label"; "rejects an invalid transition kind"; "rejects a malformed scope"; "no raw payload / unsafe marker survives a rejected transition in audit or inspection output"; **plain-record / exact-key (Codex blocker 4):** "rejects a … NON-ENUMERABLE candidate_payload"; "rejects a … INHERITED candidate_payload"; "rejects a … SYMBOL own key"; "rejects a transition carried on an UNEXPECTED prototype (class instance)"; "rejects an array, Date, and Map"; "accepts a legitimate null-prototype plain record"; "an accessor getter cannot return a safe value at validation and a different one at commit (TOCTOU)" |
+| returned reads detached from internals (Codex blocker 3) | unit | "mutating a returned audit record with unsafe_marker:raw-candidate does not persist internally"; "mutating a returned audit record with a 1 MB value does not change internal footprint/bytes"; "mutating returned audit_private/public_audit_detail does not flip the internal privacy markers"; "pushing onto the returned audit array does not grow the internal trail"; "inspectEstate() / projectRecall() return detached objects" |
+| replay without duplicate minting | unit + integration | unit "replaying the SAME synthetic transition mints no duplicate"; integration "replaying the same accept does not mint a duplicate" |
+| conflicting replay fails closed | unit only | "a CONFLICTING replay … fails closed, original intact"; "a fresh replay key minting over an existing synthetic id is a conflict" — **not reachable via the route** (route emits an identical fixed transition per scenario; conflict is unit-only) |
+| process-local ephemerality | unit | "a freshly-created ledger is empty …" |
+| process restart leaves no durable residue | unit | "a freshly-created ledger is empty (no durable … residue survives a restart)" |
+| identity/status/provenance observable WITHOUT raw payload persistence | unit | "exposes id, active status, and provenance link while storing NO raw payload" |
+
+## 7. No-leak discipline
+
+- The **public response** is unchanged and still finalized through the single
+  guarded `sendPublicResponse` → `findAdmissionPublicLeaks` path; the ledger's
+  ids and private audit records are **never** placed in the public body.
+- `findAdmissionPublicLeaks` is applied **only** to the public projection
+  (`projectRecall` placeholder/synthetic-id output) and to error-message
+  strings — **never** to a raw `SyntheticAdmittedAssertion` / `auditTrail()` /
+  `inspectEstate()` value, because those **private** records legitimately carry
+  forbidden public KEYS (`admitted_assertion_id`, `source_candidate_id`, …). The
+  private records are guarded instead by a substring/payload-field assertion
+  (no `unsafe_marker:`, no `candidate_payload`, no `source_ref`).
+- All returned reads are **detached and frozen**: `auditTrail()` returns frozen,
+  detached copies of each record (never live internal references), and
+  `inspectEstate()` / `projectRecall()` return freshly-built, frozen
+  objects/arrays. Mutating a returned value — injecting an `unsafe_marker`, a
+  1 MB string, or flipping `audit_private` / `public_audit_detail` — cannot reach
+  or alter internal ledger state. The internal records are frozen at creation as
+  defense-in-depth, and a supersession **replaces** the prior with a fresh frozen
+  object rather than mutating it in place.
+- Ledger error messages use short synthetic labels only — no UUID and no
+  unbroken alphanumeric run of **24 or more** characters (`no-leak.ts`
+  `MAX_OPAQUE_RUN = 24`), so even an accidental surfacing stays public-safe.
+  Rejection errors carry a fixed safe field token and a short reason; they
+  **never echo the rejected value**, so even an unsafe/raw input leaves no trace
+  in the error.
+- Because every accepted field is validated to a bounded synthetic shape (no
+  unsafe markers, no payload-shaped extra fields, length-capped) **before**
+  mutation, the **private** records cannot carry raw candidate payload, source
+  material, or an unsafe marker in the first place — the no-raw-material property
+  of the private surface is enforced at ingress, not merely asserted afterward.
+
+## 8. Idempotency boundary (spike-scoped only)
+
+The replay/de-duplication and conflicting-replay proofs are **spike-scoped**
+(Phase 33P §12). Replaying the **same** synthetic transition returns the prior
+result and mints **no** duplicate; a **conflicting** replay **fails closed**.
+This proves the bounded transition property only; it **does not** settle final
+production idempotency semantics (candidate-id-keyed vs header-keyed, key scope),
+which remain **explicitly unresolved**. `idempotency_final` stays `false`.
+
+## 9. Validation commands
+
+```bash
+cd app && npm run typecheck
+cd app && npm run lint
+cd app && npx vitest run tests/unit/admission-wedge-spike/
+cd app && npx vitest run tests/unit/admission-wedge-spike/scope-guards.test.ts
+cd app && npx vitest run tests/integration/admission-intake/
+node docs/admission-wedge/fixtures/validate-fixtures.mjs
+node docs/admission-wedge/route-contract-test-vectors/validate-route-contract-test-vectors.mjs
+git diff --check
+```
+
+The existing `scope-guards.test.ts` runs **unchanged** and must pass — it scans
+the new ledger source for forbidden imports (no Freeside, no `@loa/straylight`,
+no `straylight-recall-intake` `-store` import) and durable-write tokens, and
+proves the spike adds no package export.
+
+## 10. Blocked lanes preserved
+
+Phase 33Q does **not** authorize, implement, or bring nearer any of: production
+admission; durable production Admission Wedge storage; production database
+migrations; production auth/consent; public `remember-this`; Discord command/
+history ingestion; user chat becoming memory; Freeside Characters runtime/client
+integration; package exports; LLM/voice; Finn production wiring; forget/revoke/
+correction UI; final schema freeze; production route deployment; a completed
+Straylight primitive-review claim; final idempotency semantics; production
+signer/authority semantics; production tenant/estate/actor identity binding; a
+final route contract; or production implementation readiness. The carried-forward
+unresolved review rows (E, G, H, K, N, O) and review-dependent row (J) stay
+unresolved — this phase **reads** them, it does not resolve them.
+
+## 11. Next decision lane
+
+The next lane after Phase 33Q should be an **acceptance / hardening gate** for
+this synthetic ledger slice (mirroring the 33N → 33O acceptance pattern) —
+**not** a production rollout. Production durable Admission Wedge storage remains
+blocked behind the Straylight primitive review (A–O), the held ADR-022E
+durable-store gate, a final route contract, and production auth/consent, and
+requires its own separately-named gate.


### PR DESCRIPTION
## Summary

Phase 33Q adds the Admission Wedge dev/operator-only bounded admitted assertion ledger.

This is a non-production implementation slice under the Phase 33P storage / receipt hardening decision gate. It proves a process-local, bounded, synthetic admitted-assertion ledger through the existing Admission Wedge route dependency-injection seam and tests.

The ledger is test-seam-only. `server.ts` is not wired. No env flag is added. No production runtime behavior is enabled.

## Files

Created:

- `app/src/services/admission-wedge-spike/admitted-assertion-ledger.ts`
- `app/tests/unit/admission-wedge-spike/admitted-assertion-ledger.test.ts`
- `app/tests/integration/admission-intake/store-coupled.test.ts`
- `docs/admission-wedge/PHASE-33Q-DEV-STORE-RUNBOOK.md`

Modified:

- `app/src/services/admission-wedge-spike/index.ts`
- `app/src/routes/admission-intake.ts`

## Implementation

The new ledger is:

- process-local only
- Map-backed
- synthetic only
- tenant + estate scoped
- capacity bounded
- non-durable
- fail-closed
- route-DI-only
- not wired through `server.ts`
- not enabled by config or env
- not exported as a package surface

It tracks synthetic admitted assertions and private audit records without persisting raw candidate payloads.

The admission route receives optional ledger DI fields. With no ledger injected, behavior remains the Phase 33N Option A no-store path. When injected by tests, accepted/superseded outcomes record synthetic admitted assertion state internally, but public responses remain produced by the existing public response path and ledger return values are discarded.

## Proof coverage

Phase 33Q proves the Phase 33P proof contract:

- accepted candidate creates/references a synthetic admitted assertion
- admitted assertion has status/provenance/private receipt-like audit record
- pending remains not admitted and not recallable
- rejected creates no admitted assertion and is not recallable
- malformed fails closed before ledger and creates no admitted assertion
- supersession points ordinary recall toward corrected active assertion while preserving prior audit/provenance
- public response does not leak private/source/debug/operational fields
- receipt/audit explains what happened without becoming a production receipt claim

Bounded-ledger safety coverage includes:

- tenant/estate isolation
- conflicting same-estate/different-tenant reseed fail-closed behavior
- same-estate/different-tenant foreign read/write denial
- finite cap validation
- replay metadata byte accounting
- oversized replay key rejection
- atomic partial-failure behavior
- no partially admitted residue
- no residual recallable state after failed writes
- replay without duplicate assertion minting
- conflicting replay fail-closed behavior
- process-local ephemerality
- restart/no durable residue proof
- identity/status/provenance observable without raw payload persistence

Additional adversarial hardening covers:

- immutable scope snapshots for scoped views
- post-construction config mutation resistance
- detached/frozen audit, inspection, and projection outputs
- exact-key validation with `Reflect.ownKeys()`
- symbol-key rejection
- non-enumerable payload-key rejection
- inherited payload-key rejection
- unexpected prototype rejection
- accessor/TOCTOU snapshot behavior
- independent privacy-marker mutation tests
- per-rejected-input zero-residue tests

## Explicit non-goals

This PR does not authorize or implement:

- production admission
- durable Admission Wedge storage
- database writes
- migrations
- production auth/consent
- public remember-this
- Discord command/history ingestion
- user chat becoming memory
- Freeside Characters runtime/client integration
- package exports
- LLM/voice
- Finn production wiring
- forget/revoke/correction UI
- final schema freeze
- production route deployment
- completed Straylight primitive review
- final idempotency semantics
- production signer/authority semantics
- production tenant/estate/actor identity binding
- final route contract
- production readiness

## Validation

Local validation passed:

- `git diff --check`
- focused ledger unit test: 58/58
- admission-wedge unit tests: 165/165
- unchanged scope guards: 17/17
- typecheck
- lint
- admission-intake integration tests: 47/47
- full app suite: 2874 passed, 22 skipped
- Phase 33E fixture validator: 5/5
- Phase 33L route-vector validator: 5/5, no sixth vector

## Codex audit

Codex returned PATCH multiple times and the implementation was hardened accordingly.

Resolved blockers included:

- tenant isolation missing
- capacity bounding incomplete
- synthetic-only/raw-payload safety incomplete
- mutable scoped view rebinding
- externally mutable cap config
- mutable returned audit records
- incomplete exact-key validation
- incomplete privacy-marker mutation proof
- incomplete per-input zero-residue proof

Final Codex focused re-audit verdict:

- ACCEPT

Codex confirmed no required patches and no file:line concerns.
