### PR TITLE
Phase 47F feat: add admission aw sql isolation spike

### DIFF
--- a/app/scripts/aw-sql-isolation-spike-runner.mjs
+++ b/app/scripts/aw-sql-isolation-spike-runner.mjs
@@ -1,0 +1,124 @@
+// Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike: EXPLICIT runner.
+//
+// NON-PRODUCTION, dev/operator-only, disabled-by-default. This is the ONLY
+// entrypoint that ever touches the experimental aw_* SQL isolation spike. It is
+// a deliberate, out-of-band dev/operator command:
+//
+//   * It is NEVER imported by app startup (server.ts) and NEVER mounted by any
+//     route gate.
+//   * It is NEVER wired into a package lifecycle script (no pre*/post*/build
+//     hook in package.json runs it) and never runs through the normal forward-
+//     only production runner.
+//   * It is disabled by default and fails closed unless the dev/operator opt-in
+//     env var is exactly `true` AND the environment is not production.
+//
+// DEFAULT BEHAVIOR is a DRY-RUN PLAN: it resolves the exact manifest, validates
+// every experimental `.sql` path is contained inside the isolated folder, reads
+// the statement text, and prints a plan summary. It opens NO connection and
+// applies NOTHING. There is NO production DB write and NO production execution.
+//
+// EXECUTION (`--apply`) is intentionally fail-closed in this spike: the runner
+// injects NO real client, so `--apply` is refused ("DB/client is absent when
+// execution is requested"). Real execution support, if ever added by a later
+// authorized lane, must be injected and tested against a fake — never a real
+// production database — via applyIsolationSpikePlan(plan, sink) in index.ts.
+//
+// USAGE (explicit dev/operator invocation only — NOT a package script):
+//   DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true \
+//     npx tsx scripts/aw-sql-isolation-spike-runner.mjs            # dry-run forward plan
+//   ... aw-sql-isolation-spike-runner.mjs --direction=cleanup       # dry-run cleanup plan
+//   ... aw-sql-isolation-spike-runner.mjs --apply                   # REFUSED (no client injected)
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  AW_SQL_ISOLATION_SPIKE_GATE_ENV,
+  AW_SQL_ISOLATION_SPIKE_DIR_NAME,
+  assertDevOperatorGateOpen,
+  buildIsolationSpikePlan,
+} from '../src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts';
+
+/** Resolve the SOURCE spike root from this runner's own location, so the plan
+ *  always reads the real `.sql` files + manifest regardless of cwd. */
+function sourceSpikeRoot() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(
+    here,
+    '..',
+    'src',
+    'services',
+    'admission-wedge-spike',
+    AW_SQL_ISOLATION_SPIKE_DIR_NAME,
+  );
+}
+
+function parseArgs(argv) {
+  let direction = 'forward';
+  let apply = false;
+  for (const arg of argv) {
+    if (arg === '--apply') apply = true;
+    else if (arg.startsWith('--direction=')) direction = arg.slice('--direction='.length);
+    else if (arg === '--help' || arg === '-h') return { help: true, direction, apply };
+    else {
+      throw new Error(`unknown argument "${arg}" (supported: --direction=forward|cleanup, --apply, --help)`);
+    }
+  }
+  if (direction !== 'forward' && direction !== 'cleanup') {
+    throw new Error(`invalid --direction "${direction}" (supported: forward, cleanup)`);
+  }
+  return { help: false, direction, apply };
+}
+
+function printHelp() {
+  console.log(
+    [
+      'Phase 47F aw_* SQL isolation spike runner (dev/operator-only, NON-PRODUCTION).',
+      '',
+      `Gate: set ${AW_SQL_ISOLATION_SPIKE_GATE_ENV}=true (and NODE_ENV != production).`,
+      '',
+      'Options:',
+      '  --direction=forward|cleanup   which manifest list to plan (default: forward)',
+      '  --apply                       REFUSED in this spike (no client is injected)',
+      '  --help                        show this help',
+    ].join('\n'),
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  // Fail closed unless the opt-in is exactly `true` AND not production.
+  assertDevOperatorGateOpen({
+    enabledFlag: process.env[AW_SQL_ISOLATION_SPIKE_GATE_ENV],
+    nodeEnv: process.env.NODE_ENV,
+  });
+
+  if (args.apply) {
+    // Execution requested but no client is injected by this spike — fail closed.
+    throw new Error(
+      '--apply is refused: the Phase 47F spike injects no client. Execution is dry-run/plan-only here; ' +
+        'real execution requires a separately-authorized lane that injects a sink (never a production database).',
+    );
+  }
+
+  const spikeRoot = sourceSpikeRoot();
+  const plan = buildIsolationSpikePlan(spikeRoot, args.direction);
+
+  console.log(`Phase 47F aw_* SQL isolation spike — DRY-RUN PLAN (${plan.direction})`);
+  console.log(`  spike root: ${plan.spikeRoot}`);
+  console.log(`  steps: ${plan.steps.length}`);
+  for (const step of plan.steps) {
+    console.log(`    - ${step.relPath} (${step.statementsText.length} bytes; not executed)`);
+  }
+  console.log('  NON-PRODUCTION dry-run only — no connection opened, nothing applied.');
+}
+
+main().catch((err) => {
+  console.error(`aw-sql-isolation-spike-runner: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts
+++ b/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts
@@ -1,0 +1,800 @@
+// Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike: planner / guard module.
+//
+// NON-PRODUCTION, dev/operator-only, disabled-by-default, route-owned spike.
+// Authorized (acceptance-gated) by Phase 47E
+// (docs/ADMISSION-WEDGE-LANE1-AW-SQL-ISOLATION-AUTHORIZATION-CHECKLIST-GATE.md).
+//
+// WHAT THIS MODULE IS. A small, dependency-free planning + validation layer for
+// an EXPERIMENTAL, isolated `aw_isolation_spike_*` family of statements that
+// live ONLY as `.sql` files under this directory's `sql/` subfolder, named by an
+// exact `manifest.json` allowlist. It resolves the manifest, fails closed on any
+// unsafe path (traversal, absolute, outside the isolated folder, a symlink, or a
+// normal production location), reconciles the on-disk `.sql` set against the
+// exact allowlist (refusing any unlisted or missing file), reads the
+// experimental statement text, and builds a dry-run PLAN. It can also apply that
+// plan through an INJECTED sink (a fake in tests; a real dev/operator client only
+// via the explicit out-of-band runner) — it never opens a connection, never
+// reaches a normal runner, and contains no statement text of its own (the text
+// is read at runtime from the `.sql` files).
+//
+// It also exposes a PURE, in-memory synthetic-write reducer that models planned
+// write identity + a content fingerprint, so the dev/operator spike can define
+// (and the tests can prove) identical-replay / conflict / fail-closed semantics
+// WITHOUT any real persistence. The reducer never touches a real client, opens no
+// connection, and is wired to NO route or startup path.
+//
+// WHAT THIS MODULE IS NOT. It is NOT production storage, NOT the final
+// Straylight store, NOT a final schema freeze, NOT a route-contract freeze, and
+// NOT an ADR-022E gate #8 discharge. It is NEVER imported by app startup, NEVER
+// imported by the route gate, and NEVER wired into a package lifecycle script —
+// the only caller is the explicit dev/operator runner
+// (app/scripts/aw-sql-isolation-spike-runner.mjs).
+//
+// ISOLATION POSTURE (by construction). The experimental material lives OUTSIDE
+// the single production source directory the normal forward-only runner scans
+// and OUTSIDE the single source directory the production build packager copies.
+// So the normal runner can neither discover nor run it, and the packager can
+// neither bundle it — without any change to the normal runner or packager, and
+// without any change to the canonical scope guards. This module also imports
+// only `node:` built-ins, so it stays inside the existing import allowlist.
+//
+// AUTH / CONSENT / SIGNER (explicit non-coverage). SQL isolation here does NOT
+// solve production auth, end-user authorization, signer authority, or consent
+// proof / receipt. Each remains its own separately-gated future blocker.
+
+import { readFileSync, existsSync, lstatSync, realpathSync, readdirSync } from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** The dev/operator opt-in env var. Strict `=== 'true'`; default off. */
+export const AW_SQL_ISOLATION_SPIKE_GATE_ENV =
+  'DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED';
+
+/** The isolated folder name (the obvious experimental marker). */
+export const AW_SQL_ISOLATION_SPIKE_DIR_NAME = 'aw-sql-isolation-spike';
+
+/** The leaf folder that holds the experimental `.sql` files. */
+export const AW_SQL_ISOLATION_SPIKE_SQL_SUBDIR = 'sql';
+
+/** The exact allowlist file name. */
+export const AW_SQL_ISOLATION_SPIKE_MANIFEST_FILE = 'manifest.json';
+
+/** The exact `spike` literal the manifest MUST carry (no coercion, exact match). */
+export const AW_SQL_ISOLATION_SPIKE_EXPECTED_SPIKE = 'phase-47f-aw-sql-isolation-spike';
+
+/** The exact `kind` literal the manifest MUST carry (no coercion, exact match). */
+export const AW_SQL_ISOLATION_SPIKE_EXPECTED_KIND = 'experimental-dev-operator-only';
+
+/** The EXACT set of allowed manifest top-level keys. Any other key fails closed. */
+export const AW_SQL_ISOLATION_SPIKE_MANIFEST_KEYS = Object.freeze([
+  'spike',
+  'kind',
+  'production',
+  'schemaFinal',
+  'note',
+  'forward',
+  'cleanup',
+] as const);
+
+/** The cleanup/down filename suffix. A forward entry may not carry it; a cleanup
+ *  entry must. Mirrors the production runner's `_down` exclusion semantics. */
+export const AW_SQL_ISOLATION_SPIKE_DOWN_SUFFIX = '_down.sql';
+
+/** Plan direction — forward DDL, or the reversible cleanup / drop path. */
+export type IsolationSpikeDirection = 'forward' | 'cleanup';
+
+/** The exact manifest shape. `production` and `schemaFinal` MUST be false. */
+export interface IsolationSpikeManifest {
+  spike: string;
+  kind: string;
+  production: boolean;
+  schemaFinal: boolean;
+  note?: string;
+  forward: string[];
+  cleanup: string[];
+}
+
+/** A single resolved, contained, read step of a plan. */
+export interface IsolationSpikeStep {
+  /** The manifest-relative path, verbatim. */
+  relPath: string;
+  /** The resolved real absolute path (proven inside the isolated `sql/` folder). */
+  absolutePath: string;
+  /** The verbatim experimental statement text, read from the `.sql` file. */
+  statementsText: string;
+}
+
+/** A dry-run plan: an ordered, validated list of steps for one direction. */
+export interface IsolationSpikePlan {
+  spikeRoot: string;
+  direction: IsolationSpikeDirection;
+  steps: IsolationSpikeStep[];
+}
+
+/** Inputs to the dev/operator gate (explicit, so the gate is testable). */
+export interface IsolationSpikeGateInput {
+  /** The raw value of the opt-in env var (or undefined when unset). */
+  enabledFlag: string | undefined;
+  /** The raw value of NODE_ENV (or undefined when unset). */
+  nodeEnv: string | undefined;
+}
+
+/** An injected sink the runner uses to apply a plan. Deliberately NOT named
+ *  with any normal-runner / client verb — the spike never reaches one. */
+export interface IsolationSpikeStatementSink {
+  begin(): void | Promise<void>;
+  applyStatement(statementsText: string): void | Promise<void>;
+  commit(): void | Promise<void>;
+  rollback(): void | Promise<void>;
+}
+
+/** Result of applying a plan through an injected sink. */
+export interface IsolationSpikeApplyResult {
+  direction: IsolationSpikeDirection;
+  appliedCount: number;
+  appliedRelPaths: string[];
+}
+
+export class IsolationSpikeDisabledError extends Error {
+  constructor() {
+    super(
+      `Phase 47F aw_* SQL isolation spike is disabled by default. Set ${AW_SQL_ISOLATION_SPIKE_GATE_ENV}=true (dev/operator only, non-production) to opt in.`,
+    );
+    this.name = 'IsolationSpikeDisabledError';
+  }
+}
+
+export class IsolationSpikeProductionRefusedError extends Error {
+  constructor(observedNodeEnv: string) {
+    super(
+      `Phase 47F aw_* SQL isolation spike refuses to run in a production environment (NODE_ENV=${observedNodeEnv}). It is dev/operator-only and non-production.`,
+    );
+    this.name = 'IsolationSpikeProductionRefusedError';
+  }
+}
+
+export class IsolationSpikeManifestError extends Error {
+  constructor(reason: string) {
+    super(`Phase 47F aw_* SQL isolation spike manifest is invalid: ${reason}`);
+    this.name = 'IsolationSpikeManifestError';
+  }
+}
+
+export class IsolationSpikePathEscapeError extends Error {
+  constructor(relPath: string, reason: string) {
+    super(
+      `Phase 47F aw_* SQL isolation spike rejected path "${relPath}": ${reason}`,
+    );
+    this.name = 'IsolationSpikePathEscapeError';
+  }
+}
+
+export class IsolationSpikeApplyError extends Error {
+  constructor(reason: string) {
+    super(`Phase 47F aw_* SQL isolation spike apply failed (rolled back): ${reason}`);
+    this.name = 'IsolationSpikeApplyError';
+  }
+}
+
+/** Thrown when a synthetic write carries non-opaque / unbounded / malformed
+ *  reference material — the spike persists ONLY short bounded opaque references,
+ *  never raw payload, source material, or raw reasons. */
+export class IsolationSpikeSyntheticInputError extends Error {
+  constructor(reason: string) {
+    super(`Phase 47F aw_* SQL isolation spike rejected synthetic write input: ${reason}`);
+    this.name = 'IsolationSpikeSyntheticInputError';
+  }
+}
+
+/** Thrown when a replay reuses an identity with DIFFERENT material — fail-closed,
+ *  nothing recorded, so no partially-admitted recallable artifact survives. */
+export class IsolationSpikeReplayConflictError extends Error {
+  /** The scope+identity key whose material changed. */
+  readonly identityKey: string;
+  constructor(identityKey: string) {
+    super(
+      `Phase 47F aw_* SQL isolation spike refused a replay conflict: the same identity was re-presented with different material (fail-closed; nothing recorded).`,
+    );
+    this.name = 'IsolationSpikeReplayConflictError';
+    this.identityKey = identityKey;
+  }
+}
+
+/** Resolve this module's own directory — the spike root. */
+export function defaultSpikeRoot(): string {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+/** The absolute path of the isolated `sql/` folder under a spike root. */
+export function isolatedSqlDir(spikeRoot: string): string {
+  return resolve(spikeRoot, AW_SQL_ISOLATION_SPIKE_SQL_SUBDIR);
+}
+
+/** True when the opt-in flag is exactly the literal `true`. Fail-closed. */
+export function isDevOperatorGateOpen(input: IsolationSpikeGateInput): boolean {
+  return input.enabledFlag === 'true' && !isProductionEnv(input.nodeEnv);
+}
+
+/** True when NODE_ENV indicates a production environment. */
+export function isProductionEnv(nodeEnv: string | undefined): boolean {
+  return (nodeEnv ?? '').trim().toLowerCase() === 'production';
+}
+
+/**
+ * Fail closed unless the dev/operator opt-in is exactly `true` AND the
+ * environment is not production. Throws a typed error otherwise — never a
+ * silent skip, never a production fallback.
+ */
+export function assertDevOperatorGateOpen(input: IsolationSpikeGateInput): void {
+  if (isProductionEnv(input.nodeEnv)) {
+    throw new IsolationSpikeProductionRefusedError((input.nodeEnv ?? '').trim());
+  }
+  if (input.enabledFlag !== 'true') {
+    throw new IsolationSpikeDisabledError();
+  }
+}
+
+/**
+ * Validate one manifest-relative path and return its proven-contained absolute
+ * path — LEXICAL containment only (no disk access). Fails closed for: a
+ * non-string / empty entry; an absolute path; any `..` (parent) or `.` segment;
+ * a backslash separator; a non-`.sql` suffix; an entry that is not EXACTLY a
+ * single file directly under the isolated `sql/` folder; or a path that does not
+ * resolve strictly inside that folder. The disk-level guards (symlink rejection
+ * + realpath containment) are layered on top by `resolveRealContainedSqlFile`.
+ */
+export function resolveContainedSqlPath(spikeRoot: string, relPath: unknown): string {
+  if (typeof relPath !== 'string' || relPath.trim().length === 0) {
+    throw new IsolationSpikePathEscapeError(String(relPath), 'entry is not a non-empty string');
+  }
+  if (isAbsolute(relPath)) {
+    throw new IsolationSpikePathEscapeError(relPath, 'absolute paths are not allowed');
+  }
+  if (relPath.includes('\\')) {
+    throw new IsolationSpikePathEscapeError(relPath, 'backslash separators are not allowed');
+  }
+  const segments = relPath.split('/');
+  for (const segment of segments) {
+    if (segment === '..' || segment === '.' || segment.length === 0) {
+      throw new IsolationSpikePathEscapeError(relPath, 'relative or empty path segments are not allowed');
+    }
+  }
+  if (!relPath.endsWith('.sql')) {
+    throw new IsolationSpikePathEscapeError(relPath, 'only .sql files are allowed');
+  }
+  // An entry must be EXACTLY `sql/<file>.sql` — the isolated leaf folder followed
+  // by a single filename. This forbids nested subfolders (so the on-disk
+  // reconciliation by basename is sound) and any sibling / normal location.
+  if (segments.length !== 2 || segments[0] !== AW_SQL_ISOLATION_SPIKE_SQL_SUBDIR) {
+    throw new IsolationSpikePathEscapeError(
+      relPath,
+      `entries must be exactly "${AW_SQL_ISOLATION_SPIKE_SQL_SUBDIR}/<file>.sql"`,
+    );
+  }
+  const sqlDir = isolatedSqlDir(spikeRoot);
+  const resolved = resolve(spikeRoot, relPath);
+  const containmentRoot = sqlDir + sep;
+  if (resolved !== sqlDir && !resolved.startsWith(containmentRoot)) {
+    throw new IsolationSpikePathEscapeError(
+      relPath,
+      'resolved path escapes the isolated sql/ folder',
+    );
+  }
+  return resolved;
+}
+
+/** True iff a manifest-relative path is LEXICALLY contained (does not throw). */
+export function isContainedSqlPath(spikeRoot: string, relPath: unknown): boolean {
+  try {
+    resolveContainedSqlPath(spikeRoot, relPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Assert a realpath-resolved child stays strictly inside a realpath-resolved
+ * parent — using `path.relative`, never a string-prefix check (so a sibling like
+ * `sql-evil/` next to `sql/` cannot satisfy a prefix match). Both sides are
+ * realpath'd by the caller, so platform symlinks in the shared prefix cancel out.
+ */
+function assertRealpathContained(
+  parentReal: string,
+  childReal: string,
+  relPath: string,
+  label: string,
+): void {
+  const rel = relative(parentReal, childReal);
+  if (rel.length === 0 || rel === '..' || rel.startsWith('..' + sep) || isAbsolute(rel)) {
+    throw new IsolationSpikePathEscapeError(
+      relPath,
+      `realpath of ${label} escapes the isolated spike folder`,
+    );
+  }
+}
+
+/**
+ * Disk-level path guard for a single manifested file. On top of lexical
+ * containment it: confirms the file exists; rejects a symlink (via `lstat`,
+ * which does NOT follow the link) so a `sql/*.sql` symlink cannot point at a
+ * production file or anywhere outside the folder; rejects a non-regular file;
+ * and verifies the file's REALPATH still resolves strictly inside the isolated
+ * `sql/` folder's realpath. Returns the proven-contained real absolute path.
+ */
+export function resolveRealContainedSqlFile(spikeRoot: string, relPath: unknown): string {
+  const lexical = resolveContainedSqlPath(spikeRoot, relPath);
+  const rel = String(relPath);
+  let lst;
+  try {
+    lst = lstatSync(lexical);
+  } catch {
+    throw new IsolationSpikeManifestError(`manifested file is missing on disk: ${rel}`);
+  }
+  if (lst.isSymbolicLink()) {
+    throw new IsolationSpikePathEscapeError(rel, 'symlinks are not allowed');
+  }
+  if (!lst.isFile()) {
+    throw new IsolationSpikePathEscapeError(rel, 'manifested entry is not a regular file');
+  }
+  const realFile = realpathSync(lexical);
+  const realSqlDir = realpathSync(isolatedSqlDir(spikeRoot));
+  assertRealpathContained(realSqlDir, realFile, rel, 'manifested file');
+  return realFile;
+}
+
+/** The EXACT basenames a manifest lists across both directions (forward∪cleanup). */
+function manifestListedBasenames(manifest: IsolationSpikeManifest): Set<string> {
+  return new Set([...manifest.forward, ...manifest.cleanup].map((p) => basename(p)));
+}
+
+/**
+ * Reconcile the on-disk `.sql` set against the exact manifest allowlist. Fails
+ * closed if ANY present `.sql` file is not listed (no "adopt every .sql in the
+ * folder" fallback) and if ANY listed file is absent. The reconciliation is by
+ * basename, which is sound because every entry is exactly `sql/<file>.sql`.
+ */
+function reconcileSqlDirAgainstManifest(spikeRoot: string, manifest: IsolationSpikeManifest): void {
+  const sqlDir = isolatedSqlDir(spikeRoot);
+  if (!existsSync(sqlDir)) {
+    throw new IsolationSpikeManifestError(`isolated sql/ folder not found at ${sqlDir}`);
+  }
+  // Reject a symlinked sql/ dir and verify its realpath stays inside the root.
+  const sqlDirStat = lstatSync(sqlDir);
+  if (sqlDirStat.isSymbolicLink()) {
+    throw new IsolationSpikePathEscapeError(AW_SQL_ISOLATION_SPIKE_SQL_SUBDIR, 'the sql/ folder must not be a symlink');
+  }
+  const realRoot = realpathSync(spikeRoot);
+  const realSqlDir = realpathSync(sqlDir);
+  assertRealpathContained(realRoot, realSqlDir, AW_SQL_ISOLATION_SPIKE_SQL_SUBDIR, 'sql/ folder');
+
+  const presentSql = readdirSync(sqlDir).filter((f) => f.endsWith('.sql'));
+  const listed = manifestListedBasenames(manifest);
+
+  // (1) Fail closed on any present `.sql` that the manifest does not list.
+  for (const f of presentSql) {
+    if (!listed.has(f)) {
+      throw new IsolationSpikeManifestError(
+        `an unlisted .sql file is present in the isolated sql/ folder: ${f} (the manifest is an EXACT allowlist; unlisted files fail closed)`,
+      );
+    }
+  }
+  // (2) Fail closed on any listed file that is absent on disk.
+  const present = new Set(presentSql);
+  for (const f of listed) {
+    if (!present.has(f)) {
+      throw new IsolationSpikeManifestError(`manifested file is missing on disk: ${f}`);
+    }
+  }
+}
+
+/** Validate the strict manifest schema and return the normalized manifest. No
+ *  coercion: every field must already be the exact expected type/literal. */
+function validateManifestSchema(parsed: unknown): IsolationSpikeManifest {
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new IsolationSpikeManifestError('manifest must be a JSON object');
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  // (a) EXACT top-level keys — reject any unknown key (no extra metadata).
+  const allowed = new Set<string>(AW_SQL_ISOLATION_SPIKE_MANIFEST_KEYS);
+  for (const key of Object.keys(obj)) {
+    if (!allowed.has(key)) {
+      throw new IsolationSpikeManifestError(`unknown top-level key "${key}" (the manifest schema is exact)`);
+    }
+  }
+
+  // (b) Exact literal scalars — NO coercion. A wrong type or value fails closed.
+  if (obj.spike !== AW_SQL_ISOLATION_SPIKE_EXPECTED_SPIKE) {
+    throw new IsolationSpikeManifestError(
+      `manifest "spike" must be exactly "${AW_SQL_ISOLATION_SPIKE_EXPECTED_SPIKE}"`,
+    );
+  }
+  if (obj.kind !== AW_SQL_ISOLATION_SPIKE_EXPECTED_KIND) {
+    throw new IsolationSpikeManifestError(
+      `manifest "kind" must be exactly "${AW_SQL_ISOLATION_SPIKE_EXPECTED_KIND}"`,
+    );
+  }
+  if (obj.production !== false) {
+    throw new IsolationSpikeManifestError('manifest "production" must be exactly false');
+  }
+  if (obj.schemaFinal !== false) {
+    throw new IsolationSpikeManifestError('manifest "schemaFinal" must be exactly false');
+  }
+  if ('note' in obj && typeof obj.note !== 'string') {
+    throw new IsolationSpikeManifestError('manifest "note", when present, must be a string');
+  }
+
+  // (c) forward / cleanup — non-empty arrays of strings, no coercion.
+  const forward = obj.forward;
+  const cleanup = obj.cleanup;
+  if (!Array.isArray(forward) || forward.length === 0) {
+    throw new IsolationSpikeManifestError('manifest "forward" must be a non-empty array');
+  }
+  if (!Array.isArray(cleanup) || cleanup.length === 0) {
+    throw new IsolationSpikeManifestError('manifest "cleanup" must be a non-empty array');
+  }
+  for (const entry of [...forward, ...cleanup]) {
+    if (typeof entry !== 'string') {
+      throw new IsolationSpikeManifestError('every forward/cleanup entry must be a string path');
+    }
+  }
+  const forwardStr = forward as string[];
+  const cleanupStr = cleanup as string[];
+
+  // (d) Determinism — reject duplicate paths within a list and across lists.
+  assertNoDuplicates(forwardStr, 'forward');
+  assertNoDuplicates(cleanupStr, 'cleanup');
+  const cleanupSet = new Set(cleanupStr);
+  for (const f of forwardStr) {
+    if (cleanupSet.has(f)) {
+      throw new IsolationSpikeManifestError(`path "${f}" appears in BOTH forward and cleanup (lists must be disjoint)`);
+    }
+  }
+
+  // (e) Role / filename consistency — a forward entry may not carry the cleanup
+  //     suffix; a cleanup entry must. Mirrors the production runner's `_down`
+  //     exclusion so a drop step can never land in the forward apply list.
+  for (const f of forwardStr) {
+    if (f.endsWith(AW_SQL_ISOLATION_SPIKE_DOWN_SUFFIX)) {
+      throw new IsolationSpikeManifestError(
+        `forward entry "${f}" must not be a cleanup ("${AW_SQL_ISOLATION_SPIKE_DOWN_SUFFIX}") file`,
+      );
+    }
+  }
+  for (const c of cleanupStr) {
+    if (!c.endsWith(AW_SQL_ISOLATION_SPIKE_DOWN_SUFFIX)) {
+      throw new IsolationSpikeManifestError(
+        `cleanup entry "${c}" must be a "${AW_SQL_ISOLATION_SPIKE_DOWN_SUFFIX}" file`,
+      );
+    }
+  }
+
+  return {
+    spike: AW_SQL_ISOLATION_SPIKE_EXPECTED_SPIKE,
+    kind: AW_SQL_ISOLATION_SPIKE_EXPECTED_KIND,
+    production: false,
+    schemaFinal: false,
+    note: typeof obj.note === 'string' ? obj.note : undefined,
+    forward: forwardStr,
+    cleanup: cleanupStr,
+  };
+}
+
+function assertNoDuplicates(list: string[], label: string): void {
+  const seen = new Set<string>();
+  for (const item of list) {
+    if (seen.has(item)) {
+      throw new IsolationSpikeManifestError(`duplicate ${label} entry "${item}" (entries must be unique)`);
+    }
+    seen.add(item);
+  }
+}
+
+/** Read + parse + strictly validate the exact manifest under a spike root, then
+ *  reconcile the on-disk `.sql` set and prove every listed file is a contained,
+ *  non-symlink, realpath-verified regular file. Any deviation fails closed. */
+export function loadIsolationSpikeManifest(spikeRoot: string): IsolationSpikeManifest {
+  const manifestPath = join(spikeRoot, AW_SQL_ISOLATION_SPIKE_MANIFEST_FILE);
+  if (!existsSync(manifestPath)) {
+    throw new IsolationSpikeManifestError(`manifest not found at ${manifestPath}`);
+  }
+  // The manifest file itself must be a non-symlink whose realpath is in the root.
+  if (lstatSync(manifestPath).isSymbolicLink()) {
+    throw new IsolationSpikePathEscapeError(AW_SQL_ISOLATION_SPIKE_MANIFEST_FILE, 'the manifest must not be a symlink');
+  }
+  const realRoot = realpathSync(spikeRoot);
+  const realManifest = realpathSync(manifestPath);
+  assertRealpathContained(realRoot, realManifest, AW_SQL_ISOLATION_SPIKE_MANIFEST_FILE, 'manifest');
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (err) {
+    throw new IsolationSpikeManifestError(
+      `manifest is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const manifest = validateManifestSchema(parsed);
+
+  // Every listed entry must be a LEXICALLY contained `.sql` path — fail closed.
+  for (const entry of [...manifest.forward, ...manifest.cleanup]) {
+    resolveContainedSqlPath(spikeRoot, entry);
+  }
+
+  // Reconcile the on-disk set: no unlisted file, no missing file.
+  reconcileSqlDirAgainstManifest(spikeRoot, manifest);
+
+  // Disk-level guard for every listed file: no symlink, realpath-contained.
+  for (const entry of [...manifest.forward, ...manifest.cleanup]) {
+    resolveRealContainedSqlFile(spikeRoot, entry);
+  }
+
+  return manifest;
+}
+
+/**
+ * Build a validated dry-run plan for one direction. Every step is path-checked
+ * (lexical + realpath, no symlink), proven present on disk, and its experimental
+ * statement text is read verbatim from the realpath-verified file. Building a
+ * plan opens no connection and applies nothing.
+ */
+export function buildIsolationSpikePlan(
+  spikeRoot: string,
+  direction: IsolationSpikeDirection,
+): IsolationSpikePlan {
+  const manifest = loadIsolationSpikeManifest(spikeRoot);
+  const relPaths = direction === 'forward' ? manifest.forward : manifest.cleanup;
+  const steps: IsolationSpikeStep[] = relPaths.map((relPath) => {
+    // Re-verify the file right before reading (symlink + realpath containment)
+    // so a swap between load and read still fails closed.
+    const absolutePath = resolveRealContainedSqlFile(spikeRoot, relPath);
+    const statementsText = readFileSync(absolutePath, 'utf8');
+    return { relPath, absolutePath, statementsText };
+  });
+  return { spikeRoot, direction, steps };
+}
+
+/**
+ * Apply a plan through an injected sink, all-or-nothing. Calls `begin()`, then
+ * `applyStatement(text)` for each step in order, then `commit()`. Any throw
+ * triggers `rollback()` and a wrapped fail-closed error — so a partial failure
+ * never leaves a half-applied, partially-admitted footprint. The sink is
+ * injected (a fake in tests; a real dev/operator client only from the explicit
+ * runner). This function names no client, opens no connection, and embeds no
+ * statement text.
+ */
+export async function applyIsolationSpikePlan(
+  plan: IsolationSpikePlan,
+  sink: IsolationSpikeStatementSink,
+): Promise<IsolationSpikeApplyResult> {
+  const appliedRelPaths: string[] = [];
+  await sink.begin();
+  try {
+    for (const step of plan.steps) {
+      await sink.applyStatement(step.statementsText);
+      appliedRelPaths.push(step.relPath);
+    }
+    await sink.commit();
+  } catch (err) {
+    try {
+      await sink.rollback();
+    } catch {
+      // A rollback fault must not mask the original failure.
+    }
+    throw new IsolationSpikeApplyError(err instanceof Error ? err.message : String(err));
+  }
+  return {
+    direction: plan.direction,
+    appliedCount: appliedRelPaths.length,
+    appliedRelPaths,
+  };
+}
+
+// ── Bounded opaque references + dev-only replay / conflict reducer ─────────────
+//
+// The experimental schema persists ONLY short, bounded, opaque `awref:` strings —
+// never raw payload, source material, or raw reasons. The SQL DDL enforces this
+// with CHECK constraints; the reducer below enforces the SAME shape in the
+// in-memory dev model so the replay/conflict semantics are exercised against the
+// real boundary, not an unbounded string.
+
+/** Max length (chars) of any bounded opaque reference. Mirrors the DDL bound. */
+export const SYNTHETIC_REF_MAX_LENGTH = 80;
+
+/** The narrow opaque-reference kinds the spike recognizes. Each maps to a
+ *  predictable `awref:<kind>:<short-id>` prefix. */
+export const SYNTHETIC_REF_KINDS = Object.freeze([
+  'tenant',
+  'estate',
+  'actor',
+  'assertion',
+  'payload',
+  'receipt',
+  'transition',
+  'audit',
+] as const);
+
+export type SyntheticRefKind = (typeof SYNTHETIC_REF_KINDS)[number];
+
+/** The bounded opaque-reference body: a short id of a narrow character set. The
+ *  `{0,59}` bound keeps the full string well under SYNTHETIC_REF_MAX_LENGTH so a
+ *  raw JSON blob, source text, or long raw reason can never fit. */
+const SYNTHETIC_REF_BODY = '[A-Za-z0-9][A-Za-z0-9_-]{0,59}';
+
+const SYNTHETIC_REF_RE_BY_KIND: Record<SyntheticRefKind, RegExp> = (() => {
+  const map = {} as Record<SyntheticRefKind, RegExp>;
+  for (const k of SYNTHETIC_REF_KINDS) {
+    map[k] = new RegExp(`^awref:${k}:${SYNTHETIC_REF_BODY}$`);
+  }
+  return Object.freeze(map);
+})();
+
+/** A bounded synthetic assertion-class label (NOT a reference): lower-snake, short. */
+const SYNTHETIC_CLASS_RE = /^[a-z][a-z0-9_]{0,63}$/;
+
+/** True iff `value` is a bounded opaque reference of the given kind. */
+export function isSyntheticOpaqueRef(value: unknown, kind: SyntheticRefKind): boolean {
+  return (
+    typeof value === 'string' &&
+    value.length <= SYNTHETIC_REF_MAX_LENGTH &&
+    SYNTHETIC_REF_RE_BY_KIND[kind].test(value)
+  );
+}
+
+function assertSyntheticOpaqueRef(value: unknown, kind: SyntheticRefKind, field: string): string {
+  if (!isSyntheticOpaqueRef(value, kind)) {
+    throw new IsolationSpikeSyntheticInputError(
+      `field "${field}" must be a bounded opaque "awref:${kind}:<short-id>" reference (max ${SYNTHETIC_REF_MAX_LENGTH} chars)`,
+    );
+  }
+  return value as string;
+}
+
+/** A synthetic, route-owned admitted-assertion write. Identity is the
+ *  (tenant, estate, actor, assertion) tuple; material is the class + opaque refs.
+ *  Every field is a bounded opaque reference / label — NO raw payload. */
+export interface SyntheticAssertionWrite {
+  tenantRef: string;
+  estateRef: string;
+  actorRef: string;
+  assertionRef: string;
+  assertionClass: string;
+  candidatePayloadRef?: string | null;
+  publicReceiptRef?: string | null;
+}
+
+/** The outcome of planning/recording a synthetic write. */
+export type SyntheticWriteStatus = 'planned' | 'applied' | 'identical_replay' | 'conflict';
+
+export interface SyntheticWriteResult {
+  status: SyntheticWriteStatus;
+  /** Scope+identity key (tenant|estate|actor|assertion). */
+  identityKey: string;
+  /** Stable fingerprint over the write's identity-defining + material fields. */
+  fingerprint: string;
+}
+
+/** A pure, in-memory model of the synthetic admitted-assertion sink. It never
+ *  touches a real client, opens no connection, and persists nothing durably. */
+export interface SyntheticWriteReducer {
+  /** Dry-run: returns what WOULD happen WITHOUT mutating
+   *  ('planned' | 'identical_replay' | 'conflict'). */
+  plan(write: SyntheticAssertionWrite): SyntheticWriteResult;
+  /** Record into the in-memory model: 'applied' for new material, 'identical_replay'
+   *  for an exact retry (no-op), and a THROW (fail-closed) on a conflicting replay
+   *  — nothing is recorded on conflict, so no partial admit survives. */
+  record(write: SyntheticAssertionWrite): SyntheticWriteResult;
+  /** Record a batch atomically: a conflict mid-batch rolls back every write this
+   *  batch recorded and rethrows, so a conflict never leaves a partial footprint. */
+  recordBatch(writes: SyntheticAssertionWrite[]): SyntheticWriteResult[];
+  /** A read-only snapshot of the recorded identity keys (for assertions/recovery). */
+  recordedKeys(): string[];
+}
+
+/** Validate a write and derive its (identityKey, fingerprint). Validation
+ *  rejects any non-opaque / unbounded field, so raw material cannot enter. */
+function deriveSyntheticIdentity(write: SyntheticAssertionWrite): {
+  identityKey: string;
+  fingerprint: string;
+} {
+  if (write === null || typeof write !== 'object') {
+    throw new IsolationSpikeSyntheticInputError('synthetic write must be an object');
+  }
+  const tenantRef = assertSyntheticOpaqueRef(write.tenantRef, 'tenant', 'tenantRef');
+  const estateRef = assertSyntheticOpaqueRef(write.estateRef, 'estate', 'estateRef');
+  const actorRef = assertSyntheticOpaqueRef(write.actorRef, 'actor', 'actorRef');
+  const assertionRef = assertSyntheticOpaqueRef(write.assertionRef, 'assertion', 'assertionRef');
+
+  if (typeof write.assertionClass !== 'string' || !SYNTHETIC_CLASS_RE.test(write.assertionClass)) {
+    throw new IsolationSpikeSyntheticInputError(
+      'field "assertionClass" must be a short lower-snake label (max 64 chars)',
+    );
+  }
+  const candidatePayloadRef =
+    write.candidatePayloadRef === undefined || write.candidatePayloadRef === null
+      ? null
+      : assertSyntheticOpaqueRef(write.candidatePayloadRef, 'payload', 'candidatePayloadRef');
+  const publicReceiptRef =
+    write.publicReceiptRef === undefined || write.publicReceiptRef === null
+      ? null
+      : assertSyntheticOpaqueRef(write.publicReceiptRef, 'receipt', 'publicReceiptRef');
+
+  // Identity = the scope tuple that the SQL unique constraint pins.
+  const identityKey = JSON.stringify([tenantRef, estateRef, actorRef, assertionRef]);
+  // Fingerprint = identity + all material, so an identical retry matches and any
+  // material change is a conflict. Bounded because every field is bounded above.
+  const fingerprint = JSON.stringify([
+    tenantRef,
+    estateRef,
+    actorRef,
+    assertionRef,
+    write.assertionClass,
+    candidatePayloadRef,
+    publicReceiptRef,
+  ]);
+  return { identityKey, fingerprint };
+}
+
+/**
+ * Create a fresh, pure in-memory synthetic-write reducer that defines the
+ * dev-only replay / conflict semantics for the spike. It is NOT a real sink: it
+ * opens no connection, names no client, and persists nothing durably — it exists
+ * so the spike can prove identical-replay vs conflict behavior in isolation.
+ */
+export function createSyntheticWriteReducer(): SyntheticWriteReducer {
+  // identityKey -> fingerprint of the recorded material.
+  const recorded = new Map<string, string>();
+
+  function plan(write: SyntheticAssertionWrite): SyntheticWriteResult {
+    const { identityKey, fingerprint } = deriveSyntheticIdentity(write);
+    const prior = recorded.get(identityKey);
+    if (prior === undefined) {
+      return { status: 'planned', identityKey, fingerprint };
+    }
+    if (prior === fingerprint) {
+      return { status: 'identical_replay', identityKey, fingerprint };
+    }
+    return { status: 'conflict', identityKey, fingerprint };
+  }
+
+  function record(write: SyntheticAssertionWrite): SyntheticWriteResult {
+    const { identityKey, fingerprint } = deriveSyntheticIdentity(write);
+    const prior = recorded.get(identityKey);
+    if (prior === undefined) {
+      recorded.set(identityKey, fingerprint);
+      return { status: 'applied', identityKey, fingerprint };
+    }
+    if (prior === fingerprint) {
+      // Idempotent retry: explicit no-op, NOT a generic duplicate failure.
+      return { status: 'identical_replay', identityKey, fingerprint };
+    }
+    // Conflicting replay: fail closed, record nothing.
+    throw new IsolationSpikeReplayConflictError(identityKey);
+  }
+
+  function recordBatch(writes: SyntheticAssertionWrite[]): SyntheticWriteResult[] {
+    // Snapshot the prior state so a conflict mid-batch leaves NO partial footprint.
+    const saved = new Map(recorded);
+    const results: SyntheticWriteResult[] = [];
+    try {
+      for (const w of writes) {
+        results.push(record(w));
+      }
+      return results;
+    } catch (err) {
+      recorded.clear();
+      for (const [k, v] of saved) {
+        recorded.set(k, v);
+      }
+      throw err;
+    }
+  }
+
+  function recordedKeys(): string[] {
+    return [...recorded.keys()];
+  }
+
+  return { plan, record, recordBatch, recordedKeys };
+}

--- a/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/manifest.json
+++ b/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/manifest.json
@@ -1,0 +1,13 @@
+{
+  "spike": "phase-47f-aw-sql-isolation-spike",
+  "kind": "experimental-dev-operator-only",
+  "production": false,
+  "schemaFinal": false,
+  "note": "EXACT allowlist of experimental aw_* SQL files for the Phase 47F dev/operator isolated spike. NON-PRODUCTION. Files are relative to this manifest's directory and must resolve inside the sql/ subdirectory. The normal production runner never consults this manifest; isolation of the normal runner is by LOCATION, not by this manifest.",
+  "forward": [
+    "sql/0001_aw_isolation_spike_init.sql"
+  ],
+  "cleanup": [
+    "sql/0001_aw_isolation_spike_init_down.sql"
+  ]
+}

--- a/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init.sql
+++ b/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init.sql
@@ -1,0 +1,111 @@
+-- Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike (EXPERIMENTAL forward DDL).
+--
+-- NON-PRODUCTION, dev/operator-only, disabled-by-default, route-owned spike DDL.
+--
+-- ISOLATION (by construction):
+--   * This file lives OUTSIDE the normal production migration directory
+--     (app/src/db/migrations/). The normal production runner scans only its own
+--     single directory and the production packager copies only that directory's
+--     `.sql` assets — neither ever discovers, executes, or bundles this file.
+--   * This file is applied ONLY by the explicit dev/operator runner
+--     (app/scripts/aw-sql-isolation-spike-runner.mjs), and only when the
+--     dev/operator opt-in env gate is set to exactly `true` AND the environment
+--     is NOT production. It NEVER runs on app startup and NEVER runs through any
+--     package lifecycle script.
+--
+-- NON-GOALS (explicit): this is NOT production storage, NOT the final Straylight
+-- store, NOT a final schema freeze, NOT a route-contract freeze, and NOT an
+-- ADR-022E gate #8 discharge. The shape below is the Phase 46S DRAFT
+-- (schema_final FALSE), realized here as an obviously-experimental
+-- `aw_isolation_spike_*` family for a dev/operator spike only.
+--
+-- DATA MINIMIZATION (BOUNDED OPAQUE REFERENCES ONLY; enforced, not commented):
+--   Every reference column is a short, bounded, opaque `awref:<kind>:<short-id>`
+--   string — NEVER a raw candidate payload, source material, raw reasons, private
+--   audit internals, or any public-response-expanding material. This is enforced
+--   in the SCHEMA itself: each ref column is VARCHAR(80) AND carries a CHECK
+--   constraint pinning a narrow `awref:` prefix + character set + length bound, so
+--   a raw JSON blob, long source text, or free-form reason can NOT be stored by
+--   schema design. `candidate_payload_ref` is therefore a short reference, never
+--   the payload; `public_receipt_ref` is a public-safe short reference or NULL.
+
+-- The synthetic admitted-assertion artifact. Every row is scoped by
+-- (tenant_ref, estate_ref, actor_ref) and pins an opaque assertion_ref.
+CREATE TABLE IF NOT EXISTS aw_isolation_spike_assertion (
+  spike_row_id           BIGSERIAL PRIMARY KEY,
+  tenant_ref             VARCHAR(80) NOT NULL,
+  estate_ref             VARCHAR(80) NOT NULL,
+  actor_ref              VARCHAR(80) NOT NULL,
+  assertion_ref          VARCHAR(80) NOT NULL,
+  assertion_class        VARCHAR(64) NOT NULL,
+  assertion_status       VARCHAR(16) NOT NULL DEFAULT 'active',
+  candidate_payload_ref  VARCHAR(80),
+  public_receipt_ref     VARCHAR(80),
+  recorded_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT aw_isolation_spike_assertion_status_chk
+    CHECK (assertion_status IN ('active', 'superseded')),
+  CONSTRAINT aw_isolation_spike_assertion_class_chk
+    CHECK (assertion_class ~ '^[a-z][a-z0-9_]{0,63}$'),
+  CONSTRAINT aw_isolation_spike_assertion_tenant_ref_chk
+    CHECK (tenant_ref ~ '^awref:tenant:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_assertion_estate_ref_chk
+    CHECK (estate_ref ~ '^awref:estate:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_assertion_actor_ref_chk
+    CHECK (actor_ref ~ '^awref:actor:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_assertion_assertion_ref_chk
+    CHECK (assertion_ref ~ '^awref:assertion:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_assertion_candidate_payload_ref_chk
+    CHECK (candidate_payload_ref IS NULL
+           OR candidate_payload_ref ~ '^awref:payload:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_assertion_public_receipt_ref_chk
+    CHECK (public_receipt_ref IS NULL
+           OR public_receipt_ref ~ '^awref:receipt:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_assertion_uniq
+    UNIQUE (tenant_ref, estate_ref, actor_ref, assertion_ref)
+);
+
+-- Dixie-local INVERSE link only (never a rewrite of the canonical append-only
+-- chain): repoints recall from a superseded reference to its correction. The row
+-- is actor-scoped (actor_ref) so every scoped artifact carries the actor, exactly
+-- as the assertion table does.
+CREATE TABLE IF NOT EXISTS aw_isolation_spike_supersession_link (
+  spike_link_id             BIGSERIAL PRIMARY KEY,
+  tenant_ref                VARCHAR(80) NOT NULL,
+  estate_ref                VARCHAR(80) NOT NULL,
+  actor_ref                 VARCHAR(80) NOT NULL,
+  superseded_assertion_ref  VARCHAR(80) NOT NULL,
+  correcting_assertion_ref  VARCHAR(80) NOT NULL,
+  linked_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT aw_isolation_spike_supersession_tenant_ref_chk
+    CHECK (tenant_ref ~ '^awref:tenant:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_supersession_estate_ref_chk
+    CHECK (estate_ref ~ '^awref:estate:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_supersession_actor_ref_chk
+    CHECK (actor_ref ~ '^awref:actor:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_supersession_superseded_ref_chk
+    CHECK (superseded_assertion_ref ~ '^awref:assertion:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_supersession_correcting_ref_chk
+    CHECK (correcting_assertion_ref ~ '^awref:assertion:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_supersession_uniq
+    UNIQUE (tenant_ref, estate_ref, actor_ref, superseded_assertion_ref)
+);
+
+-- Explicit dev/operator cleanup marker (the reversible drop/cleanup story lives
+-- in the paired `_down.sql`; this records intent for a bounded dev artifact). The
+-- row is actor-scoped (actor_ref) so every scoped artifact carries the actor.
+CREATE TABLE IF NOT EXISTS aw_isolation_spike_tombstone (
+  spike_tombstone_id  BIGSERIAL PRIMARY KEY,
+  tenant_ref          VARCHAR(80) NOT NULL,
+  estate_ref          VARCHAR(80) NOT NULL,
+  actor_ref           VARCHAR(80) NOT NULL,
+  assertion_ref       VARCHAR(80) NOT NULL,
+  tombstoned_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT aw_isolation_spike_tombstone_tenant_ref_chk
+    CHECK (tenant_ref ~ '^awref:tenant:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_tombstone_estate_ref_chk
+    CHECK (estate_ref ~ '^awref:estate:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_tombstone_actor_ref_chk
+    CHECK (actor_ref ~ '^awref:actor:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$'),
+  CONSTRAINT aw_isolation_spike_tombstone_assertion_ref_chk
+    CHECK (assertion_ref ~ '^awref:assertion:[A-Za-z0-9][A-Za-z0-9_-]{0,59}$')
+);

--- a/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init_down.sql
+++ b/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init_down.sql
@@ -1,0 +1,16 @@
+-- Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike (EXPERIMENTAL cleanup/drop DDL).
+--
+-- NON-PRODUCTION, dev/operator-only. This is the reversible cleanup / drop /
+-- tombstone path for the experimental `aw_isolation_spike_*` family created by
+-- the paired forward file. It is applied ONLY by the explicit dev/operator
+-- runner under an explicit cleanup invocation — never on app startup, never via
+-- the normal production runner (which ignores `_down` files by construction),
+-- and never via any package lifecycle script.
+--
+-- Dropping these experimental objects removes the entire dev/operator spike
+-- footprint and leaves NO production state behind (the objects are synthetic and
+-- dev-only). Order is reverse of creation.
+
+DROP TABLE IF EXISTS aw_isolation_spike_tombstone;
+DROP TABLE IF EXISTS aw_isolation_spike_supersession_link;
+DROP TABLE IF EXISTS aw_isolation_spike_assertion;

--- a/app/tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts
+++ b/app/tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts
@@ -1,0 +1,177 @@
+// Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike: normal-runner / packaging / startup isolation.
+//
+// Proves, against the ACTUAL production runner + packager + server sources (read
+// from disk, not paraphrased), that the experimental aw_* SQL this lane adds is:
+//   * Section A (§8) — outside the normal production migration directory, so the
+//     normal forward-only runner can neither discover nor execute it;
+//   * Section D (§11) — the normal runner is UNCHANGED (no hard-deny needed,
+//     because isolation is by LOCATION) and existing production migrations stay
+//     valid; a misplaced experimental .sql in the normal dir is proven absent;
+//   * Section E (§12) — the production packager copies only its own src dir's
+//     .sql, so it can never bundle the experimental material (location, not a
+//     copy-script change);
+//   * Section F (§13) — server.ts startup, the base route gate, the Mode-1 gate,
+//     and the durable selector run NO experimental SQL and never import the
+//     runner; only the explicit dev/operator runner can.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_APP = resolve(__dirname, '..', '..', '..');
+const PROD_MIGRATIONS_DIR = join(REPO_APP, 'src', 'db', 'migrations');
+const MIGRATE_SRC = join(REPO_APP, 'src', 'db', 'migrate.ts');
+const SERVER_SRC = join(REPO_APP, 'src', 'server.ts');
+const COPY_MIGRATIONS_SRC = join(REPO_APP, 'scripts', 'copy-migrations.mjs');
+const SPIKE_SERVICE_DIR = join(REPO_APP, 'src', 'services', 'admission-wedge-spike');
+const ISO_SPIKE_DIR = join(SPIKE_SERVICE_DIR, 'aw-sql-isolation-spike');
+const ISO_SQL_DIR = join(ISO_SPIKE_DIR, 'sql');
+const RUNNER_SRC = join(REPO_APP, 'scripts', 'aw-sql-isolation-spike-runner.mjs');
+
+/** EXACT production discovery predicate, mirrored from migrate.ts:79
+ *  (`f.endsWith('.sql') && !f.includes('_down')`). The first test pins the
+ *  source literal so this mirror cannot silently drift. */
+function productionDiscoveryAdopts(filename: string): boolean {
+  return filename.endsWith('.sql') && !filename.includes('_down');
+}
+
+/** EXACT production packager copy predicate, mirrored from
+ *  copy-migrations.mjs:39 (`e.name.endsWith('.sql')`). */
+function productionPackagerCopies(filename: string): boolean {
+  return filename.endsWith('.sql');
+}
+
+// ── Section A (§8) — experimental SQL lives outside the production dir ─────────
+
+describe('Phase 47F isolation — experimental SQL is outside the production migration dir (A.1)', () => {
+  it('the isolated experimental SQL lives under the spike service dir, NOT src/db/migrations', () => {
+    expect(existsSync(ISO_SQL_DIR)).toBe(true);
+    // The isolated dir is under the admission-wedge-spike service tree.
+    expect(ISO_SQL_DIR.startsWith(SPIKE_SERVICE_DIR)).toBe(true);
+    // It is NOT inside the production migrations directory.
+    expect(ISO_SQL_DIR.startsWith(PROD_MIGRATIONS_DIR)).toBe(false);
+    const experimentalFiles = readdirSync(ISO_SQL_DIR).filter((f) => f.endsWith('.sql'));
+    expect(experimentalFiles.length).toBeGreaterThan(0);
+    // Every experimental file carries the aw_ marker.
+    for (const f of experimentalFiles) {
+      expect(/aw_isolation_spike/i.test(f)).toBe(true);
+    }
+  });
+
+  it('A.2 — the production discovery dir contains NO aw_* SQL and nothing admission-related', () => {
+    const files = readdirSync(PROD_MIGRATIONS_DIR);
+    const awSql = files.filter((f) => /^aw[_-]/i.test(f) && f.endsWith('.sql'));
+    expect(awSql).toEqual([]);
+    const adopted = files.filter(productionDiscoveryAdopts);
+    for (const f of adopted) {
+      expect(/admission|aw_isolation|aw_route|aw_assertion|isolation-spike/i.test(f)).toBe(false);
+    }
+  });
+
+  it('A.2 — the production runner scans a single dir and the experimental dir is not it', () => {
+    const src = readFileSync(MIGRATE_SRC, 'utf8');
+    // The runner resolves migrations relative to its own dir: join(__dirname, 'migrations').
+    expect(src).toContain("join(__dirname, 'migrations')");
+    // A non-recursive readdir — it cannot descend into a service subfolder.
+    expect(src).toContain('readdir(MIGRATIONS_DIR)');
+    expect(src).not.toContain('aw-sql-isolation-spike');
+  });
+});
+
+// ── Section D (§11) — normal runner unchanged; production migrations valid ─────
+
+describe('Phase 47F isolation — normal runner is unchanged (Section D / §11)', () => {
+  it('D.3/D.5 — the production discovery predicate is intact (`.sql && !_down`)', () => {
+    const src = readFileSync(MIGRATE_SRC, 'utf8');
+    expect(src).toContain(".endsWith('.sql')");
+    expect(src).toContain("!f.includes('_down')");
+  });
+
+  it('migrate.ts has no aw_* / isolation-spike coupling (no hard-deny was needed)', () => {
+    const src = readFileSync(MIGRATE_SRC, 'utf8');
+    expect(src).not.toMatch(/aw[_-]|isolation-spike|admission/i);
+  });
+
+  it('existing production migrations (003–015) are still present and discoverable', () => {
+    const files = readdirSync(PROD_MIGRATIONS_DIR);
+    const discoverable = files.filter(productionDiscoveryAdopts);
+    // The known production set remains intact.
+    expect(discoverable).toContain('003_schedules.sql');
+    expect(discoverable).toContain('015_agent_ecology.sql');
+    // _down files are excluded by the predicate.
+    expect(discoverable.some((f) => f.includes('_down'))).toBe(false);
+  });
+
+  it('D.4 — even a hypothetically misplaced experimental aw_*.sql is NOT in the production dir', () => {
+    const files = readdirSync(PROD_MIGRATIONS_DIR);
+    expect(files.some((f) => /aw_isolation_spike/i.test(f))).toBe(false);
+  });
+});
+
+// ── Section E (§12) — packaging/copy isolation ────────────────────────────────
+
+describe('Phase 47F isolation — packaging/copy cannot bundle experimental SQL (Section E / §12)', () => {
+  it('E.1 — copy-migrations.mjs scans only src/db/migrations and copies only .sql (unchanged)', () => {
+    const src = readFileSync(COPY_MIGRATIONS_SRC, 'utf8');
+    expect(src).toContain("'src', 'db', 'migrations'");
+    expect(src).toContain("endsWith('.sql')");
+    // It has no awareness of the isolated experimental location.
+    expect(src).not.toMatch(/aw-sql-isolation-spike|admission/i);
+  });
+
+  it('E.3 — the experimental SQL dir is not the packager source dir, so it is never copied', () => {
+    const packagerSrcDir = join(REPO_APP, 'src', 'db', 'migrations');
+    expect(ISO_SQL_DIR.startsWith(packagerSrcDir)).toBe(false);
+  });
+
+  it('E.2 — the packager .sql predicate would copy a .sql, which is exactly why location isolation is used', () => {
+    // The predicate itself copies .sql by name; the safety is that the experimental
+    // .sql is NOT in the scanned source dir (proven above), not a name exclusion.
+    expect(productionPackagerCopies('0001_aw_isolation_spike_init.sql')).toBe(true);
+    expect(productionPackagerCopies('manifest.json')).toBe(false);
+  });
+});
+
+// ── Section F (§13) — startup non-execution ───────────────────────────────────
+
+describe('Phase 47F isolation — startup runs no experimental SQL (Section F / §13)', () => {
+  const serverSrc = () => readFileSync(SERVER_SRC, 'utf8');
+
+  it('F.1 — server.ts startup still calls migrate(dbPool) only inside `if (dbPool)` and adds no new runner', () => {
+    const src = serverSrc();
+    expect(src).toContain('await migrate(dbPool)');
+    const migrateCalls = src.match(/\bmigrate\s*\(/g) ?? [];
+    expect(migrateCalls.length).toBe(1);
+  });
+
+  it('F.2–F.5 — server.ts never imports or invokes the isolation-spike runner / planner', () => {
+    const src = serverSrc();
+    expect(src).not.toMatch(/aw-sql-isolation-spike/);
+    expect(src).not.toMatch(/buildIsolationSpikePlan|applyIsolationSpikePlan|IsolationSpike/);
+    expect(src).not.toMatch(/aw-sql-isolation-spike-runner/);
+  });
+
+  it('the spike service barrel index.ts does NOT re-export the SQL isolation spike (stays runner-only)', () => {
+    const barrel = readFileSync(join(SPIKE_SERVICE_DIR, 'index.ts'), 'utf8');
+    expect(barrel).not.toMatch(/aw-sql-isolation-spike/);
+  });
+
+  it('F.5 — the ONLY caller of the planner is the explicit dev/operator runner', () => {
+    const runner = readFileSync(RUNNER_SRC, 'utf8');
+    expect(runner).toContain('aw-sql-isolation-spike/index.ts');
+    // The runner has a top-level guard assertion before any plan is built.
+    expect(runner).toContain('assertDevOperatorGateOpen');
+  });
+});
+
+// ── Section C (§10 C.7) — no package-lifecycle invocation ─────────────────────
+
+describe('Phase 47F isolation — no package-lifecycle invocation (Section C / §10 C.7)', () => {
+  it('no package.json script references the runner', () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_APP, 'package.json'), 'utf8'));
+    const scriptsStr = JSON.stringify(pkg.scripts ?? {});
+    expect(scriptsStr).not.toMatch(/aw-sql-isolation-spike/);
+    // And the build script still only does tsc + copy-migrations (no spike runner).
+    expect(pkg.scripts.build).toBe('tsc && node scripts/copy-migrations.mjs');
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts
+++ b/app/tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts
@@ -1,0 +1,169 @@
+// Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike: scope-guard preservation evidence.
+//
+// Section G (§14) of the Phase 47E checklist. Phase 47F achieves the STRONGEST
+// possible outcome (same as Phase 47A's `.json` store): the new TypeScript
+// module needs NONE of the forbidden DB/SQL/durable-write tokens, so it passes
+// the CANONICAL 19-entry Phase 33N denylist UNCHANGED — NO denylist entry was
+// removed, NO import rule was relaxed, and NO per-module allowlist was added.
+//
+// This is possible because the experimental SQL text lives ONLY in `.sql` files
+// (which the guard does not scan) and is read at runtime as opaque file content;
+// the `.ts` planner names no client, opens no connection, and embeds no DDL.
+//
+// These tests:
+//   G.1 — re-run the canonical denylist + import rules against the NEW module
+//         and prove zero hits (it is inside the existing guard, not exempted);
+//   G.2/G.3 — prove scope-guards.test.ts adds NO allowlist / opt-out for this
+//         lane (the guard file is unchanged in spirit: no aw-sql allowlist);
+//   G.4/G.5 — prove adjacent forbidden paths STILL fail closed against the same
+//         evasion-resistance bar (re-applied to adversarial samples).
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
+
+const REPO_APP = resolve(__dirname, '..', '..', '..');
+const ISO_INDEX = join(
+  REPO_APP,
+  'src',
+  'services',
+  'admission-wedge-spike',
+  'aw-sql-isolation-spike',
+  'index.ts',
+);
+const SCOPE_GUARDS_SRC = join(REPO_APP, 'tests', 'unit', 'admission-wedge-spike', 'scope-guards.test.ts');
+
+// The CANONICAL Phase 33N 19-entry denylist (lock-step with scope-guards.test.ts:122-142).
+const DURABLE_WRITE_DENYLIST: Array<[string, RegExp]> = [
+  ['INSERT', /\bINSERT\b/i],
+  ['INSERT INTO', /\bINSERT\s+INTO\b/i],
+  ['UPDATE', /\bUPDATE\b/i],
+  ['DELETE', /\bDELETE\b/i],
+  ['CREATE TABLE', /\bCREATE\s+TABLE\b/i],
+  ['ALTER TABLE', /\bALTER\s+TABLE\b/i],
+  ['DROP TABLE', /\bDROP\s+TABLE\b/i],
+  ['pool.query', /\bpool\.query\b/],
+  ['.query(', /\.query\s*\(/],
+  ['query(', /\bquery\s*\(/],
+  ['.execute(', /\.execute\s*\(/],
+  ['execute(', /\bexecute\s*\(/],
+  ['sql`` tagged template', /\bsql\s*`/],
+  ['db.', /\bdb\./],
+  ['database', /\bdatabase\b/i],
+  ['pg', /\bpg\b/],
+  ['postgres', /\bpostgres\b/i],
+  ['migration', /\bmigration\b/i],
+  ['migrate', /\bmigrate\b/i],
+];
+
+const IMPORT_DENYLIST: Array<[string, (spec: string) => boolean]> = [
+  ['bare pg', (s) => s === 'pg'],
+  ['db runner', (s) => /\/db\/(client|pool|migrate|transaction)/.test(s)],
+  ['migrations dir', (s) => /\/db\/migrations\//.test(s)],
+  ['production -store', (s) => /-store(\.js)?$/.test(s)],
+  ['BoundedEstateStore', (s) => /BoundedEstateStore|bounded-estate-store/.test(s)],
+];
+
+/** Parser-backed comment stripper (same approach as scope-guards.test.ts). */
+function stripComments(src: string): string {
+  const sf = ts.createSourceFile('sample.ts', src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const keep = new Uint8Array(src.length);
+  const mark = (node: ts.Node): void => {
+    if (node.kind >= ts.SyntaxKind.FirstJSDocNode && node.kind <= ts.SyntaxKind.LastJSDocNode) return;
+    const children = node.getChildren(sf);
+    if (children.length === 0) {
+      const start = node.getStart(sf, false);
+      const end = node.getEnd();
+      for (let i = start; i < end; i++) keep[i] = 1;
+      return;
+    }
+    for (const child of children) mark(child);
+  };
+  mark(sf);
+  let out = '';
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i]!;
+    out += keep[i] === 1 || /\s/.test(ch) ? ch : ' ';
+  }
+  return out;
+}
+
+function durableWriteHits(stripped: string): string[] {
+  return DURABLE_WRITE_DENYLIST.filter(([, re]) => re.test(stripped)).map(([name]) => name);
+}
+
+const ANY_IMPORT_RE = /^\s*import\b[^'"]*?from\s*['"]([^'"]+)['"]/gm;
+const BARE_IMPORT_RE = /^\s*import\s*['"]([^'"]+)['"]/gm;
+function importSpecifiers(src: string): string[] {
+  const stripped = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const out: string[] = [];
+  for (const m of stripped.matchAll(ANY_IMPORT_RE)) out.push(m[1]!);
+  for (const m of stripped.matchAll(BARE_IMPORT_RE)) out.push(m[1]!);
+  return out;
+}
+
+// ── G.1 — the new module passes the canonical denylist with ZERO hits ─────────
+
+describe('Phase 47F scope-guard — the new module is inside the canonical guard (G.1)', () => {
+  it('the isolation-spike index.ts has NO durable-write/SQL/DB token in executable source', () => {
+    const code = stripComments(readFileSync(ISO_INDEX, 'utf8'));
+    expect(durableWriteHits(code)).toEqual([]);
+  });
+
+  it('the isolation-spike index.ts imports only node: built-ins (inside the import allowlist)', () => {
+    const specifiers = importSpecifiers(readFileSync(ISO_INDEX, 'utf8'));
+    for (const spec of specifiers) {
+      expect({ spec, ok: spec.startsWith('node:') }).toEqual({ spec, ok: true });
+    }
+    for (const [, fn] of IMPORT_DENYLIST) {
+      expect(specifiers.some((s) => fn(s))).toBe(false);
+    }
+  });
+});
+
+// ── G.2/G.3 — no allowlist / opt-out was added for this lane ───────────────────
+
+describe('Phase 47F scope-guard — no allowlist or opt-out was added (G.2/G.3)', () => {
+  it('scope-guards.test.ts adds no aw-sql-isolation allowlist / opt-out', () => {
+    const src = readFileSync(SCOPE_GUARDS_SRC, 'utf8');
+    expect(src).not.toMatch(/aw-sql-isolation.*(allow|skip|exempt|opt-?out|ignore)/i);
+    expect(src).not.toMatch(/(allow|skip|exempt|opt-?out|ignore).*aw-sql-isolation/i);
+    expect(src).not.toMatch(/ALLOW(ED)?_(SQL|DURABLE|STORE|MIGRATION)/);
+  });
+
+  it('the canonical 19-entry denylist tokens are all still present in the live guard', () => {
+    const src = readFileSync(SCOPE_GUARDS_SRC, 'utf8');
+    for (const token of ['INSERT', 'UPDATE', 'DELETE', 'pool\\.query', 'migrate', 'postgres', 'database']) {
+      expect(new RegExp(token).test(src)).toBe(true);
+    }
+  });
+});
+
+// ── G.4/G.5 — adjacent forbidden paths still fail closed ──────────────────────
+
+describe('Phase 47F scope-guard — adjacent forbidden paths still fail closed (G.4/G.5)', () => {
+  it('raw SQL durable-write statements would still be caught by the denylist', () => {
+    const offending = 'const x = 1; pool.query("INSERT INTO aw_records VALUES (1)"); execute("UPDATE x");';
+    expect(durableWriteHits(stripComments(offending))).toEqual(
+      expect.arrayContaining(['pool.query', 'INSERT', 'UPDATE', 'execute(']),
+    );
+  });
+
+  it('forbidden imports (pg / db runner / migrations dir / -store) would still be rejected', () => {
+    for (const spec of ['pg', '../db/migrate.js', '../db/migrations/016_aw.sql', './aw-route-store.js']) {
+      expect(IMPORT_DENYLIST.some(([, fn]) => fn(spec))).toBe(true);
+    }
+  });
+
+  it('the same evasion-resistance bar still holds (nested template / regex char class)', () => {
+    const nested = 'const m = `${`//`}`; pool.query("UPDATE records SET x = 1");';
+    expect(durableWriteHits(stripComments(nested))).toEqual(
+      expect.arrayContaining(['pool.query', 'UPDATE']),
+    );
+    const regexClass = 'function f() { throw /[//]/; } pool.query("UPDATE x");';
+    expect(durableWriteHits(stripComments(regexClass))).toEqual(
+      expect.arrayContaining(['pool.query', 'UPDATE']),
+    );
+  });
+});

--- a/app/tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts
+++ b/app/tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts
@@ -1,0 +1,789 @@
+// Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike: planner / gate / manifest / apply / reducer tests.
+//
+// Proves the Phase 47E checklist obligations for the isolated experimental
+// aw_* SQL spike that this lane implements:
+//   * §10 (Section C) — dev/operator gate required, disabled by default, strict
+//     `=== 'true'`, production refused, never a production default;
+//   * §9 (Section B) — exact manifest: strict schema (exact keys/literals, no
+//     coercion, no duplicates, role/filename consistency), fail closed on
+//     unlisted / unknown / out-of-location / missing, cannot name a production
+//     path or follow a symlink;
+//   * §8 (Section A) — path traversal / absolute / outside-folder / symlink /
+//     realpath-escape fail closed;
+//   * §15 (Section H) — storage semantics: BOUNDED opaque refs only (DDL CHECK +
+//     reducer), NO raw payload, actor scope on every scoped artifact;
+//   * §18 (Section K) — rollback/recovery: all-or-nothing apply, partial-failure
+//     rollback is deterministic; dev-only identical-replay vs conflict is defined
+//     and fails closed with no partial footprint; dry-run plan opens nothing;
+//   * §16 (Section I) — no public response expansion / no-leak parity preserved.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync, symlinkSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  AW_SQL_ISOLATION_SPIKE_GATE_ENV,
+  AW_SQL_ISOLATION_SPIKE_DIR_NAME,
+  assertDevOperatorGateOpen,
+  isDevOperatorGateOpen,
+  isProductionEnv,
+  loadIsolationSpikeManifest,
+  buildIsolationSpikePlan,
+  applyIsolationSpikePlan,
+  resolveContainedSqlPath,
+  resolveRealContainedSqlFile,
+  isContainedSqlPath,
+  isolatedSqlDir,
+  defaultSpikeRoot,
+  createSyntheticWriteReducer,
+  isSyntheticOpaqueRef,
+  SYNTHETIC_REF_MAX_LENGTH,
+  IsolationSpikeDisabledError,
+  IsolationSpikeProductionRefusedError,
+  IsolationSpikeManifestError,
+  IsolationSpikePathEscapeError,
+  IsolationSpikeApplyError,
+  IsolationSpikeSyntheticInputError,
+  IsolationSpikeReplayConflictError,
+  type IsolationSpikeStatementSink,
+  type SyntheticAssertionWrite,
+} from '../../../src/services/admission-wedge-spike/aw-sql-isolation-spike/index.js';
+import {
+  findAdmissionPublicLeaks,
+  isAdmissionPublicSafe,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+const REPO_APP = resolve(__dirname, '..', '..', '..');
+const REAL_SPIKE_ROOT = join(
+  REPO_APP,
+  'src',
+  'services',
+  'admission-wedge-spike',
+  AW_SQL_ISOLATION_SPIKE_DIR_NAME,
+);
+const PROD_MIGRATIONS_DIR = join(REPO_APP, 'src', 'db', 'migrations');
+
+/** Build a temp spike root with a manifest + sql files so manifest edge cases
+ *  can be exercised without touching the real shipped manifest. */
+function makeTempSpike(manifest: unknown, sqlFiles: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'aw-sql-iso-spike-'));
+  mkdirSync(join(root, 'sql'), { recursive: true });
+  for (const [name, body] of Object.entries(sqlFiles)) {
+    writeFileSync(join(root, 'sql', name), body, 'utf8');
+  }
+  writeFileSync(join(root, 'manifest.json'), JSON.stringify(manifest), 'utf8');
+  return root;
+}
+
+const tempRoots: string[] = [];
+function tempSpike(manifest: unknown, sqlFiles: Record<string, string>): string {
+  const root = makeTempSpike(manifest, sqlFiles);
+  tempRoots.push(root);
+  return root;
+}
+function trackTemp(root: string): string {
+  tempRoots.push(root);
+  return root;
+}
+afterEach(() => {
+  while (tempRoots.length) rmSync(tempRoots.pop()!, { recursive: true, force: true });
+});
+
+// The strict schema requires the EXACT spike/kind literals — mirror them here.
+const OK_MANIFEST = {
+  spike: 'phase-47f-aw-sql-isolation-spike',
+  kind: 'experimental-dev-operator-only',
+  production: false,
+  schemaFinal: false,
+  forward: ['sql/0001_init.sql'],
+  cleanup: ['sql/0001_init_down.sql'],
+};
+const OK_SQL = {
+  '0001_init.sql': 'CREATE TABLE IF NOT EXISTS aw_isolation_spike_assertion (x TEXT);',
+  '0001_init_down.sql': 'DROP TABLE IF EXISTS aw_isolation_spike_assertion;',
+};
+
+// ── Section C (§10) — dev/operator gate ───────────────────────────────────────
+
+describe('Phase 47F — dev/operator gate (Section C / §10)', () => {
+  it('is disabled by default: an unset flag fails closed', () => {
+    expect(isDevOperatorGateOpen({ enabledFlag: undefined, nodeEnv: 'development' })).toBe(false);
+    expect(() => assertDevOperatorGateOpen({ enabledFlag: undefined, nodeEnv: 'development' })).toThrow(
+      IsolationSpikeDisabledError,
+    );
+  });
+
+  it('requires the literal "true" — any other value fails closed', () => {
+    for (const v of ['1', 'TRUE', 'yes', 'on', '', ' true ', 'false']) {
+      expect(isDevOperatorGateOpen({ enabledFlag: v, nodeEnv: 'development' })).toBe(false);
+      expect(() => assertDevOperatorGateOpen({ enabledFlag: v, nodeEnv: 'development' })).toThrow(
+        IsolationSpikeDisabledError,
+      );
+    }
+  });
+
+  it('opens only for exactly "true" in a non-production env', () => {
+    expect(isDevOperatorGateOpen({ enabledFlag: 'true', nodeEnv: 'development' })).toBe(true);
+    expect(() => assertDevOperatorGateOpen({ enabledFlag: 'true', nodeEnv: 'development' })).not.toThrow();
+  });
+
+  it('refuses a production environment even when the flag is "true" (§10 C.6 / §7)', () => {
+    for (const env of ['production', 'PRODUCTION', ' production ']) {
+      expect(isProductionEnv(env)).toBe(true);
+      expect(isDevOperatorGateOpen({ enabledFlag: 'true', nodeEnv: env })).toBe(false);
+      expect(() => assertDevOperatorGateOpen({ enabledFlag: 'true', nodeEnv: env })).toThrow(
+        IsolationSpikeProductionRefusedError,
+      );
+    }
+  });
+
+  it('the gate env var name is the dedicated Phase 47F var (no production default)', () => {
+    expect(AW_SQL_ISOLATION_SPIKE_GATE_ENV).toBe(
+      'DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED',
+    );
+  });
+});
+
+// ── Section B (§9) — exact manifest + strict schema ───────────────────────────
+
+describe('Phase 47F — exact manifest (Section B / §9)', () => {
+  it('loads the real shipped manifest and it is non-production / non-final', () => {
+    const m = loadIsolationSpikeManifest(REAL_SPIKE_ROOT);
+    expect(m.production).toBe(false);
+    expect(m.schemaFinal).toBe(false);
+    expect(m.forward.length).toBeGreaterThan(0);
+    expect(m.cleanup.length).toBeGreaterThan(0);
+  });
+
+  it('refuses a manifest whose "production" is not exactly false (B / §15)', () => {
+    const root = tempSpike({ ...OK_MANIFEST, production: true }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(IsolationSpikeManifestError);
+  });
+
+  it('refuses a manifest whose "schemaFinal" is not exactly false (no final schema freeze, §15 H.8)', () => {
+    const root = tempSpike({ ...OK_MANIFEST, schemaFinal: true }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/schemaFinal/);
+  });
+
+  it('refuses an empty forward / cleanup list', () => {
+    const root1 = tempSpike({ ...OK_MANIFEST, forward: [] }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root1)).toThrow(/forward/);
+    const root2 = tempSpike({ ...OK_MANIFEST, cleanup: [] }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root2)).toThrow(/cleanup/);
+  });
+
+  it('refuses a non-object / non-JSON manifest', () => {
+    const root = mkdtempSync(join(tmpdir(), 'aw-sql-iso-bad-'));
+    tempRoots.push(root);
+    mkdirSync(join(root, 'sql'), { recursive: true });
+    writeFileSync(join(root, 'manifest.json'), 'not json at all', 'utf8');
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(IsolationSpikeManifestError);
+  });
+
+  it('B.2 — refuses a manifest entry whose file is missing on disk (fail closed)', () => {
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql', 'sql/9999_absent.sql'] },
+      OK_SQL,
+    );
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/missing on disk/);
+    expect(() => buildIsolationSpikePlan(root, 'forward')).toThrow(/missing on disk/);
+  });
+
+  it('B.5 — refuses an entry outside the isolated sql/ folder', () => {
+    const root = tempSpike({ ...OK_MANIFEST, forward: ['notsql/0001_init.sql'] }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(IsolationSpikePathEscapeError);
+  });
+
+  it('B.5 — refuses a nested subfolder entry (entries must be exactly sql/<file>.sql)', () => {
+    const root = tempSpike({ ...OK_MANIFEST, forward: ['sql/sub/0001_init.sql'] }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(IsolationSpikePathEscapeError);
+  });
+
+  it('B.4 — refuses an entry that names a normal production location', () => {
+    for (const evil of [
+      '../db/migrations/016_aw.sql',
+      '../../db/migrations/016_aw.sql',
+      'sql/../../db/migrations/016_aw.sql',
+    ]) {
+      const root = tempSpike({ ...OK_MANIFEST, forward: [evil] }, OK_SQL);
+      expect(() => loadIsolationSpikeManifest(root)).toThrow(IsolationSpikePathEscapeError);
+    }
+  });
+
+  // ── FAIL CLOSED on unlisted SQL (Codex defect #1) ──────────────────────────
+  it('FAILS CLOSED when an unlisted .sql file is present in sql/ (no "adopt every .sql" fallback)', () => {
+    const root = tempSpike(OK_MANIFEST, {
+      ...OK_SQL,
+      '0002_unlisted.sql': 'CREATE TABLE aw_isolation_spike_extra (x TEXT);',
+    });
+    // The extra file exists on disk...
+    expect(readdirSync(join(root, 'sql'))).toContain('0002_unlisted.sql');
+    // ...and planning REFUSES it (fail closed), rather than silently ignoring it.
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/unlisted .sql/);
+    expect(() => buildIsolationSpikePlan(root, 'forward')).toThrow(/unlisted .sql/);
+  });
+
+  it('FAILS CLOSED when a manifest-listed file is missing (no silent skip)', () => {
+    // Manifest lists two forward files; only one is on disk.
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql', 'sql/0002_more.sql'] },
+      OK_SQL,
+    );
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/missing on disk/);
+  });
+});
+
+describe('Phase 47F — strict manifest schema (Section B / §9, Codex defect #3)', () => {
+  it('rejects an unknown top-level key (exact schema, no extra metadata)', () => {
+    const root = tempSpike({ ...OK_MANIFEST, surprise: true }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/unknown top-level key/);
+  });
+
+  it('rejects a wrong "spike" literal (no coercion)', () => {
+    const root = tempSpike({ ...OK_MANIFEST, spike: 'phase-99z-evil' }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/"spike" must be exactly/);
+  });
+
+  it('rejects a wrong "kind" literal (no coercion)', () => {
+    const root = tempSpike({ ...OK_MANIFEST, kind: 'production-ready' }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/"kind" must be exactly/);
+  });
+
+  it('rejects a coerced "production" (e.g. the string "false", number 0, null)', () => {
+    for (const bad of ['false', 0, null]) {
+      const root = tempSpike({ ...OK_MANIFEST, production: bad }, OK_SQL);
+      expect(() => loadIsolationSpikeManifest(root)).toThrow(/"production" must be exactly false/);
+    }
+  });
+
+  it('rejects a coerced "schemaFinal" (string "false" is NOT boolean false)', () => {
+    const root = tempSpike({ ...OK_MANIFEST, schemaFinal: 'false' }, OK_SQL);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/"schemaFinal" must be exactly false/);
+  });
+
+  it('rejects a non-string ("object") entry — entries are exact string paths, not sub-objects', () => {
+    // The manifest entries are plain string paths; there are no entry sub-keys,
+    // so a non-string entry (the only place "unknown entry keys" could hide) is
+    // rejected outright.
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: [{ path: 'sql/0001_init.sql', extra: 1 }] },
+      OK_SQL,
+    );
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/must be a string path/);
+  });
+
+  it('rejects duplicate forward entries (deterministic unique entries)', () => {
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql', 'sql/0001_init.sql'] },
+      OK_SQL,
+    );
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/duplicate forward entry/);
+  });
+
+  it('rejects a path that appears in BOTH forward and cleanup (disjoint lists)', () => {
+    // Same path in both lists — the disjoint check fires.
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql'], cleanup: ['sql/0001_init.sql'] },
+      OK_SQL,
+    );
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/BOTH forward and cleanup/);
+  });
+
+  it('rejects a `_down.sql` placed in the forward (apply) list', () => {
+    // Disjoint lists, but the forward entry carries the cleanup suffix.
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init_down.sql'], cleanup: ['sql/0002_more_down.sql'] },
+      OK_SQL,
+    );
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/must not be a cleanup/);
+  });
+
+  it('rejects a non-`_down.sql` file placed in the cleanup list', () => {
+    // Disjoint lists, but the cleanup entry is not a `_down.sql` file.
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql'], cleanup: ['sql/0002_more.sql'] },
+      OK_SQL,
+    );
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/must be a "_down\.sql" file/);
+  });
+});
+
+// ── Section A (§8) — path containment / traversal / symlink / realpath ────────
+
+describe('Phase 47F — path containment (Section A / §8, traversal/absolute)', () => {
+  const root = REAL_SPIKE_ROOT;
+
+  it('accepts a contained sql/ path', () => {
+    expect(isContainedSqlPath(root, 'sql/0001_aw_isolation_spike_init.sql')).toBe(true);
+    const abs = resolveContainedSqlPath(root, 'sql/0001_aw_isolation_spike_init.sql');
+    expect(abs.startsWith(isolatedSqlDir(root))).toBe(true);
+  });
+
+  it('rejects traversal (..) segments', () => {
+    for (const evil of ['../x.sql', 'sql/../x.sql', 'sql/../../etc/passwd.sql', '../../db/migrations/x.sql']) {
+      expect(isContainedSqlPath(root, evil)).toBe(false);
+      expect(() => resolveContainedSqlPath(root, evil)).toThrow(IsolationSpikePathEscapeError);
+    }
+  });
+
+  it('rejects absolute paths', () => {
+    for (const evil of ['/etc/passwd.sql', '/tmp/x.sql', resolve(root, 'sql', 'x.sql')]) {
+      expect(isContainedSqlPath(root, evil)).toBe(false);
+      expect(() => resolveContainedSqlPath(root, evil)).toThrow(/absolute/);
+    }
+  });
+
+  it('rejects non-.sql, backslash, dot, and non-string entries', () => {
+    for (const evil of ['sql/x.json', 'sql/x.txt', 'sql\\x.sql', 'sql/./x.sql', '', '   ']) {
+      expect(isContainedSqlPath(root, evil)).toBe(false);
+    }
+    for (const bad of [null, undefined, 42, {}, []]) {
+      expect(isContainedSqlPath(root, bad)).toBe(false);
+    }
+  });
+
+  it('rejects an entry not under the sql/ leaf folder', () => {
+    expect(isContainedSqlPath(root, 'manifest.json')).toBe(false);
+    expect(isContainedSqlPath(root, 'index.ts')).toBe(false);
+    expect(isContainedSqlPath(root, 'other/x.sql')).toBe(false);
+  });
+});
+
+describe('Phase 47F — symlink + realpath containment fail closed (Section A / §8, Codex defect #2)', () => {
+  it('rejects a sql/*.sql symlink that escapes the isolated folder (points outside temp root)', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'aw-sql-iso-outside-'));
+    trackTemp(outside);
+    const outsideFile = join(outside, 'evil.sql');
+    writeFileSync(outsideFile, 'CREATE TABLE evil (x TEXT);', 'utf8');
+
+    const root = mkdtempSync(join(tmpdir(), 'aw-sql-iso-symlink-'));
+    trackTemp(root);
+    mkdirSync(join(root, 'sql'), { recursive: true });
+    writeFileSync(join(root, 'sql', '0001_init_down.sql'), OK_SQL['0001_init_down.sql'], 'utf8');
+    // The forward file is a SYMLINK pointing outside the isolated folder.
+    symlinkSync(outsideFile, join(root, 'sql', '0001_init.sql'));
+    writeFileSync(join(root, 'manifest.json'), JSON.stringify(OK_MANIFEST), 'utf8');
+
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(IsolationSpikePathEscapeError);
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/symlink/);
+    expect(() => resolveRealContainedSqlFile(root, 'sql/0001_init.sql')).toThrow(/symlink/);
+  });
+
+  it('rejects a sql/*.sql symlink that points at a production migration file', () => {
+    const prodFiles = readdirSync(PROD_MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'));
+    expect(prodFiles.length).toBeGreaterThan(0);
+    const prodTarget = join(PROD_MIGRATIONS_DIR, prodFiles[0]!);
+
+    const root = mkdtempSync(join(tmpdir(), 'aw-sql-iso-prodlink-'));
+    trackTemp(root);
+    mkdirSync(join(root, 'sql'), { recursive: true });
+    writeFileSync(join(root, 'sql', '0001_init_down.sql'), OK_SQL['0001_init_down.sql'], 'utf8');
+    symlinkSync(prodTarget, join(root, 'sql', '0001_init.sql'));
+    writeFileSync(join(root, 'manifest.json'), JSON.stringify(OK_MANIFEST), 'utf8');
+
+    // Even though the symlink target is a real .sql file, the symlink itself is
+    // refused before it is ever followed.
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/symlink/);
+  });
+
+  it('rejects a symlinked sql/ directory (the whole folder cannot be a link)', () => {
+    const realSql = mkdtempSync(join(tmpdir(), 'aw-sql-iso-realsql-'));
+    trackTemp(realSql);
+    writeFileSync(join(realSql, '0001_init.sql'), OK_SQL['0001_init.sql'], 'utf8');
+    writeFileSync(join(realSql, '0001_init_down.sql'), OK_SQL['0001_init_down.sql'], 'utf8');
+
+    const root = mkdtempSync(join(tmpdir(), 'aw-sql-iso-dirlink-'));
+    trackTemp(root);
+    symlinkSync(realSql, join(root, 'sql'), 'dir');
+    writeFileSync(join(root, 'manifest.json'), JSON.stringify(OK_MANIFEST), 'utf8');
+
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(IsolationSpikePathEscapeError);
+  });
+
+  it('rejects a symlinked manifest.json', () => {
+    const outside = mkdtempSync(join(tmpdir(), 'aw-sql-iso-manlink-src-'));
+    trackTemp(outside);
+    const manSrc = join(outside, 'manifest.json');
+    writeFileSync(manSrc, JSON.stringify(OK_MANIFEST), 'utf8');
+
+    const root = mkdtempSync(join(tmpdir(), 'aw-sql-iso-manlink-'));
+    trackTemp(root);
+    mkdirSync(join(root, 'sql'), { recursive: true });
+    writeFileSync(join(root, 'sql', '0001_init.sql'), OK_SQL['0001_init.sql'], 'utf8');
+    writeFileSync(join(root, 'sql', '0001_init_down.sql'), OK_SQL['0001_init_down.sql'], 'utf8');
+    symlinkSync(manSrc, join(root, 'manifest.json'));
+
+    expect(() => loadIsolationSpikeManifest(root)).toThrow(/symlink/);
+  });
+
+  it('accepts the real (non-symlinked) shipped files via the disk-level guard', () => {
+    const abs = resolveRealContainedSqlFile(REAL_SPIKE_ROOT, 'sql/0001_aw_isolation_spike_init.sql');
+    expect(abs.startsWith(isolatedSqlDir(REAL_SPIKE_ROOT))).toBe(true);
+  });
+});
+
+// ── Section H (§15) — storage semantics: bounded opaque refs, NO raw payload ──
+
+describe('Phase 47F — storage semantics / bounded opaque refs (Section H / §15)', () => {
+  const forwardText = () =>
+    buildIsolationSpikePlan(REAL_SPIKE_ROOT, 'forward')
+      .steps.map((s) => s.statementsText)
+      .join('\n');
+
+  /** Slice the forward DDL into per-table CREATE blocks (keyed by table name).
+   *  Splits on the CREATE TABLE marker so comments between tables cannot fuse
+   *  two blocks; each block runs to the next CREATE TABLE (or end of file). */
+  function tableBlocks(): Record<string, string> {
+    const text = forwardText();
+    const marker = 'CREATE TABLE IF NOT EXISTS';
+    const blocks: Record<string, string> = {};
+    const starts: number[] = [];
+    for (let i = text.indexOf(marker); i !== -1; i = text.indexOf(marker, i + 1)) {
+      starts.push(i);
+    }
+    for (let k = 0; k < starts.length; k++) {
+      const start = starts[k]!;
+      const end = k + 1 < starts.length ? starts[k + 1]! : text.length;
+      const block = text.slice(start, end);
+      const name = /CREATE TABLE IF NOT EXISTS (aw_isolation_spike_\w+)/.exec(block)?.[1];
+      if (name) blocks[name] = block;
+    }
+    return blocks;
+  }
+
+  it('the real forward plan reads the experimental statement text (dry-run, applies nothing)', () => {
+    const p = buildIsolationSpikePlan(REAL_SPIKE_ROOT, 'forward');
+    expect(p.direction).toBe('forward');
+    expect(p.steps.length).toBe(1);
+    expect(p.steps[0]!.statementsText.length).toBeGreaterThan(0);
+  });
+
+  it('H.1 — reference columns are BOUNDED VARCHAR with CHECK constraints, never unbounded TEXT', () => {
+    const text = forwardText();
+    // Every ref column is declared VARCHAR(80), not raw TEXT.
+    for (const col of [
+      'tenant_ref',
+      'estate_ref',
+      'actor_ref',
+      'assertion_ref',
+      'candidate_payload_ref',
+      'public_receipt_ref',
+    ]) {
+      expect(new RegExp(`${col}\\s+VARCHAR\\(80\\)`).test(text)).toBe(true);
+      // No ref column is declared as bare TEXT.
+      expect(new RegExp(`${col}\\s+TEXT\\b`).test(text)).toBe(false);
+    }
+    // The opaque-ref CHECK pattern (awref: prefix) is enforced in the schema.
+    expect(text).toContain('awref:tenant:');
+    expect(text).toContain('awref:payload:');
+    expect(text).toContain('awref:receipt:');
+    expect(/candidate_payload_ref.*CHECK|CHECK[\s\S]*candidate_payload_ref/.test(text)).toBe(true);
+  });
+
+  it('H.1 — candidate_payload_ref cannot be unbounded raw text by schema design', () => {
+    const text = forwardText();
+    // It is VARCHAR(80) AND constrained to the bounded awref:payload pattern.
+    expect(/candidate_payload_ref\s+VARCHAR\(80\)/.test(text)).toBe(true);
+    expect(text).toContain("candidate_payload_ref ~ '^awref:payload:");
+    // It is NOT a bare TEXT column.
+    expect(/candidate_payload_ref\s+TEXT\b/.test(text)).toBe(false);
+  });
+
+  it('H.1 — there is NO raw payload / source material / raw reasons column', () => {
+    const text = forwardText();
+    expect(/\braw_candidate_payload\b/.test(text)).toBe(false);
+    expect(/\bsource_material\b/.test(text)).toBe(false);
+    expect(/\braw_reasons?\b/.test(text)).toBe(false);
+    expect(/\bcandidate_payload(?!_ref)/.test(text)).toBe(false);
+    expect(/\bprivate_receipt_ref\b/.test(text)).toBe(false);
+  });
+
+  it('H — actor_ref scope appears on EVERY scoped table (assertion + supersession + tombstone)', () => {
+    const blocks = tableBlocks();
+    expect(Object.keys(blocks).sort()).toEqual([
+      'aw_isolation_spike_assertion',
+      'aw_isolation_spike_supersession_link',
+      'aw_isolation_spike_tombstone',
+    ]);
+    for (const [table, ddl] of Object.entries(blocks)) {
+      expect({ table, hasActorRef: /\bactor_ref\b/.test(ddl) }).toEqual({ table, hasActorRef: true });
+      // And actor_ref is itself a bounded opaque ref with a CHECK.
+      expect({ table, bounded: /actor_ref\s+VARCHAR\(80\)/.test(ddl) }).toEqual({ table, bounded: true });
+      expect({ table, checked: /actor_ref ~ '\^awref:actor:/.test(ddl) }).toEqual({ table, checked: true });
+    }
+  });
+
+  it('H.2 — assertion status is the canonical active/superseded only', () => {
+    const text = forwardText();
+    expect(text).toContain("'active'");
+    expect(text).toContain("'superseded'");
+  });
+
+  it('H.6/H.7 — supersession is a Dixie-local inverse link and a cleanup/drop path exists', () => {
+    const forward = forwardText();
+    expect(forward).toContain('aw_isolation_spike_supersession_link');
+    expect(forward).toContain('aw_isolation_spike_tombstone');
+    const cleanup = buildIsolationSpikePlan(REAL_SPIKE_ROOT, 'cleanup');
+    const cleanupText = cleanup.steps.map((s) => s.statementsText).join('\n');
+    expect(cleanupText).toContain('DROP TABLE IF EXISTS aw_isolation_spike_assertion');
+  });
+});
+
+// ── Section H/K — dev-only synthetic-write reducer: replay vs conflict ─────────
+
+describe('Phase 47F — dev-only replay/conflict reducer (Codex defect #5)', () => {
+  const base: SyntheticAssertionWrite = {
+    tenantRef: 'awref:tenant:t1',
+    estateRef: 'awref:estate:e1',
+    actorRef: 'awref:actor:a1',
+    assertionRef: 'awref:assertion:s1',
+    assertionClass: 'admit_assertion',
+    candidatePayloadRef: 'awref:payload:p1',
+    publicReceiptRef: 'awref:receipt:r1',
+  };
+
+  it('a first write is planned, then applied', () => {
+    const r = createSyntheticWriteReducer();
+    expect(r.plan(base).status).toBe('planned');
+    // plan() does not mutate — it can be called repeatedly.
+    expect(r.plan(base).status).toBe('planned');
+    expect(r.recordedKeys()).toEqual([]);
+    expect(r.record(base).status).toBe('applied');
+    expect(r.recordedKeys().length).toBe(1);
+  });
+
+  it('an identical replay returns identical_replay (a no-op), NOT a generic duplicate failure', () => {
+    const r = createSyntheticWriteReducer();
+    r.record(base);
+    expect(r.plan(base).status).toBe('identical_replay');
+    expect(r.record(base).status).toBe('identical_replay');
+    // Still exactly one recorded identity (the retry minted nothing new).
+    expect(r.recordedKeys().length).toBe(1);
+  });
+
+  it('a conflicting replay (same identity, different material) FAILS CLOSED and records nothing', () => {
+    const r = createSyntheticWriteReducer();
+    r.record(base);
+    const conflicting: SyntheticAssertionWrite = { ...base, assertionClass: 'supersede_assertion' };
+    // plan() reports the conflict without throwing; record() fails closed.
+    expect(r.plan(conflicting).status).toBe('conflict');
+    expect(() => r.record(conflicting)).toThrow(IsolationSpikeReplayConflictError);
+    // The original material is intact; the conflicting write left NO footprint.
+    expect(r.recordedKeys().length).toBe(1);
+    expect(r.record(base).status).toBe('identical_replay');
+  });
+
+  it('a conflicting payload reference is also a conflict (material includes refs)', () => {
+    const r = createSyntheticWriteReducer();
+    r.record(base);
+    expect(r.plan({ ...base, candidatePayloadRef: 'awref:payload:p2' }).status).toBe('conflict');
+  });
+
+  it('new material at a different identity is applied independently', () => {
+    const r = createSyntheticWriteReducer();
+    r.record(base);
+    const other: SyntheticAssertionWrite = { ...base, assertionRef: 'awref:assertion:s2' };
+    expect(r.record(other).status).toBe('applied');
+    expect(r.recordedKeys().length).toBe(2);
+  });
+
+  it('recordBatch rolls back on a mid-batch conflict — no partially-admitted assertion survives', () => {
+    const r = createSyntheticWriteReducer();
+    const w1: SyntheticAssertionWrite = { ...base, assertionRef: 'awref:assertion:s1' };
+    r.record(w1); // pre-existing
+    const before = r.recordedKeys().sort();
+
+    const w2: SyntheticAssertionWrite = { ...base, assertionRef: 'awref:assertion:s2' };
+    const conflicting: SyntheticAssertionWrite = { ...w1, assertionClass: 'supersede_assertion' };
+    // Batch: a brand-new write (w2) THEN a conflicting replay of w1.
+    expect(() => r.recordBatch([w2, conflicting])).toThrow(IsolationSpikeReplayConflictError);
+    // The brand-new w2 was rolled back — the recorded set is exactly what it was.
+    expect(r.recordedKeys().sort()).toEqual(before);
+  });
+
+  it('recordBatch commits all writes when there is no conflict', () => {
+    const r = createSyntheticWriteReducer();
+    const w2: SyntheticAssertionWrite = { ...base, assertionRef: 'awref:assertion:s2' };
+    const results = r.recordBatch([base, w2]);
+    expect(results.map((x) => x.status)).toEqual(['applied', 'applied']);
+    expect(r.recordedKeys().length).toBe(2);
+  });
+});
+
+describe('Phase 47F — bounded opaque reference enforcement (reducer mirror of DDL CHECK)', () => {
+  const base: SyntheticAssertionWrite = {
+    tenantRef: 'awref:tenant:t1',
+    estateRef: 'awref:estate:e1',
+    actorRef: 'awref:actor:a1',
+    assertionRef: 'awref:assertion:s1',
+    assertionClass: 'admit_assertion',
+  };
+
+  it('accepts a bounded awref:<kind>:<short-id> reference', () => {
+    expect(isSyntheticOpaqueRef('awref:tenant:abc-123', 'tenant')).toBe(true);
+    expect(isSyntheticOpaqueRef('awref:payload:p1', 'payload')).toBe(true);
+  });
+
+  it('rejects a raw JSON / source-material blob as a reference (no raw payload)', () => {
+    const r = createSyntheticWriteReducer();
+    const rawBlob = JSON.stringify({ raw: 'sensitive candidate text'.repeat(50) });
+    expect(isSyntheticOpaqueRef(rawBlob, 'payload')).toBe(false);
+    expect(() => r.record({ ...base, candidatePayloadRef: rawBlob })).toThrow(
+      IsolationSpikeSyntheticInputError,
+    );
+  });
+
+  it('rejects an over-length reference (capacity bound)', () => {
+    const tooLong = 'awref:payload:' + 'x'.repeat(SYNTHETIC_REF_MAX_LENGTH);
+    expect(tooLong.length).toBeGreaterThan(SYNTHETIC_REF_MAX_LENGTH);
+    expect(isSyntheticOpaqueRef(tooLong, 'payload')).toBe(false);
+    const r = createSyntheticWriteReducer();
+    expect(() => r.record({ ...base, candidatePayloadRef: tooLong })).toThrow(
+      IsolationSpikeSyntheticInputError,
+    );
+  });
+
+  it('rejects a reference with the wrong kind prefix', () => {
+    expect(isSyntheticOpaqueRef('awref:payload:p1', 'tenant')).toBe(false);
+    const r = createSyntheticWriteReducer();
+    expect(() => r.record({ ...base, tenantRef: 'awref:payload:p1' })).toThrow(
+      IsolationSpikeSyntheticInputError,
+    );
+  });
+
+  it('rejects a missing required scope reference', () => {
+    const r = createSyntheticWriteReducer();
+    expect(() => r.record({ ...base, actorRef: '' })).toThrow(IsolationSpikeSyntheticInputError);
+  });
+
+  it('accepts a null/omitted optional payload/receipt reference', () => {
+    const r = createSyntheticWriteReducer();
+    expect(r.record({ ...base, candidatePayloadRef: null, publicReceiptRef: undefined }).status).toBe(
+      'applied',
+    );
+  });
+});
+
+// ── Section K (§18) — rollback / recovery, all-or-nothing apply ───────────────
+
+describe('Phase 47F — rollback / recovery (Section K / §18)', () => {
+  function recordingSink(): IsolationSpikeStatementSink & { calls: string[]; applied: string[] } {
+    const calls: string[] = [];
+    const applied: string[] = [];
+    return {
+      calls,
+      applied,
+      begin() {
+        calls.push('begin');
+      },
+      applyStatement(text: string) {
+        calls.push('apply');
+        applied.push(text);
+      },
+      commit() {
+        calls.push('commit');
+      },
+      rollback() {
+        calls.push('rollback');
+      },
+    };
+  }
+
+  it('K — applies all steps in order then commits (begin → apply* → commit)', async () => {
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql', 'sql/0002_more.sql'] },
+      { ...OK_SQL, '0002_more.sql': 'CREATE TABLE aw_isolation_spike_two (x TEXT);' },
+    );
+    const sink = recordingSink();
+    const result = await applyIsolationSpikePlan(buildIsolationSpikePlan(root, 'forward'), sink);
+    expect(sink.calls).toEqual(['begin', 'apply', 'apply', 'commit']);
+    expect(result.appliedCount).toBe(2);
+    expect(result.appliedRelPaths).toEqual(['sql/0001_init.sql', 'sql/0002_more.sql']);
+  });
+
+  it('K.1/K.2 — a partial failure rolls back deterministically and throws (no half-applied state)', async () => {
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql', 'sql/0002_more.sql'] },
+      { ...OK_SQL, '0002_more.sql': 'CREATE TABLE aw_isolation_spike_two (x TEXT);' },
+    );
+    const calls: string[] = [];
+    let n = 0;
+    const failing: IsolationSpikeStatementSink = {
+      begin() {
+        calls.push('begin');
+      },
+      applyStatement() {
+        calls.push('apply');
+        n += 1;
+        if (n === 2) throw new Error('synthetic apply fault');
+      },
+      commit() {
+        calls.push('commit');
+      },
+      rollback() {
+        calls.push('rollback');
+      },
+    };
+    await expect(
+      applyIsolationSpikePlan(buildIsolationSpikePlan(root, 'forward'), failing),
+    ).rejects.toThrow(IsolationSpikeApplyError);
+    expect(calls).toEqual(['begin', 'apply', 'apply', 'rollback']);
+    expect(calls).not.toContain('commit');
+  });
+
+  it('K — a rollback fault does not mask the original failure', async () => {
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    const failing: IsolationSpikeStatementSink = {
+      begin() {},
+      applyStatement() {
+        throw new Error('apply fault');
+      },
+      commit() {},
+      rollback() {
+        throw new Error('rollback also faulted');
+      },
+    };
+    await expect(
+      applyIsolationSpikePlan(buildIsolationSpikePlan(root, 'forward'), failing),
+    ).rejects.toThrow(IsolationSpikeApplyError);
+  });
+
+  it('dry-run plan building opens no connection and applies nothing (no sink involved)', () => {
+    const p = buildIsolationSpikePlan(REAL_SPIKE_ROOT, 'forward');
+    expect(Array.isArray(p.steps)).toBe(true);
+  });
+});
+
+// ── Section I (§16) — no public response expansion / no-leak parity ───────────
+
+describe('Phase 47F — public/private no-leak (Section I / §16)', () => {
+  it('the isolation spike adds NO public-response builder (no public surface)', () => {
+    const src = readFileSync(join(REAL_SPIKE_ROOT, 'index.ts'), 'utf8');
+    expect(src).not.toMatch(/buildAdmissionSpikePublicResponse|PublicResponse/);
+  });
+
+  it('the runtime no-leak guard is intact and still flags forbidden keys (114-key parity preserved)', () => {
+    expect(findAdmissionPublicLeaks({ tenant_id: 'x' })).not.toEqual([]);
+    expect(findAdmissionPublicLeaks({ receipt_hash: 'x' })).not.toEqual([]);
+    expect(isAdmissionPublicSafe({ outcome_class: 'accepted', recall_eligible: false })).toBe(true);
+  });
+
+  it('I.5 — neither the manifest nor the experimental SQL carries a forbidden public key as data', () => {
+    const manifest = JSON.parse(readFileSync(join(REAL_SPIKE_ROOT, 'manifest.json'), 'utf8'));
+    const manifestStr = JSON.stringify(manifest);
+    expect(manifestStr).not.toMatch(/raw_candidate_payload|source_material|signature|private_receipt_ref/);
+  });
+});
+
+// ── Cross-check — the real spike root resolves and is self-consistent ─────────
+
+describe('Phase 47F — real spike root integrity', () => {
+  it('defaultSpikeRoot resolves under the admission-wedge-spike service dir', () => {
+    expect(typeof defaultSpikeRoot()).toBe('string');
+    const m = loadIsolationSpikeManifest(REAL_SPIKE_ROOT);
+    for (const rel of [...m.forward, ...m.cleanup]) {
+      expect(isContainedSqlPath(REAL_SPIKE_ROOT, rel)).toBe(true);
+    }
+  });
+});

--- a/docs/admission-wedge/PHASE-47F-AW-SQL-ISOLATION-SPIKE-RUNBOOK.md
+++ b/docs/admission-wedge/PHASE-47F-AW-SQL-ISOLATION-SPIKE-RUNBOOK.md
@@ -1,0 +1,240 @@
+# Phase 47F — Admission Wedge dev/operator-only Lane-1 `aw_*` SQL ISOLATION implementation spike: runbook
+
+> **What this is.** Phase 47F is the **first code-bearing lane** after the Phase 47E checklist
+> ([`../ADMISSION-WEDGE-LANE1-AW-SQL-ISOLATION-AUTHORIZATION-CHECKLIST-GATE.md`](../ADMISSION-WEDGE-LANE1-AW-SQL-ISOLATION-AUTHORIZATION-CHECKLIST-GATE.md),
+> Verdict A). It implements the **bounded, dev/operator-only, disabled-by-default, NON-PRODUCTION,
+> route-owned, isolated** experimental `aw_*` SQL spike that the Phase 47D §18 layered direction selected
+> on paper and the Phase 47E §8–§18 checklist authorized — **acceptance-gated** on that checklist.
+>
+> **What it is NOT.** This is **not** production storage, **not** the final Straylight store, **not** a
+> route-contract freeze, **not** a final schema freeze, and **not** an ADR-022E gate #8 discharge. It
+> performs **no** production DB write, opens **no** database connection at startup or via any route,
+> executes **no** production migration, changes **no** production migration runner or packager, weakens
+> **no** scope guard, expands **no** public response, persists **no** raw candidate payload, and integrates
+> **no** Freeside runtime/client. Lane-2 canonical Straylight-store migrations and the operative
+> Straylight-side ADR-022E gate #8 remain **blocked**. **Phase 47F does not claim that `aw_*` SQL is
+> production-safe and does not claim this is production storage.**
+
+---
+
+## 1. Mechanism — isolation by LOCATION (lowest blast radius)
+
+The Phase 47D §5 isolation problem is that the production forward-only runner
+(`app/src/db/migrate.ts`) scans a single directory and adopts every `*.sql` (not `_down`) in it, and the
+production build packager (`app/scripts/copy-migrations.mjs`) copies every `*.sql` from that one source
+directory. A misplaced `aw_*.sql` in `src/db/migrations/` would be auto-adopted into the production set.
+
+Phase 47F resolves this **by location, not by changing the production path** — the strongest possible
+outcome (the same posture Phase 47A used for the `.json` store):
+
+- **Isolated experimental SQL location.** The experimental DDL lives at
+  `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/` — under the Admission Wedge spike
+  service tree, **outside** the single production migration directory the runner scans and **outside** the
+  single source directory the packager copies. The runner's `readdir(MIGRATIONS_DIR)` is non-recursive and
+  cannot descend into a service subfolder; the packager only scans `src/db/migrations`. So the production
+  runner can neither **discover** nor **execute** it, and the packager can neither **bundle** it —
+  **without any change to `migrate.ts` or `copy-migrations.mjs`**.
+- **Exact manifest + strict schema.** `aw-sql-isolation-spike/manifest.json` is an exact allowlist of the
+  experimental `.sql` files (`forward` + `cleanup` lists). The schema is **strict**: only the exact
+  top-level keys are accepted (any unknown key **fails closed**), `spike` / `kind` / `production` /
+  `schemaFinal` are matched as **exact literals with no coercion**, entries must be unique and the two lists
+  disjoint, a `_down.sql` may **never** appear in `forward`, and every `cleanup` entry **must** be a
+  `_down.sql`. The runner then **reconciles the on-disk `.sql` set against the manifest**: any **unlisted**
+  `.sql` present in `sql/` **fails closed** (there is **no** "adopt every `.sql` in the folder" fallback),
+  and any **listed** file that is absent **fails closed**. An unlisted, missing, absolute, traversal,
+  out-of-folder, symlinked, or production-located entry **fails closed**. The manifest protects **only** the
+  experimental runner path — normal-runner protection comes from **location isolation**, never from the
+  manifest (the Phase 47E §7 / B.6 Candidate C limitation, carried forward).
+- **Symlink + realpath containment.** Before reading any file the planner `lstat`s it and **rejects a
+  symlink** (so a `sql/*.sql` symlink can never point at a production migration file or anywhere outside the
+  isolated folder), rejects a non-regular file, and verifies the **realpath** of the spike root, the `sql/`
+  folder, the manifest, and each `.sql` file stays strictly inside the isolated folder using
+  `path.relative` (never a string-prefix-only check). The file is re-verified immediately before it is read,
+  so a swap between validation and read still fails closed.
+- **Token-clean planner.** `aw-sql-isolation-spike/index.ts` resolves the manifest, validates path
+  containment, reads the experimental statement text from the `.sql` files at runtime, and builds a
+  **dry-run plan**. It names no client, opens no connection, and embeds **no** SQL/DDL text of its own — so
+  it passes the canonical Phase 33N 19-entry scope-guard denylist **unchanged, with no allowlist** (the SQL
+  text lives only in `.sql` files, which the guard does not scan). It also exposes a **pure, in-memory
+  synthetic-write reducer** (`createSyntheticWriteReducer`) that models planned-write identity + a content
+  fingerprint to define the dev-only replay / conflict semantics — it touches no client, persists nothing
+  durably, and is wired to no route or startup path.
+- **Explicit dev/operator runner.** `app/scripts/aw-sql-isolation-spike-runner.mjs` is the **only** caller.
+  It is disabled by default, fails closed unless its dedicated env gate is exactly `true` **and** the
+  environment is not production, **never** runs on app startup, **never** runs through the production
+  runner, and is **not** wired into any `package.json` lifecycle script. Its default behavior is a
+  **dry-run plan** that opens nothing; `--apply` is **refused** (no client is injected in this spike).
+
+**Source / wiring:**
+
+- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init.sql` —
+  experimental forward DDL (synthetic `aw_isolation_spike_*` family; references only, no raw payload).
+- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init_down.sql` —
+  the reversible cleanup / drop path.
+- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/manifest.json` — exact allowlist.
+- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts` — planner / guard / apply.
+- `app/scripts/aw-sql-isolation-spike-runner.mjs` — the explicit dev/operator runner.
+
+> **No production-path change.** `app/src/db/migrate.ts`, `app/scripts/copy-migrations.mjs`,
+> `app/src/server.ts`, `app/src/config.ts`, and `app/tests/unit/admission-wedge-spike/scope-guards.test.ts`
+> are **unchanged** by Phase 47F. Isolation is proven by construction + tests, not by editing the
+> production runner / packager / startup / guard.
+
+---
+
+## 2. Gate (disabled by default; dev/operator-only; non-production)
+
+| Gate | Env var | Default | Rule |
+|------|---------|---------|------|
+| dev/operator opt-in | `DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED` | off | strict `=== 'true'`; any other value fails closed |
+| non-production | `NODE_ENV` | — | `NODE_ENV=production` is **refused** even when the opt-in is `true` |
+
+The gate is enforced at the top of the runner (`assertDevOperatorGateOpen`) before any plan is built. There
+is **no production default** under which the experimental path engages — neither config, env, nor startup.
+
+---
+
+## 3. Use (explicit dev/operator invocation only — NOT a package script)
+
+```bash
+cd app
+
+# Dry-run FORWARD plan (default). Opens no connection, applies nothing.
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true NODE_ENV=development \
+  npx tsx scripts/aw-sql-isolation-spike-runner.mjs
+
+# Dry-run CLEANUP plan (the reversible drop path).
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true NODE_ENV=development \
+  npx tsx scripts/aw-sql-isolation-spike-runner.mjs --direction=cleanup
+
+# Execution is REFUSED in this spike (no client is injected — fail closed):
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true NODE_ENV=development \
+  npx tsx scripts/aw-sql-isolation-spike-runner.mjs --apply   # -> error, exit 1
+```
+
+**Disabled by default:** with the env var unset (or any value other than `true`), the runner exits 1 with a
+disabled message. With `NODE_ENV=production`, the runner exits 1 with a production-refused message.
+
+---
+
+## 4. Storage semantics (synthetic-only; no raw payload; no final schema freeze)
+
+The experimental `aw_isolation_spike_*` family is the Phase 46S **draft** shape (`schemaFinal` stays
+**false** — the manifest refuses a `schemaFinal: true`), realized as an obviously-experimental dev/operator
+family:
+
+- **Bounded opaque references only (enforced in the schema, not in comments).** Every reference column is a
+  `VARCHAR(80)` carrying a `CHECK` constraint that pins a narrow `awref:<kind>:<short-id>` prefix +
+  character set + length bound. So `candidate_payload_ref`, `public_receipt_ref`, `tenant_ref`,
+  `estate_ref`, `actor_ref`, and the assertion references are **short bounded opaque strings by schema
+  design** — a raw JSON blob, long source text, or free-form reason **cannot** be stored. `candidate_payload_ref`
+  is a short reference, never the payload; `public_receipt_ref` is a public-safe short reference or NULL.
+  There is no raw payload, source material, raw reasons, private audit internals, or public-response-expanding
+  column.
+- **Canonical status.** `assertion_status` is constrained to `active` / `superseded` (the canonical
+  Straylight-owned lifecycle; Dixie stores only route-owned references, never a parallel lifecycle).
+- **Tenant / estate / actor isolation on every scoped table.** Every scoped artifact row — the assertion
+  table, the supersession-link table, **and** the tombstone table — carries `tenant_ref` / `estate_ref` /
+  `actor_ref`, each bounded by its own `awref:` `CHECK`. The assertion table is unique per
+  `(tenant, estate, actor, assertion)` and the supersession link per
+  `(tenant, estate, actor, superseded_assertion)`.
+- **Supersession / correction.** A Dixie-local **inverse link** (`aw_isolation_spike_supersession_link`),
+  never a rewrite of the canonical append-only chain.
+- **Cleanup / tombstone / drop.** The paired `_down.sql` drops the entire experimental family; an
+  `aw_isolation_spike_tombstone` table records dev cleanup intent. The forward-only production runner never
+  auto-runs a `_down` file — any drop is an explicit dev/operator action.
+
+**Dev-only replay / conflict semantics.** The pure in-memory `createSyntheticWriteReducer` models a synthetic
+admitted-assertion write whose **identity** is the `(tenant, estate, actor, assertion)` tuple (the same
+columns the unique constraint pins) and whose **fingerprint** covers identity + all bounded-ref material:
+
+- a **first** write `plan`s as `planned` and `record`s as `applied` (into the fake in-memory sink only);
+- an **identical** replay returns an explicit `identical_replay` no-op — **not** a generic duplicate failure;
+- a **conflicting** replay (same identity, different material) **fails closed**: `record` throws and records
+  **nothing**, so no partially-admitted recallable assertion survives;
+- `recordBatch` is **atomic** — a conflict mid-batch rolls back every write the batch recorded and rethrows;
+- every reference is validated against the **same bounded `awref:` shape** the DDL `CHECK` enforces, so raw
+  material can never enter the model.
+
+The planner's apply path (`applyIsolationSpikePlan`) is **all-or-nothing through an injected sink**:
+`begin → applyStatement* → commit`, with any failure triggering `rollback` and a wrapped fail-closed error.
+Both the reducer and the apply path are exercised only against **fake / in-memory** sinks in tests — never a
+production database.
+
+---
+
+## 5. Rollback / recovery / cleanup
+
+- **Partial-failure fail-closed.** A fault mid-apply rolls back and throws; no half-applied, partially
+  admitted recallable footprint survives (proven deterministically with a fake sink).
+- **Replay is idempotent; conflict fails closed.** An identical synthetic replay is an explicit no-op
+  (`identical_replay`); a conflicting replay (same identity, different material) throws and records nothing;
+  a batch with a mid-batch conflict rolls back fully (proven with the in-memory reducer — no real DB).
+- **Reversible cleanup.** Run the runner with `--direction=cleanup` to obtain the drop plan; the `_down`
+  file drops the whole experimental family, leaving no production state behind.
+- **Recovery is deterministic.** The spike persists nothing at runtime by itself (dry-run plan only); a
+  re-run re-derives the same plan from the same manifest + `.sql` files.
+
+---
+
+## 6. Auth / consent / signer — explicit NON-coverage (Section J / §17)
+
+Phase 47F SQL isolation is **orthogonal to** and **does not solve** the production trust boundaries:
+
+- **Production auth.** The dev/operator opt-in env gate (and the route's dev `x-admission-service-token` /
+  `x-admission-operator-id` allowlist) is **not** production authentication.
+- **End-user authorization.** There is no end-user authorization model in a dev/operator-only spike.
+- **Signer authority.** The canonical signer / receipt-signing authority is Straylight-owned and
+  undischarged.
+- **Consent proof / receipt.** Consent proof / receipt remains future-gated (the Phase 46S
+  `aw_consent_proof_ref` is **deferred**); service/operator auth is never treated as consent.
+
+Each remains its **own separately-gated future blocker**; this spike neither implements nor unblocks any of
+them.
+
+---
+
+## 7. Public / private no-leak (Section I / §16)
+
+The public response shape is **unchanged** — the isolation spike adds **no** public-response builder and no
+public surface. The runtime no-leak guard (`no-leak.ts`) is **untouched**, so the 114-key parity is
+preserved. The manifest and experimental SQL are **private** dev/operator artifacts carrying only synthetic
+labels / references; no SQL, path, debug, stack, or internal storage detail leaks to any public response.
+
+---
+
+## 8. Tests
+
+- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts` — dev/operator gate (default off,
+  strict `=== 'true'`, production refused); strict manifest schema (exact keys, no coercion on
+  `spike`/`kind`/`production`/`schemaFinal`, no duplicates, disjoint lists, `_down` role consistency);
+  **fail-closed reconciliation** (an unlisted `.sql` in `sql/` is refused, a missing listed file is
+  refused); path traversal / absolute / outside-folder / nested-subfolder fail closed; **symlink +
+  realpath containment** (an escaping symlink, a symlink at a production migration file, a symlinked `sql/`
+  dir, and a symlinked manifest all fail closed); storage semantics (**bounded `awref:` opaque refs with
+  DDL `CHECK`, no raw payload, `actor_ref` on every scoped table**, canonical status, supersession inverse
+  link, cleanup/drop); **dev-only replay/conflict reducer** (first→`applied`, identical→`identical_replay`,
+  conflict→fail-closed with no footprint, atomic batch rollback); all-or-nothing apply + deterministic
+  partial-failure rollback; public no-leak parity.
+- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts` — experimental SQL is
+  outside `src/db/migrations`; the production runner is unchanged and existing migrations stay valid; the
+  packager cannot bundle the experimental SQL; `server.ts` startup / route gates run no experimental SQL
+  and never import the runner; only the explicit runner can; no package-lifecycle invocation.
+- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts` — the new module passes the
+  canonical 19-entry denylist with zero hits (no allowlist added); adjacent forbidden paths still fail
+  closed against the same evasion-resistance bar.
+- `app/tests/unit/admission-wedge-spike/scope-guards.test.ts` (existing, unchanged) — still passes with the
+  new module present in the scanned spike tree.
+
+---
+
+## 9. Preserved blocked lanes
+
+Production migration files; production DB writes; production durable-store implementation; production
+migration execution; route-contract freeze; final schema freeze; ADR-022E gate #8 discharge; Freeside
+runtime/client integration; Lane-2 canonical Straylight-store migrations; public response expansion; raw
+candidate payload persistence; production admission / signer / auth / consent — **all remain blocked**.
+Phase 47F is a bounded dev/operator-only isolated spike and changes none of them. If the spike could not be
+isolated safely without weakening the production posture, the fallback is to remain the Phase 47A `.json`
+path — but isolation was achievable here by location with no production-path change, so the spike stands as
+authorized.


### PR DESCRIPTION
## Summary

Phase 47F adds the checklist-gated Lane-1 `aw_*` SQL isolated dev/operator implementation spike.

This is a bounded, disabled-by-default, non-production, dev/operator-only, route-owned spike. It proves isolated experimental SQL can exist outside production migration discovery, production migration execution, startup execution, and production packaging/copy paths.

Phase 47F does not implement production durable storage, production DB writes, production migration execution, route-contract freeze, final schema freeze, ADR-022E gate #8 discharge, Freeside integration, Lane-2 canonical Straylight-store migrations, public response expansion, raw candidate payload persistence, or production readiness.

## Files

New:

- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init.sql`
- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/sql/0001_aw_isolation_spike_init_down.sql`
- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/manifest.json`
- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts`
- `app/scripts/aw-sql-isolation-spike-runner.mjs`
- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts`
- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts`
- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts`
- `docs/admission-wedge/PHASE-47F-AW-SQL-ISOLATION-SPIKE-RUNBOOK.md`

No tracked production migration runner, startup, config, package, lockfile, or CI files are modified.

## Architecture

Phase 47F uses location isolation:

- experimental SQL lives under the Admission Wedge spike service tree, not under the production migration directory;
- normal `migrate(dbPool)` is unchanged and cannot discover the experimental SQL;
- normal packaging/copy behavior is unchanged and does not copy experimental SQL or the manifest into production migration assets;
- server startup is unchanged and does not import or execute the spike;
- the runner is explicit dev/operator-only and disabled by default;
- `--apply` remains refused, so no real DB execution path is reachable.

## Manifest and path safety

The manifest path is exact and fail-closed:

- present-but-unlisted `.sql` files are refused;
- manifest-listed missing files are refused;
- manifest schema is strict;
- unknown top-level keys are rejected;
- non-string entries are rejected;
- literal manifest values are required;
- duplicate entries and forward/cleanup overlap are rejected;
- forward entries cannot point to `_down.sql`;
- cleanup entries must point to `_down.sql`.

Path containment is realpath-based and rejects symlinks:

- SQL directory symlink rejected;
- manifest symlink rejected;
- SQL file symlink rejected;
- non-regular files rejected;
- path traversal rejected;
- absolute paths rejected;
- realpath containment is checked before reading.

## Storage semantics

The spike DDL uses bounded opaque references:

- no unrestricted `TEXT` ref columns;
- refs use bounded `VARCHAR(80)` plus `CHECK` constraints;
- `candidate_payload_ref` is a short opaque reference, not raw payload;
- no raw candidate payload, source material, raw reasons, private audit blob, or public-response expansion column is added;
- actor scope is present on all scoped artifact tables, including assertion, supersession link, and tombstone.

Replay/conflict semantics are modeled in a pure in-memory reducer:

- first write plans/applies;
- identical replay returns explicit `identical_replay`;
- conflicting replay fails closed with a typed conflict;
- conflict records no new state;
- batch application is atomic;
- rollback failure does not mask the original apply failure.

This reducer does not create production storage and opens no DB/client/connection.

## Codex audit

Codex initially returned PATCH for five implementation defects:

1. manifest did not fail closed on present-but-unlisted SQL;
2. path containment was lexical and followed symlinks;
3. manifest validation was permissive and role confusion was possible;
4. DDL refs were unbounded and actor scope was missing from supersession/tombstone;
5. replay/conflict behavior was absent.

The patch resolved these. Codex re-audited ACCEPT.

## Validation

Validated locally:

- `npm run typecheck`: pass
- `npm run lint`: pass
- targeted Phase 47F and guard suite: pass
- full Admission Wedge plus intake suite: pass
- `node docs/admission-wedge/fixtures/validate-fixtures.mjs`: PASS, 5/5
- `node docs/admission-wedge/route-contract-test-vectors/validate-route-contract-test-vectors.mjs`: PASS, 5/5, no sixth vector
- `node docs/admission-wedge/route-contract-test-vectors/validate-route-contract-test-vectors.mjs --self-check`: PASS, 44/44
- `npm run build` from `app/`: pass
- build artifact `app/dist` removed after validation

## Non-goals

This PR does not authorize:

- production durable-store implementation
- production DB writes
- production migration execution
- production migration files
- production migration runner changes
- startup wiring
- config/env production behavior
- package/lockfile changes
- CI changes
- route-contract freeze
- final schema freeze
- ADR-022E gate #8 discharge
- Freeside runtime/client integration
- Lane-2 canonical Straylight-store migrations
- public response expansion
- raw candidate payload persistence
- production readiness
- any claim that `aw_*` SQL is production-safe
