### PR TITLE
feat: add Admission Wedge route-storage spike

### DIFF
--- a/app/src/config.ts
+++ b/app/src/config.ts
@@ -113,6 +113,21 @@ export interface DixieConfig {
   /** Dev/operator id allowlist (checked against the `x-admission-operator-id`
    *  header); [] when unset. An empty token AND empty allowlist rejects all. */
   admissionIntakeSpikeOperatorIds: string[];
+
+  // Phase 46V: dev/operator-only Admission Wedge ROUTE-STORAGE spike gate
+  // (DRAFT / non-final; default OFF; NON-PRODUCTION). Authorized narrowly by
+  // Phase 46U (docs/ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md
+  // §3–§16). This is a SEPARATE gate from the base route gate: the route-storage
+  // spike does NOT activate merely because route intake is enabled — it engages
+  // ONLY when BOTH this flag AND admissionIntakeSpikeEnabled are exactly 'true'
+  // (the AND is applied at the server mount site). Storage Mode 1 only
+  // (no-migration, bounded-synthetic, in-process): NO durable write, NO DB, NO
+  // migration. The env name DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED is a
+  // DRAFT / non-final proposal (Phase 46U §5). This does NOT authorize production
+  // storage/admission/auth/consent, a final schema, or a route-contract freeze.
+  /** Phase 46V draft route-storage-spike gate (`=== 'true'`); default false.
+   *  Inert unless admissionIntakeSpikeEnabled is also true (ANDed at mount). */
+  admissionIntakeStorageSpikeEnabled: boolean;
 }
 
 /**
@@ -195,6 +210,20 @@ const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
  *                                          Empty when unset. With BOTH the token and the operator
  *                                          allowlist empty, the enabled spike rejects ALL calls
  *                                          (fail-closed; no production default).
+ *
+ * Phase 46V additions (dev/operator-only Admission Wedge ROUTE-STORAGE spike; DRAFT / non-final;
+ * default OFF; NON-PRODUCTION):
+ * DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED (optional) — when 'true', AND DIXIE_ADMISSION_INTAKE_ENABLED
+ *                                          is also 'true', wire the dev/operator-only route-storage spike
+ *                                          (Storage Mode 1: no-migration, bounded-synthetic, in-process —
+ *                                          NO durable write, NO DB, NO migration) behind the existing
+ *                                          dev/operator gate. Default 'false'; anything other than the
+ *                                          literal 'true' (incl. blank/malformed) leaves it OFF
+ *                                          (fail-closed; never a production storage path). The storage
+ *                                          spike NEVER activates on the base route gate alone. This name is
+ *                                          a DRAFT / non-final proposal (Phase 46U §5). Authorized narrowly
+ *                                          by Phase 46U; does NOT authorize production storage/admission,
+ *                                          a final schema, or a route-contract freeze.
  */
 export function loadConfig(): DixieConfig {
   const finnUrl = process.env.FINN_URL;
@@ -403,5 +432,14 @@ export function loadConfig(): DixieConfig {
       .split(',')
       .map((id) => id.trim())
       .filter((id) => id.length > 0),
+
+    // Phase 46V: dev/operator-only route-storage spike gate (DRAFT; default off,
+    // NON-PRODUCTION). Strict `=== 'true'`, so blank/malformed/any-other value is
+    // off (fail-closed; never a production storage path). This flag is inert on
+    // its own — the server only wires the storage spike when BOTH this flag AND
+    // admissionIntakeSpikeEnabled are true (ANDed at the mount site, server.ts),
+    // so storage never activates merely because route intake is enabled.
+    admissionIntakeStorageSpikeEnabled:
+      process.env.DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED === 'true',
   };
 }

--- a/app/src/routes/admission-intake.ts
+++ b/app/src/routes/admission-intake.ts
@@ -33,6 +33,7 @@ import {
   type AdmissionSpikeGateConfig,
   type AdmittedAssertionLedger,
   type SyntheticAdmissionTransition,
+  type RouteStorageSpikeStore,
 } from '../services/admission-wedge-spike/index.js';
 
 /** Header carrying the dev/operator id (checked against the allowlist). */
@@ -108,6 +109,37 @@ export interface AdmissionSpikeRouteDeps {
    *  spike request body carries NO tenant/estate/candidate ids, so the estate is
    *  a fixed synthetic dev constant (never request-derived). */
   admittedAssertionEstateId?: string;
+
+  // ── Phase 46V — dev/operator-only ROUTE-STORAGE spike seam (Storage Mode 1) ──
+  //
+  // Disabled-by-default. When undefined (the production/server default unless the
+  // separate route-storage-spike env gate is enabled), the route behaves EXACTLY
+  // as the Phase 33N no-store Option A spike / the Phase 33Q ledger-seam path. The
+  // server wires this ONLY when BOTH the base route gate AND the draft
+  // route-storage-spike gate are 'true' (config.admissionIntakeStorageSpikeEnabled
+  // ANDed with admissionIntakeSpikeEnabled at the mount site) — so storage never
+  // activates merely because route intake is enabled.
+  //
+  // It records the SAME fixed synthetic transition the ledger seam derives (built
+  // from constants, never request material), into a bounded, process-local,
+  // NON-DURABLE, tenant/estate/ACTOR-scoped store. Its records / ids are NEVER
+  // surfaced in the public body; any store throw fails closed to the same stable
+  // public-safe refusal as a partial failure. NO durable write, NO migration.
+  //
+  // The store write is attempted ONLY when the store AND the full synthetic
+  // (tenant, estate, actor) scope are all injected; a partial injection records
+  // nothing (stays the no-store path).
+  /** Phase 46V route-storage spike store (DI seam). */
+  routeStorageSpikeStore?: RouteStorageSpikeStore;
+  /** Synthetic tenant id the route-storage spike records under (fixed dev
+   *  constant; never request-derived). */
+  routeStorageSpikeTenantId?: string;
+  /** Synthetic estate id the route-storage spike records into (fixed dev
+   *  constant; never request-derived). */
+  routeStorageSpikeEstateId?: string;
+  /** Synthetic actor id the route-storage spike scopes by (fixed dev constant;
+   *  never request-derived) — the third isolation dimension (Phase 46U §10). */
+  routeStorageSpikeActorId?: string;
 }
 
 /** Fixed synthetic identity constants for the dev-only ledger seam. These are
@@ -358,6 +390,32 @@ export function createAdmissionIntakeRoutes(deps: AdmissionSpikeRouteDeps): Hono
             {
               tenant_id: deps.admittedAssertionTenantId,
               estate_id: deps.admittedAssertionEstateId,
+            },
+            transition,
+          );
+        }
+      }
+      // Phase 46V route-storage spike (Mode 1): record the SAME fixed synthetic
+      // transition into the bounded, NON-DURABLE, tenant/estate/actor-scoped
+      // store when the store AND the full synthetic scope are injected. Inside
+      // the SAME guarded try, so a store throw (capacity / scope / conflict /
+      // tombstone) collapses to the identical stable public-safe refusal and the
+      // store is left exactly as it was (atomic; no partially-admitted /
+      // recallable residue). The result is intentionally discarded — it is NEVER
+      // surfaced in the public body (step 5).
+      if (
+        deps.routeStorageSpikeStore &&
+        deps.routeStorageSpikeTenantId &&
+        deps.routeStorageSpikeEstateId &&
+        deps.routeStorageSpikeActorId
+      ) {
+        const transition = synthTransitionFor(classification);
+        if (transition) {
+          deps.routeStorageSpikeStore.record(
+            {
+              tenant_id: deps.routeStorageSpikeTenantId,
+              estate_id: deps.routeStorageSpikeEstateId,
+              actor_id: deps.routeStorageSpikeActorId,
             },
             transition,
           );

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -27,6 +27,10 @@ import { createMemoryRoutes } from './routes/memory.js';
 import { createRecallIntakeRoutes } from './routes/recall-intake.js';
 import { createAdmissionIntakeRoutes } from './routes/admission-intake.js';
 import {
+  createRouteStorageSpikeStore,
+  type RouteStorageSpikeStore,
+} from './services/admission-wedge-spike/index.js';
+import {
   createCapabilityHolder,
   createBoundedEstateStore,
   createIdempotencyCache,
@@ -117,6 +121,23 @@ export interface DixieApp {
   /** cycle-009: Async initialization promise (migration + store setup) */
   ready: Promise<void>;
 }
+
+// Phase 46V — fixed SYNTHETIC dev constants for the route-storage spike (Storage
+// Mode 1). The spike request body carries NO tenant/estate/actor/candidate ids,
+// so the storage scope is built from these constants alone — never from request
+// material. They are short synthetic labels (never UUID/long-opaque), and the
+// route-storage store ALSO validates every field to a bounded synthetic shape, so
+// no raw-payload material can enter the store. These are a SPIKE isolation
+// mechanism, NOT the final production tenant/estate/actor binding (Phase 46U §10,
+// which stays unresolved). The capacity bounds are generous dev/test ceilings,
+// far below any production scale; inserts beyond them fail closed (bounded
+// rejection, no eviction).
+const ADMISSION_ROUTE_STORAGE_SPIKE_TENANT_ID = 'tenant-synthetic-dev';
+const ADMISSION_ROUTE_STORAGE_SPIKE_ESTATE_ID = 'estate-synthetic-dev';
+const ADMISSION_ROUTE_STORAGE_SPIKE_ACTOR_ID = 'actor-synthetic-dev';
+const ADMISSION_ROUTE_STORAGE_SPIKE_MAX_ACTORS = 64;
+const ADMISSION_ROUTE_STORAGE_SPIKE_MAX_ASSERTIONS_PER_ESTATE = 256;
+const ADMISSION_ROUTE_STORAGE_SPIKE_MAX_BYTES_PER_ESTATE = 262_144;
 
 /**
  * Create and configure the Dixie BFF Hono application.
@@ -632,6 +653,50 @@ export function createDixieApp(config: DixieConfig): DixieApp {
       event: 'admission_intake_spike_active',
       note: 'dev/operator-only Admission Wedge route spike enabled — NOT production admission',
     });
+
+    // Phase 46V — dev/operator-only ROUTE-STORAGE spike (Storage Mode 1:
+    // no-migration, bounded-synthetic, in-process; NON-PRODUCTION). Disabled by
+    // default and SEPARATELY gated: it engages ONLY when BOTH the base route gate
+    // AND the draft route-storage-spike gate are enabled (the AND below), so
+    // storage never activates merely because route intake is enabled. When the
+    // storage gate is off, NO store is created and NO store deps are injected, so
+    // the route stays the Phase 33N no-store Option A path verbatim. The store
+    // opens no DB / file / socket / timer, performs NO durable write and NO
+    // migration; its synthetic state is lost on restart (no recallable residue).
+    // Authorized narrowly by Phase 46U
+    // (docs/ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md §3–§16).
+    let routeStorageSpikeDeps: {
+      routeStorageSpikeStore?: RouteStorageSpikeStore;
+      routeStorageSpikeTenantId?: string;
+      routeStorageSpikeEstateId?: string;
+      routeStorageSpikeActorId?: string;
+    } = {};
+    if (config.admissionIntakeStorageSpikeEnabled) {
+      const store = createRouteStorageSpikeStore({
+        maxActors: ADMISSION_ROUTE_STORAGE_SPIKE_MAX_ACTORS,
+        maxAssertionsPerEstate: ADMISSION_ROUTE_STORAGE_SPIKE_MAX_ASSERTIONS_PER_ESTATE,
+        maxAssertionBytesPerEstate: ADMISSION_ROUTE_STORAGE_SPIKE_MAX_BYTES_PER_ESTATE,
+      });
+      // Seed the single synthetic (tenant, estate, actor) dev slot the spike
+      // records under. These are fixed synthetic dev constants — never
+      // request-derived, never production identity binding (Phase 46U §10).
+      store.seedScope({
+        tenant_id: ADMISSION_ROUTE_STORAGE_SPIKE_TENANT_ID,
+        estate_id: ADMISSION_ROUTE_STORAGE_SPIKE_ESTATE_ID,
+        actor_id: ADMISSION_ROUTE_STORAGE_SPIKE_ACTOR_ID,
+      });
+      routeStorageSpikeDeps = {
+        routeStorageSpikeStore: store,
+        routeStorageSpikeTenantId: ADMISSION_ROUTE_STORAGE_SPIKE_TENANT_ID,
+        routeStorageSpikeEstateId: ADMISSION_ROUTE_STORAGE_SPIKE_ESTATE_ID,
+        routeStorageSpikeActorId: ADMISSION_ROUTE_STORAGE_SPIKE_ACTOR_ID,
+      };
+      log('warn', {
+        event: 'admission_intake_route_storage_spike_active',
+        note: 'dev/operator-only route-storage spike (Mode 1, non-durable, in-process) enabled — NOT production storage',
+      });
+    }
+
     app.route(
       '/api/admission/intake',
       createAdmissionIntakeRoutes({
@@ -641,6 +706,7 @@ export function createDixieApp(config: DixieConfig): DixieApp {
           operatorIds: config.admissionIntakeSpikeOperatorIds,
         },
         emitAudit: (ev) => log('info', { ...ev }),
+        ...routeStorageSpikeDeps,
       }),
     );
   }

--- a/app/src/services/admission-wedge-spike/index.ts
+++ b/app/src/services/admission-wedge-spike/index.ts
@@ -70,3 +70,23 @@ export {
   type EstateFootprint,
   type RecallProjection,
 } from './admitted-assertion-ledger.js';
+
+// Phase 46V — dev/operator-only Admission Wedge ROUTE-STORAGE spike
+// (Storage Mode 1: no-migration, bounded-synthetic, in-process; disabled-by-
+// default, NON-PRODUCTION). Authorized by Phase 46U §3–§16
+// (docs/ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md). It wraps the
+// Phase 33Q ledger to add the THIRD scope dimension (actor) — one independent
+// bounded ledger per synthetic actor — plus a reversible tombstone/cleanup path.
+// Like the rest of the spike it stays on the internal service barrel ONLY (NO
+// package export, NO `src/index.ts` re-export; Phase 33M §8 / 46U §4) and
+// performs NO durable write, NO migration, NO `@loa/straylight` / Freeside import.
+export {
+  createRouteStorageSpikeStore,
+  RouteStorageSpikeInvalidConfigError,
+  RouteStorageSpikeInvalidActorError,
+  RouteStorageSpikeActorScopeError,
+  RouteStorageSpikeActorCapExceededError,
+  type RouteStorageSpikeStore,
+  type RouteStorageSpikeConfig,
+  type RouteStorageSpikeScope,
+} from './route-storage-spike.js';

--- a/app/src/services/admission-wedge-spike/route-storage-spike.ts
+++ b/app/src/services/admission-wedge-spike/route-storage-spike.ts
@@ -1,0 +1,411 @@
+// Phase 46V — dev/operator-only Admission Wedge ROUTE-STORAGE spike
+// (Storage Mode 1: no-migration, bounded-synthetic, in-process).
+//
+// Authorized NARROWLY by the Phase 46U route-storage spike authorization gate
+// (docs/ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md §3–§16), which
+// AUTHORIZED a disabled-by-default, dev/operator-only, reversible,
+// NON-PRODUCTION route-storage spike and PREFERRED Mode 1 (§6) — reuse the Phase
+// 33Q bounded synthetic ledger shape, persist nothing durable, add no migration.
+// Mode 2 (durable + Lane-1 `aw_*` migrations) was NOT selected: the Phase 33N
+// scope guards (tests/unit/admission-wedge-spike/scope-guards.test.ts) forbid any
+// durable-write / SQL / migration token and any production-store import in the
+// spike path, and the repo's global migration runner would adopt any new
+// migration into the PRODUCTION set — so Mode 2 cannot be added narrowly without
+// weakening an existing security guard. Mode 1 proves the route-owned storage
+// semantics with the lowest blast radius (46U §6 / §7).
+//
+// WHAT THIS ADDS over Phase 33Q. The Phase 33Q ledger
+// (`admitted-assertion-ledger.ts`) is `(tenant_id, estate_id)`-scoped. Phase 46U
+// §10 requires tenant / estate / ACTOR isolation. This module adds the THIRD
+// scope dimension by holding ONE INDEPENDENT Phase 33Q ledger per synthetic
+// actor: an actor's synthetic state lives in its own factory closure, so one
+// actor's records are STRUCTURALLY unreachable from another actor (cross-actor
+// isolation is not a runtime check that could be bypassed — it is separate
+// closures). Within an actor, the wrapped ledger enforces the proven 33Q
+// guarantees: tenant+estate scoping, idempotent replay, conflict fail-closed,
+// supersession, per-estate capacity bounds, synthetic-only label validation, and
+// no raw-payload persistence.
+//
+// PRECEDENT, NOT REUSE-OF-RECALL. Like Phase 33Q, this mirrors ONLY the
+// operational properties of a bounded process-local store. It opens NO database
+// connection, NO file handle, NO socket, NO timer; runs NO background task;
+// performs NO durable write and NO migration. Its entire state is JS Maps in a
+// factory closure, so a process restart leaves NO recallable residue. It imports
+// ONLY the Phase 33Q ledger; it imports nothing from Recall, nothing from
+// `@loa/straylight`, and nothing from Freeside. It freezes NO schema and decides
+// NO final idempotency / signer / authority / tenant-estate-actor binding
+// semantics — those remain UNRESOLVED (46U §9 / §10 / §13). The synthetic actor
+// binding here is a SPIKE isolation mechanism, NOT the final production binding.
+//
+// Filename note: `*-spike.ts`, deliberately NOT `*-store.ts`. The Phase 33N
+// scope guards reject any spike-path import specifier matching `/-store(.js)?$/`
+// as a forbidden production-storage import; a `-spike` name stays inside the
+// authorized envelope without weakening that guard.
+
+import {
+  createAdmittedAssertionLedger,
+  type AdmittedAssertionLedger,
+  type AdmittedScope,
+  type EstateFootprint,
+  type RecallProjection,
+  type RecordOutcome,
+  type SyntheticAdmissionTransition,
+  type SyntheticAuditRecord,
+} from './admitted-assertion-ledger.js';
+
+/** A (tenant_id, estate_id, actor_id) scope. EVERY access is bound to all three:
+ *  cross-tenant and cross-estate isolation is enforced by the wrapped Phase 33Q
+ *  ledger; cross-actor isolation is enforced structurally by one ledger per
+ *  actor. All three ids must be bounded synthetic labels (validated before use). */
+export interface RouteStorageSpikeScope {
+  tenant_id: string;
+  estate_id: string;
+  actor_id: string;
+}
+
+/** Per-store capacity bounds. `maxActors` bounds the number of DISTINCT synthetic
+ *  actors ever seeded (bounded REJECTION beyond the cap — the store never evicts
+ *  and never grows unbounded). The two per-estate bounds are passed straight
+ *  through to each per-actor Phase 33Q ledger. All three are validated at
+ *  creation; a malformed/unbounded config fails closed at construction. */
+export interface RouteStorageSpikeConfig {
+  maxActors: number;
+  maxAssertionsPerEstate: number;
+  maxAssertionBytesPerEstate: number;
+}
+
+/** A bounded, process-local, NON-DURABLE, tenant/estate/actor-scoped, fail-closed
+ *  route-owned store. Reads on a valid-but-unseeded/tombstoned actor return empty
+ *  (fail closed without throwing); writes fail closed (throw). */
+export interface RouteStorageSpikeStore {
+  /** Establish a synthetic actor slot and seed its (tenant, estate). Idempotent
+   *  for the SAME (tenant, estate, actor). Fails closed on a malformed scope, a
+   *  tombstoned actor, an over-capacity new actor, or (delegated) an estate
+   *  re-homed to a different tenant within the actor's ledger. */
+  seedScope(scope: RouteStorageSpikeScope): void;
+  /** Record a synthetic admit/supersede transition into a seeded, non-tombstoned
+   *  actor's (tenant, estate). Delegates idempotency / conflict / capacity /
+   *  scope to the wrapped Phase 33Q ledger. Fails closed (throws) on a malformed
+   *  scope, an unseeded actor, a tombstoned actor, or any ledger violation. */
+  record(scope: RouteStorageSpikeScope, transition: SyntheticAdmissionTransition): RecordOutcome;
+  /** Internal recall-eligibility projection for a seeded, non-tombstoned actor
+   *  (empty for an unseeded/tombstoned actor — reads fail closed without throwing). */
+  projectRecall(scope: RouteStorageSpikeScope): RecallProjection;
+  /** Per-(estate, actor) synthetic footprint (zeros for an unseeded/tombstoned actor). */
+  inspectScope(scope: RouteStorageSpikeScope): EstateFootprint;
+  /** Private synthetic audit trail for a seeded, non-tombstoned actor (empty for
+   *  an unseeded/tombstoned actor). */
+  auditTrail(scope: RouteStorageSpikeScope): readonly SyntheticAuditRecord[];
+  /** Reversible kill/cleanup path: mark a synthetic actor tombstoned, releasing
+   *  its synthetic state. After this, the actor is not recallable (empty
+   *  projection / zero footprint / empty audit) and further writes fail closed —
+   *  no recallable residue (46U §11). Idempotent; a no-op for an unseeded actor. */
+  tombstoneActor(scope: RouteStorageSpikeScope): void;
+  /** True iff the actor has been tombstoned. */
+  isActorTombstoned(scope: RouteStorageSpikeScope): boolean;
+  /** Number of distinct synthetic actors ever seeded (tombstoned actors still
+   *  counted — bounded, no eviction). Diagnostic only; never public. */
+  actorCount(): number;
+}
+
+/** Thrown at store CREATION when a capacity bound is not a finite positive
+ *  integer within the dev/test ceiling. Carries only the field name + a short
+ *  reason — never a payload. */
+export class RouteStorageSpikeInvalidConfigError extends Error {
+  readonly field: 'maxActors' | 'maxAssertionsPerEstate' | 'maxAssertionBytesPerEstate';
+  readonly reason: 'not_a_number' | 'not_finite' | 'not_integer' | 'not_positive' | 'exceeds_dev_ceiling';
+  constructor(opts: {
+    field: 'maxActors' | 'maxAssertionsPerEstate' | 'maxAssertionBytesPerEstate';
+    reason: 'not_a_number' | 'not_finite' | 'not_integer' | 'not_positive' | 'exceeds_dev_ceiling';
+  }) {
+    super(`route-storage spike invalid config [${opts.reason}]`);
+    this.name = 'RouteStorageSpikeInvalidConfigError';
+    this.field = opts.field;
+    this.reason = opts.reason;
+  }
+}
+
+/** Thrown BEFORE any mutation when `actor_id` is not a bounded synthetic label.
+ *  Never echoes the rejected value, so a rejected unsafe actor leaves zero
+ *  residue. (tenant_id / estate_id and the transition fields are validated by the
+ *  wrapped Phase 33Q ledger.) */
+export class RouteStorageSpikeInvalidActorError extends Error {
+  readonly reason: 'not_a_string' | 'empty' | 'too_long' | 'invalid_format' | 'unsafe_value';
+  constructor(opts: { reason: 'not_a_string' | 'empty' | 'too_long' | 'invalid_format' | 'unsafe_value' }) {
+    super(`route-storage spike invalid actor [${opts.reason}]`);
+    this.name = 'RouteStorageSpikeInvalidActorError';
+    this.reason = opts.reason;
+  }
+}
+
+/** Thrown when a write targets an actor that is not in a writable state: an
+ *  unseeded actor (`unseeded_actor`) or a tombstoned actor (`tombstoned_actor`).
+ *  Carries the safe reason only — never the actor id. */
+export class RouteStorageSpikeActorScopeError extends Error {
+  readonly reason: 'unseeded_actor' | 'tombstoned_actor';
+  constructor(opts: { reason: 'unseeded_actor' | 'tombstoned_actor' }) {
+    super(`route-storage spike actor scope violation [${opts.reason}]`);
+    this.name = 'RouteStorageSpikeActorScopeError';
+    this.reason = opts.reason;
+  }
+}
+
+/** Thrown when seeding a NEW actor would exceed `maxActors` (bounded REJECTION,
+ *  46U §11 capacity bullet — never an eviction). */
+export class RouteStorageSpikeActorCapExceededError extends Error {
+  readonly cap: number;
+  readonly observed: number;
+  constructor(opts: { cap: number; observed: number }) {
+    super('route-storage spike actor capacity exceeded [actor_count]');
+    this.name = 'RouteStorageSpikeActorCapExceededError';
+    this.cap = opts.cap;
+    this.observed = opts.observed;
+  }
+}
+
+/** Max length for the actor label (mirrors the ledger's MAX_FIELD_LEN). */
+const MAX_ACTOR_LEN = 128;
+
+/** Actor label shape: lowercase snake/kebab plus digits — narrow and synthetic,
+ *  deliberately excluding whitespace, uppercase, and free-form punctuation that
+ *  could carry raw material. Linear-time (no backtracking). Mirrors the ledger's
+ *  SYNTH_LABEL_RE. */
+const SYNTH_ACTOR_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+/** Raw-material / unsafe-marker substrings rejected in the actor label
+ *  (defense-in-depth; mirrors the ledger's intent). Checked case-insensitively. */
+const UNSAFE_ACTOR_SUBSTRINGS = [
+  'unsafe_marker',
+  'candidate_payload',
+  'source_material',
+  'source_ref',
+  'raw_candidate',
+  'raw_reason',
+  'policy_reason',
+  'sentinel',
+  'secret',
+  'token',
+];
+
+/** Dev/test ceiling for the actor cap — generous for every spike/test config,
+ *  far below any production scale. */
+const MAX_ACTORS_CEILING = 100_000;
+
+/** Validate the actor label to a bounded synthetic shape BEFORE any mutation.
+ *  Order: type → emptiness → length → unsafe-substring → shape. Throws
+ *  `RouteStorageSpikeInvalidActorError` without echoing the value. */
+function assertSyntheticActor(value: unknown): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new RouteStorageSpikeInvalidActorError({ reason: 'not_a_string' });
+  }
+  if (value.length === 0) {
+    throw new RouteStorageSpikeInvalidActorError({ reason: 'empty' });
+  }
+  if (value.length > MAX_ACTOR_LEN) {
+    throw new RouteStorageSpikeInvalidActorError({ reason: 'too_long' });
+  }
+  const lower = value.toLowerCase();
+  for (const marker of UNSAFE_ACTOR_SUBSTRINGS) {
+    if (lower.includes(marker)) {
+      throw new RouteStorageSpikeInvalidActorError({ reason: 'unsafe_value' });
+    }
+  }
+  if (!SYNTH_ACTOR_RE.test(value)) {
+    throw new RouteStorageSpikeInvalidActorError({ reason: 'invalid_format' });
+  }
+}
+
+/** A FROZEN, closure-owned copy of the validated caps. Once built at creation
+ *  these are the only caps ever read — the caller-owned config is never read
+ *  again, so mutating it afterward cannot widen a cap (mirrors the ledger's
+ *  Codex-blocker-2 hardening). */
+interface ValidatedStoreCaps {
+  readonly maxActors: number;
+  readonly maxAssertionsPerEstate: number;
+  readonly maxAssertionBytesPerEstate: number;
+}
+
+function validateStoreConfig(config: RouteStorageSpikeConfig): ValidatedStoreCaps {
+  const rawActors: unknown = config.maxActors;
+  const rawAssertions: unknown = config.maxAssertionsPerEstate;
+  const rawBytes: unknown = config.maxAssertionBytesPerEstate;
+  const checks: Array<['maxActors' | 'maxAssertionsPerEstate' | 'maxAssertionBytesPerEstate', unknown, number]> = [
+    ['maxActors', rawActors, MAX_ACTORS_CEILING],
+    // The per-estate ceilings are re-validated by the wrapped ledger at first
+    // seed; here we only enforce the same positive-integer floor so a malformed
+    // config fails closed at store creation rather than at first write.
+    ['maxAssertionsPerEstate', rawAssertions, Number.MAX_SAFE_INTEGER],
+    ['maxAssertionBytesPerEstate', rawBytes, Number.MAX_SAFE_INTEGER],
+  ];
+  for (const [field, raw, ceiling] of checks) {
+    if (typeof raw !== 'number') {
+      throw new RouteStorageSpikeInvalidConfigError({ field, reason: 'not_a_number' });
+    }
+    if (!Number.isFinite(raw)) {
+      throw new RouteStorageSpikeInvalidConfigError({ field, reason: 'not_finite' });
+    }
+    if (!Number.isInteger(raw)) {
+      throw new RouteStorageSpikeInvalidConfigError({ field, reason: 'not_integer' });
+    }
+    if (raw <= 0) {
+      throw new RouteStorageSpikeInvalidConfigError({ field, reason: 'not_positive' });
+    }
+    if (raw > ceiling) {
+      throw new RouteStorageSpikeInvalidConfigError({ field, reason: 'exceeds_dev_ceiling' });
+    }
+  }
+  return Object.freeze({
+    maxActors: rawActors as number,
+    maxAssertionsPerEstate: rawAssertions as number,
+    maxAssertionBytesPerEstate: rawBytes as number,
+  });
+}
+
+/** One per-actor slot. A live actor holds its own Phase 33Q ledger; a tombstoned
+ *  actor holds none (its synthetic state has been released for GC). */
+interface ActorSlot {
+  tombstoned: boolean;
+  ledger: AdmittedAssertionLedger | null;
+}
+
+/** Project a (tenant, estate, actor) scope onto the wrapped ledger's
+ *  (tenant, estate) scope. */
+function ledgerScope(scope: RouteStorageSpikeScope): AdmittedScope {
+  return { tenant_id: scope.tenant_id, estate_id: scope.estate_id };
+}
+
+/** Read `scope.actor_id` EXACTLY ONCE into a local, validate that local to a
+ *  bounded synthetic label, and return it. Every `actors.get` / `actors.set`,
+ *  tombstone check, error-reason classification, and ledger selection in an
+ *  operation then reads ONLY this returned local — NEVER `scope.actor_id` again —
+ *  so a caller-owned accessor getter cannot validate as one actor and then
+ *  map/set as another (TOCTOU). A tombstoned actor therefore cannot be silently
+ *  revived, and a write/read cannot be diverted across actor isolation, by a
+ *  shifting getter. Mirrors the Phase 33Q ledger's `snapshotScope` discipline
+ *  (admitted-assertion-ledger.ts), which snapshots tenant/estate once for the
+ *  same reason. Does NOT weaken actor-label validation: the same
+ *  `assertSyntheticActor` runs, exactly once. */
+function snapshotActorId(scope: RouteStorageSpikeScope): string {
+  const actor_id = scope.actor_id;
+  assertSyntheticActor(actor_id);
+  return actor_id;
+}
+
+const EMPTY_PROJECTION: RecallProjection = Object.freeze({
+  includes: Object.freeze([]),
+  excludes: Object.freeze([]),
+});
+const EMPTY_FOOTPRINT: EstateFootprint = Object.freeze({ assertions: 0, bytes: 0 });
+const EMPTY_AUDIT: readonly SyntheticAuditRecord[] = Object.freeze([]);
+
+/**
+ * Create a bounded, process-local, tenant/estate/actor-scoped, NON-DURABLE
+ * route-storage spike store. The capacity config is validated immediately, so an
+ * unbounded/malformed config fails closed at construction. All state lives in the
+ * Map below, captured in this closure — a second call yields a fresh, empty
+ * store, which is exactly how "process restart leaves no recallable residue" is
+ * proven (46U §6 / §11). Mode 1: NO durable write, NO migration.
+ */
+export function createRouteStorageSpikeStore(config: RouteStorageSpikeConfig): RouteStorageSpikeStore {
+  const caps = validateStoreConfig(config);
+
+  /** Keyed by actor_id. Each actor owns an independent Phase 33Q ledger, so one
+   *  actor's synthetic state is structurally unreachable from another's. */
+  const actors = new Map<string, ActorSlot>();
+
+  function liveLedgerFor(scope: RouteStorageSpikeScope, forWrite: boolean): AdmittedAssertionLedger | null {
+    // Snapshot + validate the actor id ONCE, then key the lookup off the local —
+    // a shifting `actor_id` getter cannot validate as one actor and resolve to a
+    // different actor's slot (TOCTOU; cross-actor isolation bypass).
+    const actorId = snapshotActorId(scope);
+    const slot = actors.get(actorId);
+    if (!slot) {
+      if (forWrite) throw new RouteStorageSpikeActorScopeError({ reason: 'unseeded_actor' });
+      return null;
+    }
+    if (slot.tombstoned || slot.ledger === null) {
+      if (forWrite) throw new RouteStorageSpikeActorScopeError({ reason: 'tombstoned_actor' });
+      return null;
+    }
+    return slot.ledger;
+  }
+
+  return {
+    seedScope(scope) {
+      // Snapshot + validate the actor id ONCE. The tombstone check, the
+      // `actors.get`, and the `actors.set` below ALL key off this local — never
+      // `scope.actor_id` — so a shifting getter cannot validate/get as an unseeded
+      // decoy actor (skipping the tombstone branch) and then SET a live ledger
+      // onto a tombstoned actor's key, silently reviving it (TOCTOU). The wrapped
+      // tenant/estate validation still runs inside `seedEstate` (unchanged).
+      const actorId = snapshotActorId(scope);
+      const existing = actors.get(actorId);
+      if (existing) {
+        if (existing.tombstoned || existing.ledger === null) {
+          // A tombstoned actor cannot be silently revived — fail closed.
+          throw new RouteStorageSpikeActorScopeError({ reason: 'tombstoned_actor' });
+        }
+        // Delegate (idempotent for same tenant/estate; throws on a tenant
+        // conflict within the actor's ledger).
+        existing.ledger.seedEstate(ledgerScope(scope));
+        return;
+      }
+      // A new actor must fit the bound (bounded REJECTION; never eviction).
+      if (actors.size + 1 > caps.maxActors) {
+        throw new RouteStorageSpikeActorCapExceededError({ cap: caps.maxActors, observed: actors.size + 1 });
+      }
+      const ledger = createAdmittedAssertionLedger({
+        maxAssertionsPerEstate: caps.maxAssertionsPerEstate,
+        maxAssertionBytesPerEstate: caps.maxAssertionBytesPerEstate,
+      });
+      ledger.seedEstate(ledgerScope(scope));
+      actors.set(actorId, { tombstoned: false, ledger });
+    },
+
+    record(scope, transition) {
+      const ledger = liveLedgerFor(scope, /*forWrite*/ true)!;
+      return ledger.record(ledgerScope(scope), transition);
+    },
+
+    projectRecall(scope) {
+      const ledger = liveLedgerFor(scope, /*forWrite*/ false);
+      return ledger ? ledger.projectRecall(ledgerScope(scope)) : EMPTY_PROJECTION;
+    },
+
+    inspectScope(scope) {
+      const ledger = liveLedgerFor(scope, /*forWrite*/ false);
+      return ledger ? ledger.inspectEstate(ledgerScope(scope)) : EMPTY_FOOTPRINT;
+    },
+
+    auditTrail(scope) {
+      const ledger = liveLedgerFor(scope, /*forWrite*/ false);
+      return ledger ? ledger.auditTrail(ledgerScope(scope)) : EMPTY_AUDIT;
+    },
+
+    tombstoneActor(scope) {
+      // Snapshot + validate ONCE; the `actors.get` (existence check) and the
+      // `actors.set` (tombstone mark) below both key off this local, so a shifting
+      // getter cannot tombstone an actor other than the one validated.
+      const actorId = snapshotActorId(scope);
+      const slot = actors.get(actorId);
+      if (!slot) return; // nothing seeded → nothing to tombstone (idempotent)
+      // Mark tombstoned and release the ledger reference (its synthetic state
+      // becomes unreachable / GC-eligible) WITHOUT physically evicting the slot,
+      // so the actor stays counted against the bound and cannot be silently
+      // revived. After this the actor is not recallable and writes fail closed.
+      actors.set(actorId, { tombstoned: true, ledger: null });
+    },
+
+    isActorTombstoned(scope) {
+      // Snapshot + validate ONCE; the lookup keys off the local, so the answer
+      // reflects the actor that was validated, not one a getter shifts to after.
+      const actorId = snapshotActorId(scope);
+      const slot = actors.get(actorId);
+      return slot ? slot.tombstoned || slot.ledger === null : false;
+    },
+
+    actorCount() {
+      return actors.size;
+    },
+  };
+}

--- a/app/tests/integration/admission-intake/full-stack.test.ts
+++ b/app/tests/integration/admission-intake/full-stack.test.ts
@@ -75,6 +75,9 @@ function baseConfig(finnPort: number): DixieConfig {
     admissionIntakeSpikeEnabled: true,
     admissionIntakeSpikeServiceToken: SERVICE_TOKEN,
     admissionIntakeSpikeOperatorIds: [OPERATOR],
+    // Phase 46V route-storage spike gate (default off for the base full-stack
+    // suite; the dedicated registration suite proves the AND-gating).
+    admissionIntakeStorageSpikeEnabled: false,
   };
 }
 

--- a/app/tests/integration/admission-intake/registration.test.ts
+++ b/app/tests/integration/admission-intake/registration.test.ts
@@ -61,6 +61,8 @@ function baseConfig(): DixieConfig {
     admissionIntakeSpikeEnabled: false,
     admissionIntakeSpikeServiceToken: '',
     admissionIntakeSpikeOperatorIds: [],
+    // Phase 46V route-storage spike gate (default off; overridden per-case).
+    admissionIntakeStorageSpikeEnabled: false,
   };
 }
 
@@ -71,9 +73,11 @@ function hasAdmissionRoute(app: ReturnType<typeof createDixieApp>): boolean {
 // Some env may leak the enable flag in; neutralize for determinism.
 beforeEach(() => {
   delete process.env.DIXIE_ADMISSION_INTAKE_ENABLED;
+  delete process.env.DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED;
 });
 afterEach(() => {
   delete process.env.DIXIE_ADMISSION_INTAKE_ENABLED;
+  delete process.env.DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED;
 });
 
 describe('Phase 33N — admission spike route registration is gated and off by default', () => {
@@ -108,5 +112,51 @@ describe('Phase 33N — admission spike route registration is gated and off by d
     const text = await res.text();
     expect(text).not.toContain('admission.spike_disabled');
     expect(text).not.toContain('dev_operator_only_non_production');
+  });
+});
+
+// ── Phase 46V: route-storage spike is SEPARATELY gated and ANDed ──────────────
+//
+// The route-storage spike (Mode 1) engages ONLY when BOTH the base route gate
+// AND the storage-spike gate are enabled. The store is an internal closure with
+// no route-table signal, so these assert the OBSERVABLE registration posture:
+//   * the storage gate ALONE never mounts the route (base gate is the only thing
+//     that registers the route at all);
+//   * with the base gate on, the route registers WHETHER OR NOT the storage gate
+//     is on (the storage spike is additive — it never disables the base route);
+//   * `createDixieApp` constructs without throwing in every flag combination
+//     (so the storage gate, when on with the base gate, builds + seeds the store
+//     successfully).
+describe('Phase 46V — route-storage spike is separately gated (storage gate ANDed with base gate)', () => {
+  it('storage gate ON but base gate OFF → route NOT registered (storage gate alone does nothing)', () => {
+    const app = createDixieApp({
+      ...baseConfig(),
+      admissionIntakeSpikeEnabled: false,
+      admissionIntakeStorageSpikeEnabled: true,
+    });
+    expect(hasAdmissionRoute(app)).toBe(false);
+  });
+
+  it('base gate ON + storage gate OFF → route registered (no-store path), constructs cleanly', () => {
+    const app = createDixieApp({
+      ...baseConfig(),
+      admissionIntakeSpikeEnabled: true,
+      admissionIntakeStorageSpikeEnabled: false,
+      admissionIntakeSpikeServiceToken: 'dev-token-synthetic',
+    });
+    expect(hasAdmissionRoute(app)).toBe(true);
+  });
+
+  it('base gate ON + storage gate ON → route registered; store built + seeded without throwing', () => {
+    // If the store config or seed were malformed this would throw at construction
+    // (fail-closed at startup). A clean construction proves the Mode-1 store wires
+    // up under the AND of both gates.
+    const app = createDixieApp({
+      ...baseConfig(),
+      admissionIntakeSpikeEnabled: true,
+      admissionIntakeStorageSpikeEnabled: true,
+      admissionIntakeSpikeServiceToken: 'dev-token-synthetic',
+    });
+    expect(hasAdmissionRoute(app)).toBe(true);
   });
 });

--- a/app/tests/integration/admission-intake/route-storage-spike.test.ts
+++ b/app/tests/integration/admission-intake/route-storage-spike.test.ts
@@ -1,0 +1,310 @@
+// Phase 46V — dev/operator-only Admission Wedge ROUTE-STORAGE spike, exercised
+// through the route handler with the route-storage store DI seam (Storage
+// Mode 1: no-migration, bounded-synthetic, in-process; NON-PRODUCTION).
+//
+// Authorized NARROWLY by Phase 46U
+// (docs/ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md §3–§16). This
+// proves the route-level obligations the unit suite cannot:
+//
+//   * default-off: with NO store injected (the production/server default unless
+//     the route-storage gate is on), the public body is byte-IDENTICAL to the
+//     Phase 33N no-store path and leak-clean — current behavior unchanged;
+//   * persisted / replayed public no-leak: accept/supersede record into the
+//     store while the public body stays the deterministic public-safe response,
+//     deep-walked clean by the runtime guard, with NO store ids on the wire;
+//     replaying returns the SAME public body and mints no duplicate;
+//   * recall lifecycle: pending/reject/malformed mint nothing recallable; accept
+//     references an admitted assertion; supersede excludes the prior;
+//   * degraded / failed store fails closed: a throwing store collapses an accept
+//     to the stable public-safe refusal with no recallable residue, leaking
+//     neither the store error nor any id;
+//   * actor isolation at the route: the route records under one fixed synthetic
+//     actor; a different actor scope sees nothing.
+//
+// The handler is mounted directly (mirroring store-coupled.test.ts), so this
+// exercises the route logic + the DI seam. The server-level AND-gating of the
+// two env flags is proven in registration.test.ts. All ids/tokens are synthetic.
+
+import { describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import { createAdmissionIntakeRoutes } from '../../../src/routes/admission-intake.js';
+import {
+  ADMISSION_TRANSITION_INTENTS,
+  createRouteStorageSpikeStore,
+  findAdmissionPublicLeaks,
+  type RouteStorageSpikeScope,
+  type RouteStorageSpikeStore,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+const TOKEN = 'dev-operator-token-synthetic-rss-001';
+const OPERATOR = 'op-rss-test';
+
+// Must match the server's fixed synthetic constants (server.ts Phase 46V block).
+const SYNTH_TENANT = 'tenant-synthetic-dev';
+const SYNTH_ESTATE = 'estate-synthetic-dev';
+const SYNTH_ACTOR = 'actor-synthetic-dev';
+const SCOPE: RouteStorageSpikeScope = {
+  tenant_id: SYNTH_TENANT,
+  estate_id: SYNTH_ESTATE,
+  actor_id: SYNTH_ACTOR,
+};
+
+// The fixed synthetic ids the route mints (must match admission-intake.ts).
+const SYNTH_ADMITTED_ASSERTION_ID = 'assn-active-synthetic-dev';
+const SYNTH_CORRECTED_ASSERTION_ID = 'assn-corrected-synthetic-dev';
+const SYNTH_SOURCE_CANDIDATE_ID = 'cand-synthetic-dev';
+
+function authHeaders(extra?: Record<string, string>) {
+  return {
+    'content-type': 'application/json',
+    'x-admission-service-token': TOKEN,
+    'x-admission-operator-id': OPERATOR,
+    ...extra,
+  };
+}
+
+function spikeBody(transition_intent: string) {
+  return JSON.stringify({ spike: 'admission_intake_dev_spike_v0', transition_intent });
+}
+
+/** Build a route app. When `withStore` is true a real seeded store is injected
+ *  and returned for post-request inspection. A custom `store` overrides it. */
+function buildApp(opts?: { withStore?: boolean; store?: RouteStorageSpikeStore }) {
+  let store: RouteStorageSpikeStore | undefined;
+  if (opts?.store) {
+    store = opts.store;
+  } else if (opts?.withStore) {
+    store = createRouteStorageSpikeStore({
+      maxActors: 8,
+      maxAssertionsPerEstate: 32,
+      maxAssertionBytesPerEstate: 100_000,
+    });
+    store.seedScope(SCOPE);
+  }
+  const app = new Hono();
+  app.route(
+    '/api/admission/intake',
+    createAdmissionIntakeRoutes({
+      enabled: true,
+      gate: { serviceToken: TOKEN, operatorIds: [OPERATOR] },
+      routeStorageSpikeStore: store,
+      routeStorageSpikeTenantId: store ? SYNTH_TENANT : undefined,
+      routeStorageSpikeEstateId: store ? SYNTH_ESTATE : undefined,
+      routeStorageSpikeActorId: store ? SYNTH_ACTOR : undefined,
+    }),
+  );
+  return { app, store };
+}
+
+async function post(app: Hono, intent: string, headers = authHeaders()) {
+  return app.request('/api/admission/intake', { method: 'POST', headers, body: spikeBody(intent) });
+}
+
+// ── Default-off: the store seam never changes the public body ─────────────────
+
+describe('Phase 46V route — store seam does not change the public body (default-off parity)', () => {
+  for (const [name, intent] of Object.entries(ADMISSION_TRANSITION_INTENTS)) {
+    it(`${name}: public response identical with and without the store seam`, async () => {
+      const { app: noStore } = buildApp();
+      const { app: withStore } = buildApp({ withStore: true });
+
+      // A supersede needs a prior active assertion in the estate.
+      if (name === 'supersede') {
+        await post(noStore, ADMISSION_TRANSITION_INTENTS.accept);
+        await post(withStore, ADMISSION_TRANSITION_INTENTS.accept);
+      }
+
+      const r1 = await post(noStore, intent);
+      const r2 = await post(withStore, intent);
+      expect(r1.status).toBe(r2.status);
+      const [t1, t2] = [await r1.text(), await r2.text()];
+      expect(t2).toBe(t1); // byte-identical
+      expect(findAdmissionPublicLeaks(JSON.parse(t2))).toEqual([]);
+    });
+  }
+
+  it('no-store IS the production default: behavior unchanged, no leak', async () => {
+    const { app, store } = buildApp();
+    expect(store).toBeUndefined();
+    for (const intent of Object.values(ADMISSION_TRANSITION_INTENTS)) {
+      const res = await post(app, intent);
+      const body = JSON.parse(await res.text());
+      expect(body.spike).toBe('dev_operator_only_non_production');
+      expect(findAdmissionPublicLeaks(body)).toEqual([]);
+    }
+  });
+
+  it('a partial DI injection (store but no actor id) records nothing — stays no-store path', async () => {
+    const store = createRouteStorageSpikeStore({
+      maxActors: 8,
+      maxAssertionsPerEstate: 32,
+      maxAssertionBytesPerEstate: 100_000,
+    });
+    store.seedScope(SCOPE);
+    const app = new Hono();
+    app.route(
+      '/api/admission/intake',
+      createAdmissionIntakeRoutes({
+        enabled: true,
+        gate: { serviceToken: TOKEN, operatorIds: [OPERATOR] },
+        routeStorageSpikeStore: store,
+        routeStorageSpikeTenantId: SYNTH_TENANT,
+        routeStorageSpikeEstateId: SYNTH_ESTATE,
+        // routeStorageSpikeActorId intentionally omitted.
+      }),
+    );
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    expect(res.status).toBe(200);
+    expect(store.inspectScope(SCOPE).assertions).toBe(0);
+  });
+});
+
+// ── Persisted / replayed public no-leak + internal effect ─────────────────────
+
+describe('Phase 46V route — accept persists internally; public body unchanged & leak-clean', () => {
+  it('accept references one active synthetic assertion without leaking it', async () => {
+    const { app, store } = buildApp({ withStore: true });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    const text = await res.text();
+    const body = JSON.parse(text);
+
+    expect(res.status).toBe(200);
+    expect(body.outcome_class).toBe('admitted');
+    expect(body.recall_eligible).toBe(true);
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+
+    // Internal effect: one active assertion recorded under the synthetic actor.
+    expect(store!.inspectScope(SCOPE).assertions).toBe(1);
+    expect(store!.projectRecall(SCOPE).includes).toEqual([SYNTH_ADMITTED_ASSERTION_ID]);
+
+    // No store ids / private audit fields on the wire.
+    expect(text).not.toContain(SYNTH_ADMITTED_ASSERTION_ID);
+    expect(text).not.toContain(SYNTH_SOURCE_CANDIDATE_ID);
+    expect(text).not.toContain(SYNTH_ACTOR);
+    expect(text).not.toContain('assertion_admitted');
+    expect(text).not.toContain('audit_private');
+    expect(text).not.toContain('rcpt-priv-');
+  });
+
+  it('replaying the same accept returns the SAME public body and mints no duplicate', async () => {
+    const { app, store } = buildApp({ withStore: true });
+    const r1 = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    const r2 = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    const [t1, t2] = [await r1.text(), await r2.text()];
+    // Replayed public response is byte-identical AND leak-clean.
+    expect(t2).toBe(t1);
+    expect(findAdmissionPublicLeaks(JSON.parse(t2))).toEqual([]);
+    // Only one synthetic assertion despite two identical accepts.
+    expect(store!.inspectScope(SCOPE).assertions).toBe(1);
+  });
+
+  it('supersede (after accept) repoints recall; prior preserved, no id leak', async () => {
+    const { app, store } = buildApp({ withStore: true });
+    await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.supersede);
+    const text = await res.text();
+    const body = JSON.parse(text);
+
+    expect(res.status).toBe(200);
+    expect(body.outcome_class).toBe('superseded_with_correction');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+
+    expect(store!.projectRecall(SCOPE)).toEqual({
+      includes: [SYNTH_CORRECTED_ASSERTION_ID],
+      excludes: [SYNTH_ADMITTED_ASSERTION_ID],
+    });
+    expect(text).not.toContain(SYNTH_CORRECTED_ASSERTION_ID);
+    expect(text).not.toContain(SYNTH_ADMITTED_ASSERTION_ID);
+  });
+});
+
+// ── Recall lifecycle (Phase 46U §16 invariants) ───────────────────────────────
+
+describe('Phase 46V route — recall lifecycle invariants', () => {
+  it('pending records nothing recallable', async () => {
+    const { app, store } = buildApp({ withStore: true });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.pending);
+    expect(res.status).toBe(200);
+    expect(store!.inspectScope(SCOPE).assertions).toBe(0);
+    expect(store!.projectRecall(SCOPE)).toEqual({ includes: [], excludes: [] });
+  });
+
+  it('reject creates no admitted assertion', async () => {
+    const { app, store } = buildApp({ withStore: true });
+    await post(app, ADMISSION_TRANSITION_INTENTS.reject);
+    expect(store!.inspectScope(SCOPE).assertions).toBe(0);
+  });
+
+  it('malformed fails closed before the store is reached', async () => {
+    const { app, store } = buildApp({ withStore: true });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.malformed);
+    expect(res.status).toBe(400);
+    expect(store!.inspectScope(SCOPE).assertions).toBe(0);
+  });
+
+  it('a different (unseeded) actor scope sees nothing the route recorded', async () => {
+    const { app, store } = buildApp({ withStore: true });
+    await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    // The route records under SYNTH_ACTOR only; another actor is isolated.
+    const other: RouteStorageSpikeScope = { ...SCOPE, actor_id: 'actor-other-dev' };
+    expect(store!.projectRecall(other)).toEqual({ includes: [], excludes: [] });
+    expect(store!.inspectScope(other)).toEqual({ assertions: 0, bytes: 0 });
+  });
+});
+
+// ── Degraded / failed store fails closed (no residue, no leak) ─────────────────
+
+describe('Phase 46V route — store failure fails closed to the stable refusal', () => {
+  it('a throwing store collapses an accept to the stable 400 refusal, leaking nothing', async () => {
+    let recordCalls = 0;
+    const throwingStore: RouteStorageSpikeStore = {
+      seedScope: () => undefined,
+      record: () => {
+        recordCalls += 1;
+        throw new Error('synthetic route-storage failure: secret estate-synthetic-dev');
+      },
+      projectRecall: () => ({ includes: [], excludes: [] }),
+      inspectScope: () => ({ assertions: 0, bytes: 0 }),
+      auditTrail: () => [],
+      tombstoneActor: () => undefined,
+      isActorTombstoned: () => false,
+      actorCount: () => 0,
+    };
+    const { app } = buildApp({ store: throwingStore });
+
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.accept);
+    expect(res.status).toBe(400);
+    const body = JSON.parse(await res.text());
+    expect(body.outcome_class).toBe('refused');
+    expect(body.safe_reason_code).toBe('ingress.invalid_request');
+    expect(body.recall_eligible).toBe(false);
+    expect(body.public_receipt_ref ?? null).toBeNull();
+    expect(body.recall_projection?.ordinary_recall_includes ?? []).toEqual([]);
+    // The synthetic error text / ids never leak.
+    expect(JSON.stringify(body)).not.toContain('synthetic route-storage failure');
+    expect(JSON.stringify(body)).not.toContain('secret');
+    expect(findAdmissionPublicLeaks(body)).toEqual([]);
+    expect(recordCalls).toBe(1);
+  });
+
+  it('a throwing store does NOT affect pending (store never invoked for pending)', async () => {
+    let recordCalls = 0;
+    const throwingStore: RouteStorageSpikeStore = {
+      seedScope: () => undefined,
+      record: () => {
+        recordCalls += 1;
+        throw new Error('should not be called for pending');
+      },
+      projectRecall: () => ({ includes: [], excludes: [] }),
+      inspectScope: () => ({ assertions: 0, bytes: 0 }),
+      auditTrail: () => [],
+      tombstoneActor: () => undefined,
+      isActorTombstoned: () => false,
+      actorCount: () => 0,
+    };
+    const { app } = buildApp({ store: throwingStore });
+    const res = await post(app, ADMISSION_TRANSITION_INTENTS.pending);
+    expect(res.status).toBe(200);
+    expect(recordCalls).toBe(0);
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/config-gate.test.ts
+++ b/app/tests/unit/admission-wedge-spike/config-gate.test.ts
@@ -27,6 +27,8 @@ describe('config — Phase 33N admission intake spike gate (default off, non-pro
     'DIXIE_ADMISSION_INTAKE_ENABLED',
     'DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN',
     'DIXIE_ADMISSION_INTAKE_OPERATOR_IDS',
+    // Phase 46V draft route-storage spike gate.
+    'DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED',
   ];
 
   beforeEach(() => {
@@ -90,5 +92,35 @@ describe('config — Phase 33N admission intake spike gate (default off, non-pro
     expect(c.admissionIntakeSpikeEnabled).toBe(true);
     expect(c.admissionIntakeSpikeServiceToken).toBe('');
     expect(c.admissionIntakeSpikeOperatorIds).toEqual([]);
+  });
+
+  // ── Phase 46V: route-storage spike gate (DRAFT / non-final; default off) ─────
+
+  it('Phase 46V: route-storage spike gate is OFF by default', () => {
+    const c = loadConfig();
+    expect(c.admissionIntakeStorageSpikeEnabled).toBe(false);
+  });
+
+  it('Phase 46V: storage-spike gate === "true" sets the flag (server ANDs it with the base gate)', () => {
+    process.env.DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED = 'true';
+    const c = loadConfig();
+    expect(c.admissionIntakeStorageSpikeEnabled).toBe(true);
+  });
+
+  it('Phase 46V: any value other than the literal "true" leaves the storage gate off', () => {
+    for (const v of ['1', 'TRUE', 'yes', 'on', '', ' true ']) {
+      process.env.DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED = v;
+      const c = loadConfig();
+      expect(c.admissionIntakeStorageSpikeEnabled).toBe(false);
+    }
+  });
+
+  it('Phase 46V: the storage gate is independent of the base route gate at config load', () => {
+    // Config parses the two flags independently; the AND (storage engages only
+    // when BOTH are true) is applied at the server mount site, not in config.
+    process.env.DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED = 'true';
+    const c = loadConfig();
+    expect(c.admissionIntakeSpikeEnabled).toBe(false); // base gate still off
+    expect(c.admissionIntakeStorageSpikeEnabled).toBe(true);
   });
 });

--- a/app/tests/unit/admission-wedge-spike/route-storage-spike.test.ts
+++ b/app/tests/unit/admission-wedge-spike/route-storage-spike.test.ts
@@ -1,0 +1,560 @@
+// Phase 46V — dev/operator-only Admission Wedge ROUTE-STORAGE spike
+// (Storage Mode 1: no-migration, bounded-synthetic, in-process). Unit proof.
+//
+// Authorized NARROWLY by Phase 46U
+// (docs/ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md §3–§16). This
+// suite proves the route-owned store's semantics directly (the route-level
+// proofs — persisted/replayed no-leak, default-off, degraded fail-closed, recall
+// lifecycle, gate AND-ing — live in the integration suite):
+//
+//   * config validation fails closed (unbounded/malformed caps rejected);
+//   * tenant / estate / ACTOR isolation — the THIRD dimension Phase 46V adds:
+//     same idempotency key in different actors does not collide; cross-actor /
+//     cross-tenant / cross-estate reads return empty (fail closed); cross-scope
+//     writes fail closed;
+//   * idempotency / replay / conflict (delegated to the proven Phase 33Q ledger
+//     but re-proven through the actor-scoped wrapper): identical replay returns
+//     the prior result and mints no duplicate; same-key/different-content fails
+//     closed;
+//   * capacity bounds — per-estate (delegated) AND the new per-store actor cap
+//     (bounded REJECTION, never eviction);
+//   * rollback / tombstone / cleanup — a tombstoned actor is not recallable,
+//     leaves no residue, cannot be revived or written to (fail closed);
+//   * synthetic-only discipline — a raw/unsafe actor label fails closed with no
+//     residue and no value echo;
+//   * non-durability — a second store is empty (process-restart analogue).
+//
+// All ids/labels are SYNTHETIC and public-safe.
+
+import { describe, expect, it } from 'vitest';
+import {
+  createRouteStorageSpikeStore,
+  RouteStorageSpikeInvalidConfigError,
+  RouteStorageSpikeInvalidActorError,
+  RouteStorageSpikeActorScopeError,
+  RouteStorageSpikeActorCapExceededError,
+  findAdmissionPublicLeaks,
+  type RouteStorageSpikeScope,
+  type RouteStorageSpikeStore,
+} from '../../../src/services/admission-wedge-spike/index.js';
+import type { SyntheticAdmissionTransition } from '../../../src/services/admission-wedge-spike/index.js';
+
+const CONFIG = { maxActors: 8, maxAssertionsPerEstate: 32, maxAssertionBytesPerEstate: 100_000 };
+
+const TENANT = 'tenant-synthetic-dev';
+const ESTATE = 'estate-synthetic-dev';
+const ACTOR_A = 'actor-synthetic-a';
+const ACTOR_B = 'actor-synthetic-b';
+
+function scope(over?: Partial<RouteStorageSpikeScope>): RouteStorageSpikeScope {
+  return { tenant_id: TENANT, estate_id: ESTATE, actor_id: ACTOR_A, ...over };
+}
+
+function admitTransition(over?: Partial<SyntheticAdmissionTransition>): SyntheticAdmissionTransition {
+  return {
+    kind: 'admit',
+    source_candidate_id: 'cand-synthetic-dev',
+    admission_transition_id: 'txn-admit-synthetic-dev',
+    admitted_assertion_id: 'assn-active-synthetic-dev',
+    assertion_class: 'preference',
+    replay_key: 'admit:cand-synthetic-dev',
+    ...over,
+  };
+}
+
+function supersedeTransition(over?: Partial<SyntheticAdmissionTransition>): SyntheticAdmissionTransition {
+  return {
+    kind: 'supersede',
+    source_candidate_id: 'cand-synthetic-dev',
+    admission_transition_id: 'txn-supersede-synthetic-dev',
+    admitted_assertion_id: 'assn-corrected-synthetic-dev',
+    assertion_class: 'preference',
+    replay_key: 'supersede:cand-synthetic-dev',
+    supersedes_assertion_id: 'assn-active-synthetic-dev',
+    ...over,
+  };
+}
+
+function seededStore(): RouteStorageSpikeStore {
+  const store = createRouteStorageSpikeStore(CONFIG);
+  store.seedScope(scope());
+  return store;
+}
+
+// ── Config validation (fail closed at creation) ───────────────────────────────
+
+describe('Phase 46V route-storage spike — config validation fails closed', () => {
+  const badCaps: Array<[string, Partial<typeof CONFIG>]> = [
+    ['maxActors Infinity', { maxActors: Infinity }],
+    ['maxActors NaN', { maxActors: NaN }],
+    ['maxActors zero', { maxActors: 0 }],
+    ['maxActors negative', { maxActors: -1 }],
+    ['maxActors fractional', { maxActors: 1.5 }],
+    ['maxActors over ceiling', { maxActors: 100_001 }],
+    ['maxAssertionsPerEstate zero', { maxAssertionsPerEstate: 0 }],
+    ['maxAssertionsPerEstate Infinity', { maxAssertionsPerEstate: Infinity }],
+    ['maxAssertionBytesPerEstate negative', { maxAssertionBytesPerEstate: -10 }],
+  ];
+  for (const [name, over] of badCaps) {
+    it(`rejects ${name} at creation`, () => {
+      expect(() => createRouteStorageSpikeStore({ ...CONFIG, ...over })).toThrow(
+        RouteStorageSpikeInvalidConfigError,
+      );
+    });
+  }
+
+  it('a valid config constructs an empty store', () => {
+    const store = createRouteStorageSpikeStore(CONFIG);
+    expect(store.actorCount()).toBe(0);
+  });
+
+  it('a config mutated AFTER construction cannot widen the actor cap', () => {
+    const cfg = { ...CONFIG, maxActors: 1 };
+    const store = createRouteStorageSpikeStore(cfg);
+    store.seedScope(scope({ actor_id: ACTOR_A }));
+    // Mutating the caller-owned config must not widen the frozen closure cap.
+    cfg.maxActors = 999;
+    expect(() => store.seedScope(scope({ actor_id: ACTOR_B }))).toThrow(
+      RouteStorageSpikeActorCapExceededError,
+    );
+  });
+});
+
+// ── Synthetic-only actor discipline (fail closed, no residue/echo) ─────────────
+
+describe('Phase 46V route-storage spike — actor label must be a bounded synthetic label', () => {
+  const badActors: Array<[string, unknown]> = [
+    ['empty', ''],
+    ['whitespace', 'actor dev'],
+    ['uppercase', 'ActorDev'],
+    ['unsafe_marker substring', 'actor-unsafe_marker'],
+    ['candidate_payload substring', 'candidate_payload-actor'],
+    ['secret substring', 'actor-secret-1'],
+    ['token substring', 'actor-token'],
+    ['non-string', 123 as unknown],
+    ['too long', 'a'.repeat(129)],
+  ];
+  for (const [name, actor] of badActors) {
+    it(`rejects ${name} on seedScope with no value echo`, () => {
+      const store = createRouteStorageSpikeStore(CONFIG);
+      try {
+        store.seedScope(scope({ actor_id: actor as string }));
+        throw new Error('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(RouteStorageSpikeInvalidActorError);
+        // The rejected value is NEVER echoed onto the error message.
+        if (typeof actor === 'string' && actor.length > 0) {
+          expect((err as Error).message).not.toContain(actor);
+        }
+      }
+      // Nothing was seeded.
+      expect(store.actorCount()).toBe(0);
+    });
+  }
+
+  it('a record into an unsafe-labelled actor fails closed before any mutation', () => {
+    const store = createRouteStorageSpikeStore(CONFIG);
+    expect(() => store.record(scope({ actor_id: 'actor-secret' }), admitTransition())).toThrow(
+      RouteStorageSpikeInvalidActorError,
+    );
+  });
+});
+
+// ── Tenant / estate / ACTOR isolation (Phase 46U §10) ─────────────────────────
+
+describe('Phase 46V route-storage spike — tenant/estate/actor isolation', () => {
+  it('the SAME idempotency key in two different actors does NOT collide', () => {
+    const store = createRouteStorageSpikeStore(CONFIG);
+    store.seedScope(scope({ actor_id: ACTOR_A }));
+    store.seedScope(scope({ actor_id: ACTOR_B }));
+
+    // Identical transition (same replay key, same ids) recorded under each actor.
+    const rA = store.record(scope({ actor_id: ACTOR_A }), admitTransition());
+    const rB = store.record(scope({ actor_id: ACTOR_B }), admitTransition());
+    expect(rA.outcome).toBe('recorded');
+    expect(rB.outcome).toBe('recorded'); // NOT 'replayed' — different actor, no collision
+
+    // Each actor independently has exactly one assertion.
+    expect(store.inspectScope(scope({ actor_id: ACTOR_A })).assertions).toBe(1);
+    expect(store.inspectScope(scope({ actor_id: ACTOR_B })).assertions).toBe(1);
+    expect(store.projectRecall(scope({ actor_id: ACTOR_A })).includes).toEqual([
+      'assn-active-synthetic-dev',
+    ]);
+    expect(store.projectRecall(scope({ actor_id: ACTOR_B })).includes).toEqual([
+      'assn-active-synthetic-dev',
+    ]);
+  });
+
+  it('a cross-ACTOR read returns empty (an unseeded actor sees nothing)', () => {
+    const store = seededStore();
+    store.record(scope({ actor_id: ACTOR_A }), admitTransition());
+    // ACTOR_B was never seeded → reads fail closed to empty (no cross-actor read).
+    expect(store.projectRecall(scope({ actor_id: ACTOR_B }))).toEqual({ includes: [], excludes: [] });
+    expect(store.inspectScope(scope({ actor_id: ACTOR_B }))).toEqual({ assertions: 0, bytes: 0 });
+    expect(store.auditTrail(scope({ actor_id: ACTOR_B }))).toEqual([]);
+  });
+
+  it('a cross-ACTOR write fails closed (unseeded actor cannot be written)', () => {
+    const store = seededStore(); // only ACTOR_A seeded
+    expect(() => store.record(scope({ actor_id: ACTOR_B }), admitTransition())).toThrow(
+      RouteStorageSpikeActorScopeError,
+    );
+  });
+
+  it('a cross-TENANT read of the same actor/estate returns empty (delegated 33Q scoping)', () => {
+    const store = seededStore();
+    store.record(scope(), admitTransition());
+    // Same actor + estate, DIFFERENT tenant → the wrapped ledger fails closed
+    // (foreign tenant sees nothing).
+    expect(store.projectRecall(scope({ tenant_id: 'tenant-other-dev' }))).toEqual({
+      includes: [],
+      excludes: [],
+    });
+    expect(store.inspectScope(scope({ tenant_id: 'tenant-other-dev' }))).toEqual({
+      assertions: 0,
+      bytes: 0,
+    });
+  });
+
+  it('a cross-ESTATE read of the same actor returns empty', () => {
+    const store = seededStore();
+    store.record(scope(), admitTransition());
+    expect(store.projectRecall(scope({ estate_id: 'estate-other-dev' }))).toEqual({
+      includes: [],
+      excludes: [],
+    });
+  });
+});
+
+// ── Idempotency / replay / conflict (through the actor wrapper) ────────────────
+
+describe('Phase 46V route-storage spike — idempotency / replay / conflict', () => {
+  it('an identical replay returns the prior result and mints no duplicate', () => {
+    const store = seededStore();
+    const r1 = store.record(scope(), admitTransition());
+    const r2 = store.record(scope(), admitTransition());
+    expect(r1.outcome).toBe('recorded');
+    expect(r2.outcome).toBe('replayed');
+    expect(r2.admitted_assertion_id).toBe(r1.admitted_assertion_id);
+    expect(store.inspectScope(scope()).assertions).toBe(1); // no duplicate
+  });
+
+  it('a same-key / different-content replay fails closed (no overwrite)', () => {
+    const store = seededStore();
+    store.record(scope(), admitTransition());
+    // Same replay_key, different assertion id → conflict, fail closed.
+    expect(() =>
+      store.record(scope(), admitTransition({ admitted_assertion_id: 'assn-other-synthetic-dev' })),
+    ).toThrow();
+    // Original state preserved, no fork.
+    expect(store.inspectScope(scope()).assertions).toBe(1);
+    expect(store.projectRecall(scope()).includes).toEqual(['assn-active-synthetic-dev']);
+  });
+
+  it('supersede repoints recall to the corrected active; prior preserved/excluded', () => {
+    const store = seededStore();
+    store.record(scope(), admitTransition());
+    const r = store.record(scope(), supersedeTransition());
+    expect(r.outcome).toBe('recorded');
+    expect(store.projectRecall(scope())).toEqual({
+      includes: ['assn-corrected-synthetic-dev'],
+      excludes: ['assn-active-synthetic-dev'],
+    });
+    expect(store.inspectScope(scope()).assertions).toBe(2);
+  });
+});
+
+// ── Capacity bounds (per-estate delegated + per-store actor cap) ───────────────
+
+describe('Phase 46V route-storage spike — capacity bounds (bounded rejection)', () => {
+  it('seeding more than maxActors distinct actors fails closed (no eviction)', () => {
+    const store = createRouteStorageSpikeStore({ ...CONFIG, maxActors: 2 });
+    store.seedScope(scope({ actor_id: 'actor-1' }));
+    store.seedScope(scope({ actor_id: 'actor-2' }));
+    expect(() => store.seedScope(scope({ actor_id: 'actor-3' }))).toThrow(
+      RouteStorageSpikeActorCapExceededError,
+    );
+    // The two existing actors are untouched (no eviction).
+    expect(store.actorCount()).toBe(2);
+  });
+
+  it('per-estate assertion cap is enforced (delegated to the wrapped ledger)', () => {
+    const store = createRouteStorageSpikeStore({ ...CONFIG, maxAssertionsPerEstate: 1 });
+    store.seedScope(scope());
+    store.record(scope(), admitTransition());
+    // A second, distinct admit (new id + new key) into the same estate overflows.
+    expect(() =>
+      store.record(
+        scope(),
+        admitTransition({
+          admitted_assertion_id: 'assn-second-synthetic-dev',
+          replay_key: 'admit:cand-second',
+          source_candidate_id: 'cand-second-dev',
+        }),
+      ),
+    ).toThrow();
+    expect(store.inspectScope(scope()).assertions).toBe(1);
+  });
+});
+
+// ── Rollback / tombstone / cleanup (Phase 46U §11) ─────────────────────────────
+
+describe('Phase 46V route-storage spike — tombstone / cleanup is reversible & residue-free', () => {
+  it('tombstoning an actor leaves no recallable residue', () => {
+    const store = seededStore();
+    store.record(scope(), admitTransition());
+    expect(store.projectRecall(scope()).includes).toEqual(['assn-active-synthetic-dev']);
+
+    store.tombstoneActor(scope());
+    expect(store.isActorTombstoned(scope())).toBe(true);
+    // Not recallable; zero footprint; empty audit.
+    expect(store.projectRecall(scope())).toEqual({ includes: [], excludes: [] });
+    expect(store.inspectScope(scope())).toEqual({ assertions: 0, bytes: 0 });
+    expect(store.auditTrail(scope())).toEqual([]);
+  });
+
+  it('a tombstoned actor cannot be written to (fail closed)', () => {
+    const store = seededStore();
+    store.tombstoneActor(scope());
+    expect(() => store.record(scope(), admitTransition())).toThrow(RouteStorageSpikeActorScopeError);
+  });
+
+  it('a tombstoned actor cannot be silently revived by re-seeding (fail closed)', () => {
+    const store = seededStore();
+    store.tombstoneActor(scope());
+    expect(() => store.seedScope(scope())).toThrow(RouteStorageSpikeActorScopeError);
+    // Still counted (no silent revival, no eviction).
+    expect(store.actorCount()).toBe(1);
+  });
+
+  it('tombstoneActor is idempotent and a no-op for an unseeded actor', () => {
+    const store = seededStore();
+    store.tombstoneActor(scope());
+    expect(() => store.tombstoneActor(scope())).not.toThrow();
+    // No-op for a never-seeded actor.
+    expect(() => store.tombstoneActor(scope({ actor_id: 'actor-never' }))).not.toThrow();
+    expect(store.isActorTombstoned(scope({ actor_id: 'actor-never' }))).toBe(false);
+  });
+});
+
+// ── Non-durability (process-restart analogue) ─────────────────────────────────
+
+describe('Phase 46V route-storage spike — non-durable (no residue across instances)', () => {
+  it('a fresh store is empty — a second instance shares no state (restart analogue)', () => {
+    const a = seededStore();
+    a.record(scope(), admitTransition());
+    expect(a.inspectScope(scope()).assertions).toBe(1);
+
+    const b = createRouteStorageSpikeStore(CONFIG);
+    // No durable backend: the new instance knows nothing of the first.
+    expect(b.actorCount()).toBe(0);
+    expect(b.projectRecall(scope())).toEqual({ includes: [], excludes: [] });
+  });
+});
+
+// ── Actor-id snapshot / TOCTOU discipline (Codex Phase 46V blocker) ────────────
+//
+// The store reads `scope.actor_id` EXACTLY ONCE per operation (snapshot-and-
+// validate), then keys every `actors.get`/`actors.set`, tombstone check, error
+// classification, and ledger selection off that immutable local. A caller-owned
+// accessor (`get actor_id()`) that returns DIFFERENT values across reads must
+// therefore be unable to: validate as a benign/unseeded actor and then map/set
+// onto a tombstoned actor (silent revival); validate as one actor and operate on
+// another (cross-actor isolation bypass); or smuggle an unsafe label past
+// validation. These tests build such shifting accessors and prove the snapshot
+// holds. Against the pre-fix validate-then-reread implementation they fail (the
+// getter is read 2–3×, so a tombstoned actor is revived / another actor is hit);
+// against the snapshot fix they pass (the getter is read exactly once).
+
+const ACTOR_DECOY = 'actor-synthetic-decoy';
+
+/** Build a scope whose `actor_id` is an accessor that returns `values[0]` on the
+ *  first read, `values[1]` on the second, …, repeating the LAST value for every
+ *  subsequent read. `tenant_id` / `estate_id` are stable plain values (only the
+ *  actor dimension shifts). `reads()` exposes how many times `actor_id` was read
+ *  — a snapshot-correct operation reads it exactly once. */
+function shiftingActorScope(
+  values: string[],
+  over?: { tenant_id?: string; estate_id?: string },
+): { scope: RouteStorageSpikeScope; reads: () => number } {
+  let count = 0;
+  const target: Record<string, unknown> = {
+    tenant_id: over?.tenant_id ?? TENANT,
+    estate_id: over?.estate_id ?? ESTATE,
+  };
+  Object.defineProperty(target, 'actor_id', {
+    enumerable: true,
+    configurable: true,
+    get() {
+      const v = values[Math.min(count, values.length - 1)];
+      count += 1;
+      return v;
+    },
+  });
+  return { scope: target as RouteStorageSpikeScope, reads: () => count };
+}
+
+describe('Phase 46V route-storage spike — actor-id snapshot defeats shifting-accessor TOCTOU', () => {
+  it('seedScope: a shifting getter cannot silently revive a tombstoned actor', () => {
+    const store = seededStore(); // ACTOR_A seeded
+    store.record(scope({ actor_id: ACTOR_A }), admitTransition());
+    store.tombstoneActor(scope({ actor_id: ACTOR_A }));
+    expect(store.isActorTombstoned(scope({ actor_id: ACTOR_A }))).toBe(true);
+
+    // The pre-fix exploit: reads 1 & 2 (validate + actors.get) see an UNSEEDED
+    // decoy, so the new-actor branch is taken and the tombstone check is skipped;
+    // read 3 (actors.set) sees the TOMBSTONED ACTOR_A, overwriting its tombstone
+    // with a fresh live ledger → silent revival. The snapshot fix reads once.
+    const { scope: shifting, reads } = shiftingActorScope([ACTOR_DECOY, ACTOR_DECOY, ACTOR_A]);
+    store.seedScope(shifting);
+
+    // Snapshot discipline: actor_id was read EXACTLY once (pre-fix path read 3×).
+    expect(reads()).toBe(1);
+    // ACTOR_A was NOT revived — still tombstoned, not recallable, zero residue.
+    expect(store.isActorTombstoned(scope({ actor_id: ACTOR_A }))).toBe(true);
+    expect(store.projectRecall(scope({ actor_id: ACTOR_A }))).toEqual({ includes: [], excludes: [] });
+    expect(store.inspectScope(scope({ actor_id: ACTOR_A }))).toEqual({ assertions: 0, bytes: 0 });
+    expect(store.auditTrail(scope({ actor_id: ACTOR_A }))).toEqual([]);
+    // A write into tombstoned ACTOR_A still fails closed.
+    expect(() => store.record(scope({ actor_id: ACTOR_A }), admitTransition())).toThrow(
+      RouteStorageSpikeActorScopeError,
+    );
+
+    // Only the VALIDATED first-read actor (the decoy) was seeded, as its own
+    // independent, live, isolated slot — proving the operation acted on the
+    // snapshotted id, not the shifted one.
+    expect(store.isActorTombstoned(scope({ actor_id: ACTOR_DECOY }))).toBe(false);
+    expect(store.record(scope({ actor_id: ACTOR_DECOY }), admitTransition()).outcome).toBe('recorded');
+    // The decoy's data does not bleed into ACTOR_A (isolation intact).
+    expect(store.projectRecall(scope({ actor_id: ACTOR_A }))).toEqual({ includes: [], excludes: [] });
+  });
+
+  it('record: a shifting getter cannot write nominally-as-a-tombstoned-actor into a live actor', () => {
+    const store = createRouteStorageSpikeStore(CONFIG);
+    // ACTOR_A: seeded then tombstoned. ACTOR_B: seeded and live with one assertion.
+    store.seedScope(scope({ actor_id: ACTOR_A }));
+    store.record(scope({ actor_id: ACTOR_A }), admitTransition());
+    store.tombstoneActor(scope({ actor_id: ACTOR_A }));
+    store.seedScope(scope({ actor_id: ACTOR_B }));
+    store.record(scope({ actor_id: ACTOR_B }), admitTransition());
+
+    // Getter: read 1 (validate) = tombstoned ACTOR_A (validation is label-only and
+    // passes); read 2 (actors.get / ledger selection) = live ACTOR_B. The pre-fix
+    // path would select B's ledger and commit a write "as A" into B (tombstone
+    // bypass + cross-actor write). The snapshot fix resolves the single read to A,
+    // finds it tombstoned, and fails closed.
+    const crossWrite = admitTransition({
+      admitted_assertion_id: 'assn-cross-actor-dev',
+      replay_key: 'admit:cand-cross',
+      source_candidate_id: 'cand-cross-dev',
+    });
+    const { scope: shifting, reads } = shiftingActorScope([ACTOR_A, ACTOR_B]);
+
+    let reason: string | undefined;
+    expect(() => {
+      try {
+        store.record(shifting, crossWrite);
+      } catch (err) {
+        if (err instanceof RouteStorageSpikeActorScopeError) reason = err.reason;
+        throw err;
+      }
+    }).toThrow(RouteStorageSpikeActorScopeError);
+    expect(reason).toBe('tombstoned_actor'); // resolved to A (snapshot), not B
+    expect(reads()).toBe(1);
+
+    // Live ACTOR_B received NOTHING — no cross-actor write landed.
+    expect(store.inspectScope(scope({ actor_id: ACTOR_B })).assertions).toBe(1);
+    expect(store.projectRecall(scope({ actor_id: ACTOR_B })).includes).toEqual([
+      'assn-active-synthetic-dev',
+    ]);
+    // Tombstoned ACTOR_A stays empty.
+    expect(store.projectRecall(scope({ actor_id: ACTOR_A }))).toEqual({ includes: [], excludes: [] });
+  });
+
+  it('reads: a shifting getter cannot read another (live) actor through a tombstoned scope', () => {
+    const store = createRouteStorageSpikeStore(CONFIG);
+    // ACTOR_A: seeded then tombstoned. ACTOR_B: live with recallable data.
+    store.seedScope(scope({ actor_id: ACTOR_A }));
+    store.record(scope({ actor_id: ACTOR_A }), admitTransition());
+    store.tombstoneActor(scope({ actor_id: ACTOR_A }));
+    store.seedScope(scope({ actor_id: ACTOR_B }));
+    store.record(scope({ actor_id: ACTOR_B }), admitTransition());
+
+    // Each read API is given a FRESH shifting scope (read 1 = tombstoned ACTOR_A,
+    // read 2 = live ACTOR_B). The pre-fix path validates A then selects B's ledger
+    // → leaks B's data through a scope that names A. The snapshot fix resolves the
+    // single read to tombstoned A → empty (no cross-actor read, no tombstone leak).
+    const proj = shiftingActorScope([ACTOR_A, ACTOR_B]);
+    expect(store.projectRecall(proj.scope)).toEqual({ includes: [], excludes: [] });
+    expect(proj.reads()).toBe(1);
+
+    const insp = shiftingActorScope([ACTOR_A, ACTOR_B]);
+    expect(store.inspectScope(insp.scope)).toEqual({ assertions: 0, bytes: 0 });
+    expect(insp.reads()).toBe(1);
+
+    const aud = shiftingActorScope([ACTOR_A, ACTOR_B]);
+    expect(store.auditTrail(aud.scope)).toEqual([]);
+    expect(aud.reads()).toBe(1);
+
+    // ACTOR_B's own (correctly-scoped) view is unchanged and still isolated.
+    expect(store.projectRecall(scope({ actor_id: ACTOR_B })).includes).toEqual([
+      'assn-active-synthetic-dev',
+    ]);
+  });
+
+  it('a shifting getter introduces no public/private leak and echoes no actor value', () => {
+    const store = createRouteStorageSpikeStore(CONFIG);
+    store.seedScope(scope({ actor_id: ACTOR_A }));
+    store.record(scope({ actor_id: ACTOR_A }), admitTransition());
+    store.tombstoneActor(scope({ actor_id: ACTOR_A }));
+    store.seedScope(scope({ actor_id: ACTOR_B }));
+    store.record(scope({ actor_id: ACTOR_B }), admitTransition());
+
+    // The fail-closed error from a TOCTOU write attempt carries no actor value and
+    // trips no leak detector.
+    let message = '';
+    const { scope: shifting } = shiftingActorScope([ACTOR_A, ACTOR_B]);
+    try {
+      store.record(shifting, admitTransition());
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).not.toContain(ACTOR_A);
+    expect(message).not.toContain(ACTOR_B);
+    expect(findAdmissionPublicLeaks(message)).toEqual([]);
+
+    // The tombstoned victim (ACTOR_A) surfaces NOTHING after the exploit attempt —
+    // empty projection / zero footprint / empty audit. (The store's own audit
+    // trail is an intentionally PRIVATE surface carrying private keys, so the
+    // public-leak detector is applied only to surfaces that must be empty for the
+    // victim and to the public-facing recall projection.)
+    const leakFreeSurfaces: unknown[] = [
+      store.projectRecall(scope({ actor_id: ACTOR_A })),
+      store.inspectScope(scope({ actor_id: ACTOR_A })),
+      store.auditTrail(scope({ actor_id: ACTOR_A })),
+      store.projectRecall(scope({ actor_id: ACTOR_B })),
+    ];
+    for (const surface of leakFreeSurfaces) {
+      expect(findAdmissionPublicLeaks(surface)).toEqual([]);
+    }
+    // Victim ACTOR_A genuinely has no residue.
+    expect(store.projectRecall(scope({ actor_id: ACTOR_A }))).toEqual({ includes: [], excludes: [] });
+    expect(store.inspectScope(scope({ actor_id: ACTOR_A }))).toEqual({ assertions: 0, bytes: 0 });
+    expect(store.auditTrail(scope({ actor_id: ACTOR_A }))).toEqual([]);
+  });
+
+  it('seedScope: a shifting getter cannot smuggle an unsafe label past validation', () => {
+    const store = createRouteStorageSpikeStore(CONFIG);
+    // Read 1 (validate + use) = a SAFE decoy; later reads = an UNSAFE label the
+    // pre-fix path would map/set under (creating an unsafe-labelled actor slot).
+    // The snapshot fix reads once, so the unsafe value is NEVER observed.
+    const { scope: shifting, reads } = shiftingActorScope([ACTOR_DECOY, 'actor-secret-injected']);
+    store.seedScope(shifting);
+
+    expect(reads()).toBe(1); // the unsafe second value is never read
+    expect(store.actorCount()).toBe(1);
+    // The SAFE decoy is the actor that was seeded — live, isolated, writable.
+    expect(store.isActorTombstoned(scope({ actor_id: ACTOR_DECOY }))).toBe(false);
+    expect(store.record(scope({ actor_id: ACTOR_DECOY }), admitTransition()).outcome).toBe('recorded');
+  });
+});

--- a/docs/admission-wedge/PHASE-46V-ROUTE-STORAGE-SPIKE-RUNBOOK.md
+++ b/docs/admission-wedge/PHASE-46V-ROUTE-STORAGE-SPIKE-RUNBOOK.md
@@ -1,0 +1,106 @@
+# Phase 46V — Admission Wedge dev/operator-only route-storage spike: enable/disable runbook
+
+> **Status:** dev/operator-only **route-storage** spike. **Draft / non-final.**
+> **Disabled by default.** **NON-PRODUCTION.** Uses **Storage Mode 1** —
+> no-migration, bounded-synthetic, **in-process** route-owned storage: no
+> database, **no durable write**, **no migration**. Its synthetic state lives in
+> JS `Map`s in a factory closure and is lost on restart (no recallable residue).
+>
+> Authorized **narrowly** by Phase 46U
+> ([`../ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md`](../ADMISSION-WEDGE-ROUTE-STORAGE-SPIKE-AUTHORIZATION-GATE.md)
+> §3–§16). This spike does **not** authorize production storage, production DB
+> writes, production migration execution, production admission, production
+> auth/consent, public `remember-this`, Discord / freeform ingestion,
+> chat-as-memory, Freeside runtime/client integration, a route-contract freeze, or
+> a final schema freeze. It claims **no** production readiness and discharges
+> **no** operative Straylight-side gate.
+
+## What it is
+
+A bounded, process-local, **non-durable**, tenant/estate/**actor**-scoped
+route-owned store wired behind the existing `POST /api/admission/intake`
+dev/operator route. When enabled (both gates below), an `accept` / `supersede`
+records the **same** fixed synthetic transition the route already derives — built
+from constants, never from request material — into the store, so the candidate →
+admitted-assertion → recall transition's *stateful effect* can be exercised over
+**synthetic material only**. The store's records and ids are **never** surfaced in
+the public body; the public response is byte-identical to the no-store path.
+
+Storage **Mode 1** was chosen over Mode 2 (durable + Lane-1 `aw_*` migrations)
+because the Phase 33N scope guards forbid any durable-write / SQL / migration
+token or production-store import in the spike path, and the repo's global
+migration runner would adopt any new migration into the **production** set — so a
+durable mode cannot be added without weakening an existing security guard. Mode 1
+proves the route-owned storage semantics with the lowest blast radius (Phase 46U
+§6 / §7).
+
+It adds the **third** isolation dimension (actor) over the Phase 33Q ledger by
+holding one independent bounded ledger per synthetic actor, so one actor's records
+are structurally unreachable from another's.
+
+## Default (off)
+
+Two **independent** gates, **both** required:
+
+- `DIXIE_ADMISSION_INTAKE_ENABLED` (the existing base route gate) — with it unset
+  or not exactly `"true"`, the route is **not registered at all**.
+- `DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED` (the **draft / non-final** Phase
+  46V storage gate) — with it unset or not exactly `"true"`, the route runs the
+  **no-store** path verbatim (Phase 33N behavior; current behavior unchanged).
+
+The storage spike **never** activates on the base route gate alone. With the
+storage gate set but the base gate off, the route is not mounted and the storage
+spike does nothing.
+
+## Enable (dev/operator only)
+
+```bash
+# Required to mount the route at all (existing base gate).
+export DIXIE_ADMISSION_INTAKE_ENABLED=true
+
+# Required to engage the route-storage spike (DRAFT / non-final name).
+export DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED=true
+
+# Dev/operator credential gate (unchanged): a service token, an operator-id
+# allowlist, or BOTH. With BOTH empty, the enabled route rejects ALL calls.
+export DIXIE_ADMISSION_INTAKE_SERVICE_TOKEN='<synthetic-dev-operator-token>'
+export DIXIE_ADMISSION_INTAKE_OPERATOR_IDS='op-alice,op-bob'
+```
+
+`DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED` is a **draft / non-final** name
+(Phase 46U §5). Do **not** commit real tokens/ids — provide them via env/secret.
+The dev/operator credential is **not** production auth and is **not** consent.
+
+## Disable / rollback / kill switch
+
+Unset `DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED` (or set it to anything other
+than `"true"`) and restart — the route reverts to the no-store path with **no**
+durable state to roll back (Mode 1 persists nothing). Unset
+`DIXIE_ADMISSION_INTAKE_ENABLED` to remove the endpoint entirely.
+
+Within a running process, the store exposes a reversible **tombstone** cleanup
+path: tombstoning a synthetic actor releases its state, after which the actor is
+not recallable (empty projection / zero footprint / empty audit) and further
+writes fail closed — no recallable residue. Because nothing is durable, a process
+restart is itself a complete reset.
+
+## Failure / capacity posture
+
+- **degraded / failed store** → fail closed: any store throw (capacity / scope /
+  conflict / tombstoned actor) collapses the request to the stable public-safe
+  refusal (`400 ingress.invalid_request`), leaving the store exactly as it was
+  (atomic; no partially-admitted / recallable residue) and leaking neither the
+  error nor any id;
+- **capacity** → bounded **rejection**, never eviction: a per-store actor cap and
+  per-estate assertion-count / byte budgets; inserts beyond budget fail closed;
+- **disabled / unauthorized** → safe: a disabled spike leaks nothing; an
+  unauthorized caller gets a stable refusal that never reveals which gate failed.
+
+## No-leak guarantee
+
+Unchanged from Phase 33N: every public response is built purely from the
+classified scenario plus fixed synthetic placeholders, then deep-walked by the
+runtime no-leak guard (the 114-key `FORBIDDEN_PUBLIC_KEYS` + substring / regex /
+UUID / opaque-run walls). Persisted and replayed public responses are deep-walked
+exactly like a fresh one; store record ids, private audit fields, receipt refs,
+and the synthetic actor id never appear on the wire.


### PR DESCRIPTION
## Summary

Phase 46V implements the bounded Admission Wedge dev/operator route-storage spike authorized by Phase 46U / PR #166.

This implementation chooses Mode 1:

- no migrations
- no SQL
- no executable schema
- no DB writes
- bounded synthetic in-process route-owned storage
- process-local state only

Mode 2 was not chosen because existing scope guards prohibit durable-write / SQL / migration patterns inside the spike source surface, and the repo migration runner scans the shared `src/db/migrations/` directory. Adding an `aw_*` migration would risk entering the production migration set.

## Files

New:

- `app/src/services/admission-wedge-spike/route-storage-spike.ts`
- `app/tests/unit/admission-wedge-spike/route-storage-spike.test.ts`
- `app/tests/integration/admission-intake/route-storage-spike.test.ts`
- `docs/admission-wedge/PHASE-46V-ROUTE-STORAGE-SPIKE-RUNBOOK.md`

Modified:

- `app/src/services/admission-wedge-spike/index.ts`
- `app/src/config.ts`
- `app/src/routes/admission-intake.ts`
- `app/src/server.ts`
- `app/tests/unit/admission-wedge-spike/config-gate.test.ts`
- `app/tests/integration/admission-intake/registration.test.ts`
- `app/tests/integration/admission-intake/full-stack.test.ts`

## Implementation

Adds a route-owned Mode 1 store:

- `createRouteStorageSpikeStore(config)`
- process-local `Map` state
- one independent Phase 33Q admitted-assertion ledger per synthetic actor
- explicit max-actor capacity
- actor-label validation
- tenant / estate / actor isolation
- idempotent replay behavior
- conflict fail-closed behavior
- tombstone / cleanup path
- no durable DB/file/socket/timer/network dependency

The route records the fixed synthetic transition it already derives from constants. It does not store raw request material. The store write is optional DI and is guarded inside the existing finalization try/catch. The store result is discarded, and the public response body remains unchanged.

## Gates

Adds one draft/non-final env gate:

- `DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED`

The storage spike is active only when both gates are true:

- `DIXIE_ADMISSION_INTAKE_ENABLED === "true"`
- `DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED === "true"`

The storage spike remains disabled by default.

Missing, blank, or malformed env values do not enable storage.

The storage gate alone does not mount the route.

The base route gate alone does not activate storage.

There is no fallback to production storage.

Existing service-token and operator allowlist behavior remains preserved.

## PATCH resolution

Codex initially returned PATCH for an actor-scope TOCTOU bug.

Issue:

- actor id was validated, then re-read from a caller-owned scope object;
- a shifting `actor_id` getter could validate one value and then use another for actor map lookup/set;
- this could silently revive a tombstoned actor and make it recallable.

Resolution:

- `snapshotActorId(scope)` now reads `scope.actor_id` exactly once;
- validates that local value;
- returns the immutable local;
- all actor-map operations use the snapshotted value;
- `liveLedgerFor()`, `seedScope()`, `tombstoneActor()`, and `isActorTombstoned()` are snapshot-safe;
- `record`, `projectRecall`, `inspectScope`, and `auditTrail` are fixed through `liveLedgerFor()`.

Added focused shifting-accessor tests proving:

- `seedScope()` cannot revive a tombstoned actor;
- `record()` cannot write as a tombstoned actor into another live actor;
- `projectRecall`, `inspectScope`, and `auditTrail` cannot leak another actor through a tombstoned scope;
- no actor id or unsafe value is echoed;
- unsafe second getter values are never read;
- tombstoned actors remain non-recallable and unwritable.

Codex re-audited the patch and returned ACCEPT.

## Safety boundaries

This PR does not add or authorize:

- production durable-store implementation
- production DB writes
- production migration execution
- migrations
- SQL files
- executable schema
- Lane-2 canonical Straylight-store migrations
- production admission
- public remember-this
- Discord/freeform ingestion
- user chat becoming memory
- Freeside runtime/client integration
- package exports
- LLM/voice/Finn wiring
- MVP 3 forget/revoke/correction UI
- route-contract freeze
- final schema freeze
- production readiness
- operative Straylight-side production gate discharge

## No-leak and public response boundary

Public response behavior remains unchanged.

The implementation preserves that:

- stored public responses pass no-leak checks;
- replayed public responses pass no-leak checks;
- conflict/failure responses pass no-leak checks;
- private storage/audit/source/debug/auth/signer/consent details are not on the wire;
- store ids, actor ids, audit fields, receipt refs, storage keys, and ledger internals are not public;
- `active` remains canonical assertion status only;
- public `outcome_class` values remain source-real:
  - `accepted_as_proposed`
  - `admitted`
  - `denied`
  - `superseded_with_correction`
  - `refused`
- `recall_eligible` remains derived/projection-only.

## Proof coverage

Tests cover:

- storage disabled by default;
- AND-gated storage activation;
- blank/malformed env remains disabled;
- no production fallback;
- tenant / estate / actor isolation;
- same idempotency key across actors does not collide;
- same idempotency key across tenant/estate does not collide;
- identical replay returns prior safe result;
- same-key different-content conflict fails closed;
- replay does not duplicate admitted/corrected assertions;
- no cross-tenant, cross-estate, or cross-actor replay;
- throwing store produces stable public refusal;
- no partial recallable assertion residue;
- tombstone / cleanup removes residue;
- tombstoned actor cannot be silently revived;
- capacity overflow fails closed;
- non-durability is proven by fresh instance behavior;
- pending candidates are not recallable;
- rejected candidates create no admitted assertion;
- accepted candidates create/reference an admitted assertion;
- supersession excludes prior assertion from ordinary recall;
- malformed/unsafe payload fails closed.

## Candidate D / ADR-022E boundary

Candidate D remains proposal input/design baseline only.

This is Dixie route-side route-owned storage only.

Canonical Straylight semantics/interfaces/invariants remain preserved.

Phase 46N gate #8 clearing remains bounded Dixie documentation/architecture/handoff prerequisite only.

No operative Straylight-side production gate discharge is claimed.

## Validation

Codex final audit verdict after patch: ACCEPT.

Codex confirmed:

- actor-scope TOCTOU bug is closed;
- `scope.actor_id` is snapshotted exactly once and used for actor map operations;
- shifting-accessor tests directly exercise the old revive/write/read exploit paths;
- Mode 1 remains no-migration, in-process, non-durable storage;
- storage remains default-off via `DIXIE_ADMISSION_INTAKE_STORAGE_SPIKE_ENABLED`;
- base route gate and storage gate are AND-gated;
- route discards store results and builds the same public response body after guarded internal writes;
- no production storage, DB writes, migration execution, Lane-2 canonical store, public remember-this, Discord/freeform ingestion, chat-as-memory, production auth/consent, route-contract freeze, final schema freeze, or operative Straylight production gate discharge was introduced.

Validation results recorded by Codex:

- `git diff --check`: clean
- `git diff --cached --check`: clean
- docs fixture validator: PASS — 5/5
- route-vector validator: PASS — 5/5, no sixth vector
- route-vector self-check: PASS — 44/44
- `tests/unit/admission-wedge-spike/route-storage-spike.test.ts`: 41 passed
- `tests/unit/admission-wedge-spike/no-leak.test.ts`: 163 passed
- `tests/unit/admission-wedge-spike/`: 345 passed
- `tests/integration/admission-intake/route-storage-spike.test.ts`: 16 passed
- combined admission-wedge unit plus admission-intake integration: 411 passed
- `npm run typecheck`: passed
- touched-file ESLint: passed
- full `npx --no-install vitest run`: 167 files passed, 1 skipped; 3073 passed, 22 skipped
