### PR TITLE
fix: mirror Admission Wedge no-leak keys

### DIFF
--- a/app/src/services/admission-wedge-spike/no-leak.ts
+++ b/app/src/services/admission-wedge-spike/no-leak.ts
@@ -10,6 +10,21 @@
 // dependency-free runtime module — the docs validator is NOT imported into
 // runtime (it stays Node-built-ins-only, docs-bound), per Phase 33M §10.
 //
+// Phase 46P — runtime forbidden-key parity restoration (authorized by Phase 46O
+// / PR #160). Phases 33Z and 46J hardened the docs validator's
+// FORBIDDEN_PUBLIC_KEYS to 114 keys, but the runtime mirror still carried only
+// the original 52, leaving a 62-key drift (25 Phase 33Z TransitionReceipt /
+// AuditEvent / signer / metadata key names + 37 Phase 46J canonical ref/hash /
+// consent / auth key names). That drift was latent debt, not a live leak — the
+// fixed public-response builder emits an 8-field allowlist containing none of
+// the missing keys — but the mirror is now brought back to exact parity so a
+// future durable-store serializer cannot surface a canonical ref/hash/consent
+// field under a short, safe-looking value that would slip the value-pattern
+// walls. The additions are EXACT-key only (Set.has) and snake_case + camelCase,
+// so legitimate request draft markers (`consent_assumption`, `auth_assumption`,
+// `consent_scope_assumption`, `consent_note_draft`, …) that merely share a
+// prefix are NOT over-matched. No substring/prefix matching is introduced.
+//
 // `findAdmissionPublicLeaks` deep-walks any public response object and returns
 // a list of human-readable leak findings (empty when clean). The route uses it
 // as a last-line assertion before serializing a public body; the tests use it
@@ -39,7 +54,42 @@ const FORBIDDEN_PUBLIC_KEYS = new Set<string>([
   'policy_reason',
   'private_reason_family',
   'receipt_id',
+  'receiptId',
   'audit_receipt_ref',
+  // Phase 33Z private `TransitionReceipt` / `AuditEvent` / private-receipt shapes
+  // (mirrors the Phase 33L validator). Only the public-safe `public_receipt_ref`
+  // (and its `null`) may cross to the public surface; the private TransitionReceipt,
+  // the AuditEvent (incl. its class), the private/internal receipt reference, the
+  // transition id, signer/signature material, opaque policy detail, and a raw
+  // `metadata` bag must NEVER appear publicly. snake_case + camelCase both forbidden
+  // so a serializer rename cannot leak.
+  'transition_receipt',
+  'transitionReceipt',
+  'transition_receipt_ref',
+  'transitionReceiptRef',
+  'transition_id',
+  'transitionId',
+  'audit_event',
+  'auditEvent',
+  'audit_event_class',
+  'auditEventClass',
+  'audit_ref',
+  'auditRef',
+  'audit_id',
+  'auditId',
+  'receipt_ref',
+  'receiptRef',
+  'private_receipt_ref',
+  'privateReceiptRef',
+  'signer',
+  'signature',
+  'policy_details',
+  'policyDetails',
+  'metadata',
+  // `receipt_public_ref` is retired from the public envelope by Phase 33V/33X/33Y
+  // (the public field is now `public_receipt_ref`); it must never appear on a
+  // route public surface.
+  'receipt_public_ref',
   'idempotency_key',
   'idempotency_key_draft',
   'authority_signer_type_draft',
@@ -73,6 +123,55 @@ const FORBIDDEN_PUBLIC_KEYS = new Set<string>([
   'stack_traces_debug_internals',
   'storage_internals',
   'storage_internal',
+  // Phase 46J consent/storage canonical key-name hardening (mirrors the Phase 33L
+  // validator). The exact canonical key names a future durable-store serializer must
+  // never surface publicly, in snake_case AND camelCase. EXACT-key match only — the
+  // legitimate request draft markers `consent_assumption` / `auth_assumption` (and
+  // siblings like `consent_scope_assumption` / `consent_note_draft`) are NOT exact
+  // matches for the bare `consent` / `auth_decision` keys and stay allowed.
+  //   (a) canonical Straylight Assertion ref arrays.
+  'supersedes_refs',
+  'supersedesRefs',
+  'linked_assertion_refs',
+  'linkedAssertionRefs',
+  //   (b) canonical TransitionReceipt / AuditEvent private refs + hash-chain links.
+  'signer_refs',
+  'signerRefs',
+  'audit_event_ref',
+  'auditEventRef',
+  'receipt_hash',
+  'receiptHash',
+  'audit_hash',
+  'auditHash',
+  'previous_audit_hash',
+  'previousAuditHash',
+  'policy_decision_ref',
+  'policyDecisionRef',
+  'assertion_refs',
+  'assertionRefs',
+  'target_refs',
+  'targetRefs',
+  //   (c) canonical candidate-subject mapping (subject maps to canonical subject_refs,
+  //       never a coined subject_actor_id).
+  'subject_refs',
+  'subjectRefs',
+  //   (d) consent / auth-decision key-name family. Bare `consent` / `auth_decision`
+  //       are forbidden by EXACT match only.
+  'consent',
+  'consent_ref',
+  'consentRef',
+  'consent_proof',
+  'consentProof',
+  'consent_receipt',
+  'consentReceipt',
+  'consent_subject',
+  'consentSubject',
+  'consent_grantor',
+  'consentGrantor',
+  'consent_scope',
+  'consentScope',
+  'auth_decision',
+  'authDecision',
 ]);
 
 /** Negative-assertion keys: legitimate ONLY as the boolean literal `false`. */

--- a/app/tests/unit/admission-wedge-spike/no-leak.test.ts
+++ b/app/tests/unit/admission-wedge-spike/no-leak.test.ts
@@ -4,7 +4,14 @@
 // any depth — and passes clean public-safe bodies.
 
 import { describe, expect, it } from 'vitest';
-import { findAdmissionPublicLeaks, isAdmissionPublicSafe } from '../../../src/services/admission-wedge-spike/index.js';
+import {
+  findAdmissionPublicLeaks,
+  isAdmissionPublicSafe,
+  classifyAdmissionSpike,
+  buildAdmissionSpikePublicResponse,
+  ADMISSION_SPIKE_BODY_MARKER,
+  ADMISSION_TRANSITION_INTENTS,
+} from '../../../src/services/admission-wedge-spike/index.js';
 
 describe('Phase 33N — findAdmissionPublicLeaks (runtime no-leak baseline)', () => {
   it('passes a clean public-safe body', () => {
@@ -76,5 +83,128 @@ describe('Phase 33N — findAdmissionPublicLeaks (runtime no-leak baseline)', ()
   it('walks arrays and deeply nested objects', () => {
     const deep = { a: { b: [{ c: { tenant_id: '0xabc' } }] } };
     expect(findAdmissionPublicLeaks(deep).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 46P — runtime forbidden-key parity with the Phase 33L route-contract
+// validator (authorized by Phase 46O / PR #160).
+// ---------------------------------------------------------------------------
+//
+// The runtime mirror had drifted to 52 keys while the docs validator's
+// FORBIDDEN_PUBLIC_KEYS reached 114 (Phases 33Z + 46J). Phase 46P restores exact
+// parity by adding the 62 missing keys. The list below is the documented Phase
+// 46O 62-key gap (validator MINUS runtime), COPIED here as a local test fixture —
+// the runtime no-leak module exports no key set and the docs validator is never
+// imported into runtime, so there is no package/export/config change. Each key
+// is proven to FAIL CLOSED when surfaced on a public body; the exact-key
+// no-overmatch guards prove the additions do not reject legitimate
+// prefix-sharing request draft markers.
+describe('Phase 46P — runtime forbidden-key parity (62 mirrored keys fail closed)', () => {
+  // The 62 keys Phase 46P mirrored from the validator (25 Phase 33Z + 37 Phase
+  // 46J). Copied verbatim from the Phase 46O gap analysis (validator − runtime).
+  const PHASE_46P_MIRRORED_KEYS = [
+    // Phase 33Z — TransitionReceipt / AuditEvent / signer / metadata key names.
+    'receiptId',
+    'transition_receipt', 'transitionReceipt',
+    'transition_receipt_ref', 'transitionReceiptRef',
+    'transition_id', 'transitionId',
+    'audit_event', 'auditEvent',
+    'audit_event_class', 'auditEventClass',
+    'audit_ref', 'auditRef',
+    'audit_id', 'auditId',
+    'receipt_ref', 'receiptRef',
+    'private_receipt_ref', 'privateReceiptRef',
+    'signer', 'signature',
+    'policy_details', 'policyDetails',
+    'metadata',
+    'receipt_public_ref',
+    // Phase 46J — canonical ref/hash + consent/auth key-name family.
+    'supersedes_refs', 'supersedesRefs',
+    'linked_assertion_refs', 'linkedAssertionRefs',
+    'signer_refs', 'signerRefs',
+    'audit_event_ref', 'auditEventRef',
+    'receipt_hash', 'receiptHash',
+    'audit_hash', 'auditHash',
+    'previous_audit_hash', 'previousAuditHash',
+    'policy_decision_ref', 'policyDecisionRef',
+    'assertion_refs', 'assertionRefs',
+    'target_refs', 'targetRefs',
+    'subject_refs', 'subjectRefs',
+    'consent',
+    'consent_ref', 'consentRef',
+    'consent_proof', 'consentProof',
+    'consent_receipt', 'consentReceipt',
+    'consent_subject', 'consentSubject',
+    'consent_grantor', 'consentGrantor',
+    'consent_scope', 'consentScope',
+    'auth_decision', 'authDecision',
+  ];
+
+  it('the mirrored gap fixture is exactly the documented 62 keys (25 + 37), no dupes', () => {
+    expect(PHASE_46P_MIRRORED_KEYS).toHaveLength(62);
+    expect(new Set(PHASE_46P_MIRRORED_KEYS).size).toBe(62);
+  });
+
+  describe('every newly mirrored key fails closed on the public surface', () => {
+    // Exhaustive, mechanically verified coverage over the entire mirrored set.
+    // A short, safe-LOOKING value is used so the finding is attributable to the
+    // KEY-NAME check (Set.has), not to a value-pattern / UUID / opaque-run wall.
+    for (const key of PHASE_46P_MIRRORED_KEYS) {
+      it(`flags "${key}" on the public surface (top-level)`, () => {
+        const leaks = findAdmissionPublicLeaks({ outcome_class: 'admitted', [key]: 'safe_draft' });
+        expect(leaks.length).toBeGreaterThan(0);
+        expect(leaks.join(' ')).toContain(`forbidden public key "${key}"`);
+        expect(isAdmissionPublicSafe({ [key]: 'safe_draft' })).toBe(false);
+      });
+
+      it(`flags "${key}" nested at any depth`, () => {
+        const deep = { spike: 'dev_operator_only_non_production', a: { b: [{ c: { [key]: 'safe_draft' } }] } };
+        const leaks = findAdmissionPublicLeaks(deep);
+        expect(leaks.length).toBeGreaterThan(0);
+        expect(leaks.join(' ')).toContain(`forbidden public key "${key}"`);
+      });
+    }
+  });
+
+  describe('exact-key matching: legitimate prefix-sharing draft markers are NOT over-matched', () => {
+    // These request draft markers SHARE a prefix with a newly mirrored bare key
+    // (`consent` / `auth_decision`) but are not exact matches, so they must stay
+    // allowed. Values are public-safe draft markers.
+    const ALLOWED_PREFIX_SHARING_KEYS: Record<string, string> = {
+      consent_assumption: 'draft_non_implemented',
+      consent_scope_assumption: 'draft_non_implemented',
+      consent_note_draft: 'dev_only_marker_draft',
+      auth_assumption: 'draft_non_implemented',
+    };
+    for (const [key, value] of Object.entries(ALLOWED_PREFIX_SHARING_KEYS)) {
+      it(`allows "${key}" (exact-key, not over-matched)`, () => {
+        expect(findAdmissionPublicLeaks({ [key]: value })).toEqual([]);
+        expect(isAdmissionPublicSafe({ [key]: value })).toBe(true);
+      });
+    }
+
+    it('allows a request-shaped surface carrying all four prefix-sharing markers at once', () => {
+      const requestSurface = {
+        route_exists: false,
+        storage_assumption: 'draft_no_write_performed',
+        ...ALLOWED_PREFIX_SHARING_KEYS,
+      };
+      expect(findAdmissionPublicLeaks(requestSurface)).toEqual([]);
+    });
+  });
+
+  describe('public-safe builder output stays clean after the parity hardening', () => {
+    // Proves the real public-response builder — which emits a fixed 8-field
+    // allowlist — still passes the now-114-key runtime guard for all five
+    // scenarios (no false positive from the newly mirrored keys).
+    for (const intent of Object.values(ADMISSION_TRANSITION_INTENTS)) {
+      it(`scenario intent "${intent}" → clean public body`, () => {
+        const c = classifyAdmissionSpike({ spike: ADMISSION_SPIKE_BODY_MARKER, transition_intent: intent });
+        const body = buildAdmissionSpikePublicResponse(c);
+        expect(findAdmissionPublicLeaks(body)).toEqual([]);
+        expect(isAdmissionPublicSafe(body)).toBe(true);
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Phase 46P implements the bounded runtime Admission Wedge `no-leak.ts` exact-key mirror hardening slice authorized by Phase 46O / PR #160.

This slice brings runtime forbidden-key membership to parity with the route-vector validator forbidden-key membership.

## Files

Modified:

- app/src/services/admission-wedge-spike/no-leak.ts
- app/tests/unit/admission-wedge-spike/no-leak.test.ts

No other files are changed.

## Scope

This PR does not change:

- route handlers
- storage implementation
- migrations
- DB code
- auth or consent implementation
- route-vector JSON
- route-vector validator
- route-vector README
- Phase 33E fixture JSON / validator
- package files
- lockfiles
- config/env
- CI
- generated files
- binaries
- adjacent repos
- docs

## Runtime no-leak parity

Runtime `FORBIDDEN_PUBLIC_KEYS` now matches the route-vector validator:

- validator forbidden keys: 114
- runtime forbidden keys: 114
- validator minus runtime: 0
- runtime minus validator: 0

The implementation adds the 62 runtime-missing keys identified by Phase 46O:

- 25 Phase 33Z TransitionReceipt / AuditEvent / signer / metadata hardening keys
- 37 Phase 46J canonical / consent hardening keys

Runtime still uses exact-key `Set.has` matching. No substring, prefix, category, or broad regex matching was added for these exact keys.

## Tests

The matching runtime no-leak test file was extended in place.

New coverage includes:

- a 62-key local fixture for the Phase 46O runtime gap;
- uniqueness check for the 62-key fixture;
- exhaustive fail-closed coverage for every newly mirrored key;
- top-level and nested-at-depth fail-closed assertions for all 62 keys;
- exact-key no-overmatch guards for:
  - `consent_assumption`
  - `consent_scope_assumption`
  - `consent_note_draft`
  - `auth_assumption`
- builder-stays-clean checks proving real `buildAdmissionSpikePublicResponse` output for all five scenario intents remains public-safe under the expanded 114-key guard.

## Behavior boundary

This PR changes only the runtime no-leak forbidden-key membership.

It preserves:

- exact-key matching;
- existing substring/pattern/UUID/opaque-run walls;
- public/private guard shape;
- fail-closed behavior;
- existing exports;
- existing route-vector validator behavior.

It does not change route/API behavior except for the authorized stricter no-leak fail-closed rejection if newly mirrored forbidden keys appear in a public runtime body.

## Non-authorizations

This PR does not authorize or implement:

- durable-store implementation
- DB writes
- migrations
- route/API behavior changes beyond the bounded no-leak hardening
- auth/consent implementation
- production admission
- public remember-this
- Discord/freeform ingestion
- user chat becoming memory
- Freeside runtime/client integration
- package exports
- LLM/voice/Finn wiring
- MVP 3 forget/revoke/correction UI
- route-contract freeze
- final schema freeze
- production readiness

Direct durable-store implementation remains blocked.

## Validation

Codex final audit verdict: ACCEPT.

Codex confirmed:

- scope is exactly the two authorized files;
- runtime forbidden-key parity is exact: 114/114;
- no duplicate keys;
- the 62 added keys match the Phase 46O validator-minus-runtime set;
- runtime behavior still uses exact-key `Set.has`;
- no substring/prefix/category matching was introduced;
- existing exports are unchanged;
- fail-closed tests cover every new key top-level and nested;
- no-overmatch tests cover legitimate prefix-sharing fields;
- builder output remains public-safe across all five scenario intents;
- route-vector validators are unchanged and passing;
- durable-store implementation remains blocked.

Validation results recorded by Codex:

- `git diff --check`: pass
- `git diff --cached --check`: pass
- `node docs/admission-wedge/fixtures/validate-fixtures.mjs`: PASS — 5/5 probes valid, 0 failures
- `node docs/admission-wedge/route-contract-test-vectors/validate-route-contract-test-vectors.mjs`: PASS — 5/5 vectors valid, 0 failures, no sixth vector
- `node docs/admission-wedge/route-contract-test-vectors/validate-route-contract-test-vectors.mjs --self-check`: PASS — 44/44
- no-leak test file: 163 passed
- full `tests/unit/admission-wedge-spike/`: 300 passed
- `npm run typecheck`: clean
- touched-file ESLint: clean

## Next lane

The recommended next lane is a docs/decision acceptance gate:

- Phase 46Q runtime no-leak mirror hardening acceptance gate.

Do not proceed directly to durable-store implementation without a separate implementation-authorization gate.
