### PR TITLE
Phase 47J feat: add admission aw sql execution sink spike

### DIFF
--- a/app/scripts/aw-sql-isolation-spike-runner.mjs
+++ b/app/scripts/aw-sql-isolation-spike-runner.mjs
@@ -1,43 +1,88 @@
-// Phase 47F — Lane-1 aw_* SQL ISOLATED dev/operator implementation spike: EXPLICIT runner.
+// Phase 47J — Lane-1 aw_* SQL ISOLATED dev/operator EXECUTION-SINK spike: EXPLICIT runner.
 //
-// NON-PRODUCTION, dev/operator-only, disabled-by-default. This is the ONLY
-// entrypoint that ever touches the experimental aw_* SQL isolation spike. It is
-// a deliberate, out-of-band dev/operator command:
+// NON-PRODUCTION, dev/operator/test-only, disabled-by-default. This is the ONLY
+// entrypoint that ever touches the experimental aw_* SQL isolation spike, and
+// the ONLY place a real DB client / sink is ever constructed. It is a deliberate,
+// out-of-band dev/operator command:
 //
 //   * It is NEVER imported by app startup (server.ts) and NEVER mounted by any
 //     route gate.
 //   * It is NEVER wired into a package lifecycle script (no pre*/post*/build
 //     hook in package.json runs it) and never runs through the normal forward-
-//     only production runner.
+//     only production runner (app/src/db/migrate.ts), its _migrations ledger, or
+//     its advisory lock.
 //   * It is disabled by default and fails closed unless the dev/operator opt-in
-//     env var is exactly `true` AND the environment is not production.
+//     env var is exactly `true` AND the environment is NOT production.
 //
 // DEFAULT BEHAVIOR is a DRY-RUN PLAN: it resolves the exact manifest, validates
 // every experimental `.sql` path is contained inside the isolated folder, reads
 // the statement text, and prints a plan summary. It opens NO connection and
 // applies NOTHING. There is NO production DB write and NO production execution.
 //
-// EXECUTION (`--apply`) is intentionally fail-closed in this spike: the runner
-// injects NO real client, so `--apply` is refused ("DB/client is absent when
-// execution is requested"). Real execution support, if ever added by a later
-// authorized lane, must be injected and tested against a fake — never a real
-// production database — via applyIsolationSpikePlan(plan, sink) in index.ts.
+// EXECUTION (`--apply`) is a BOUNDED Phase 47J execution-sink proof. It is
+// fail-closed behind a conjunction of independent gates (Phase 47I §10): the base
+// dev/operator opt-in, a DISTINCT execution opt-in, non-production mode, a
+// strictly-non-production accepted DB target (Phase 47I §11; the production
+// DATABASE_URL is always refused), explicit out-of-band invocation, exact
+// manifest verification, SQL path containment, no-unlisted-SQL, and — for the
+// cleanup/down direction — a DISTINCT cleanup opt-in. ANY missing gate refuses,
+// fails closed, exits non-zero, opens NO connection, and applies nothing. When
+// every gate holds, the runner constructs a real DB client from the accepted
+// non-production target, wraps it in an `IsolationSpikeStatementSink`, and runs
+// the already-validated static plan through `applyIsolationSpikePlan(plan, sink)`
+// (index.ts) in a single all-or-nothing transaction.
+//
+// SECRET HYGIENE. The runner NEVER logs the target DSN, any credential, password,
+// token, or an environment dump. Refusals carry stable, non-secret reason codes
+// only. The target policy is a pure function — testable WITHOUT opening a DB
+// connection.
+//
+// NON-GOALS (explicit). This is NOT production storage, NOT the final Straylight
+// store, NOT a final schema freeze, NOT a route-contract freeze, and NOT an
+// ADR-022E gate #8 discharge. It performs NO production DB write, NO production
+// migration execution, and NO startup wiring. It does NOT claim that `aw_*` SQL
+// is safe for production, and the production DB target stays refused in every
+// environment and default.
 //
 // USAGE (explicit dev/operator invocation only — NOT a package script):
 //   DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true \
 //     npx tsx scripts/aw-sql-isolation-spike-runner.mjs            # dry-run forward plan
 //   ... aw-sql-isolation-spike-runner.mjs --direction=cleanup       # dry-run cleanup plan
-//   ... aw-sql-isolation-spike-runner.mjs --apply                   # REFUSED (no client injected)
+//   ... --apply                                                      # execution-sink proof (all gates required)
 
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
   AW_SQL_ISOLATION_SPIKE_GATE_ENV,
   AW_SQL_ISOLATION_SPIKE_DIR_NAME,
   assertDevOperatorGateOpen,
+  isDevOperatorGateOpen,
   buildIsolationSpikePlan,
+  applyIsolationSpikePlan,
+  assertIsolationSpikeExecutionGateOpen,
 } from '../src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts';
+
+// ── DRAFT, NON-FINAL env labels (Phase 47I §10 / §11). ────────────────────────
+// Named here and read ONLY inside this runner — NOT added to or parsed by
+// app/src/config.ts, NOT wired into any package lifecycle script, NOT a config
+// behavior change. Each is a draft label for this bounded dev/operator spike.
+
+/** DISTINCT execution opt-in (separate from the base spike opt-in). */
+export const AW_SQL_EXECUTION_APPLY_ENV =
+  'DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_ENABLED';
+
+/** DISTINCT cleanup/down opt-in (required only for the cleanup direction). */
+export const AW_SQL_EXECUTION_CLEANUP_ENV =
+  'DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_CLEANUP_ENABLED';
+
+/** The explicit, distinct NON-PRODUCTION target DSN. There is NO implicit
+ *  fallback to DATABASE_URL or any configured application database. */
+export const AW_SQL_EXECUTION_TARGET_DSN_ENV =
+  'DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_TARGET_DSN';
+
+/** The production target env name — read ONLY to refuse it as a target. */
+export const PRODUCTION_DB_ENV = 'DATABASE_URL';
 
 /** Resolve the SOURCE spike root from this runner's own location, so the plan
  *  always reads the real `.sql` files + manifest regardless of cwd. */
@@ -53,7 +98,241 @@ function sourceSpikeRoot() {
   );
 }
 
-function parseArgs(argv) {
+// ── Database target policy (Phase 47I §11) — PURE; no connection opened. ───────
+
+/** Stable, non-secret reason codes for a refused execution target. A refusal
+ *  NEVER carries the DSN, host credentials, query values, file paths, or any
+ *  secret material — only these fixed code constants and (for query params) the
+ *  fixed, non-secret libpq parameter-CATEGORY name. */
+export const EXECUTION_TARGET_REFUSAL = Object.freeze({
+  TARGET_MISSING: 'TARGET_MISSING',
+  TARGET_EMPTY: 'TARGET_EMPTY',
+  TARGET_EQUALS_PRODUCTION_DSN: 'TARGET_EQUALS_PRODUCTION_DSN',
+  TARGET_MALFORMED: 'TARGET_MALFORMED',
+  // The DSN scheme must be a Postgres scheme; anything else (http:, ftp:, file:,
+  // …) is refused before the host is ever trusted.
+  TARGET_UNSUPPORTED_PROTOCOL: 'TARGET_UNSUPPORTED_PROTOCOL',
+  // A query parameter that can REDIRECT the effective network target (host /
+  // hostaddr / port) so `pg` would connect somewhere other than url.hostname.
+  TARGET_HOST_OVERRIDE_UNSUPPORTED: 'TARGET_HOST_OVERRIDE_UNSUPPORTED',
+  // A TLS / file-loading query parameter (ssl* — sslcert / sslkey / sslrootcert /
+  // sslcrl / sslmode / …) that can alter file-loading or TLS behavior.
+  TARGET_TLS_FILE_PARAMETER_UNSUPPORTED: 'TARGET_TLS_FILE_PARAMETER_UNSUPPORTED',
+  // Any other query parameter — rejected wholesale, since an unknown libpq/pg
+  // query key could alter the connection target or behavior in ways the pure
+  // policy cannot anticipate.
+  TARGET_QUERY_PARAMETER_UNSUPPORTED: 'TARGET_QUERY_PARAMETER_UNSUPPORTED',
+  TARGET_NOT_LOCAL_OR_DEV: 'TARGET_NOT_LOCAL_OR_DEV',
+  TARGET_NO_DISPOSABLE_MARKER: 'TARGET_NO_DISPOSABLE_MARKER',
+  TARGET_PRODUCTION_TOKEN: 'TARGET_PRODUCTION_TOKEN',
+});
+
+/** The ONLY DSN schemes a real `pg` client should ever receive here. Anything
+ *  else is refused before the host / DB name is trusted. */
+const ALLOWED_TARGET_PROTOCOLS = new Set(['postgres:', 'postgresql:']);
+
+/** Query keys that can override the effective NETWORK target `pg` connects to —
+ *  so url.hostname can no longer be trusted as the host that will be used. */
+const NETWORK_TARGET_OVERRIDE_PARAMS = new Set(['host', 'hostaddr', 'port']);
+
+/** Prefix marking TLS / file-loading query keys (sslcert / sslkey / sslrootcert /
+ *  sslcrl / sslmode / sslpassword / …) — all refused as file/TLS overrides. */
+const TLS_QUERY_PARAM_PREFIX = 'ssl';
+
+/** Loopback hosts treated as obviously-local dev targets. */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+/** Disposable / dev / test markers required on the target host or DB name. */
+const DISPOSABLE_MARKERS = [
+  'dev',
+  'test',
+  'spike',
+  'tmp',
+  'temp',
+  'ephemeral',
+  'throwaway',
+  'sandbox',
+  'scratch',
+  'disposable',
+  'local',
+  'ci',
+];
+
+/** Production-like tokens that disqualify a target outright (checked against the
+ *  host + DB name ONLY — never the credential portion of the DSN). */
+const PRODUCTION_TOKENS = [
+  'prod',
+  'production',
+  'live',
+  'amazonaws',
+  'rds',
+  'azure',
+  'cloudsql',
+  'gcp',
+];
+
+/**
+ * Classify a single lower-cased query-parameter key into its non-secret refusal
+ * code. The KEY name (a fixed libpq parameter name) is the only thing inspected —
+ * its VALUE (which could be a remote hostname, a file path, or a secret) is never
+ * read, so the classification can never leak. Returns a stable code constant.
+ */
+function classifyQueryParamRefusal(lowerKey) {
+  if (NETWORK_TARGET_OVERRIDE_PARAMS.has(lowerKey)) {
+    return EXECUTION_TARGET_REFUSAL.TARGET_HOST_OVERRIDE_UNSUPPORTED;
+  }
+  if (lowerKey.startsWith(TLS_QUERY_PARAM_PREFIX)) {
+    return EXECUTION_TARGET_REFUSAL.TARGET_TLS_FILE_PARAMETER_UNSUPPORTED;
+  }
+  return EXECUTION_TARGET_REFUSAL.TARGET_QUERY_PARAMETER_UNSUPPORTED;
+}
+
+/**
+ * Assess a candidate execution target against the strict non-production policy.
+ * PURE: parses the DSN structurally, never opens a connection, never logs, and
+ * returns only stable non-secret reason codes. The credential portion of the DSN
+ * is NEVER inspected (scheme + host + DB name + query KEY names only — never the
+ * user, password, or any query VALUE), so a secret can neither leak nor trip a
+ * rule.
+ *
+ * The policy validates the SAME effective target `pg` will use: it refuses any
+ * non-Postgres scheme, and — critically — refuses ALL query parameters, because
+ * a query key such as `?host=` / `?hostaddr=` / `?port=` silently redirects the
+ * effective network target that `pg` / `pg-connection-string` resolve (so an
+ * apparent loopback DSN could otherwise connect to a remote / production host),
+ * and a `?ssl*=` key can alter file-loading / TLS behavior. With no query string
+ * present, `url.hostname` IS the host `pg` connects to, so the host/DB-name
+ * disposable checks are then sound.
+ *
+ * Accepts ONLY when: a DSN is present and non-empty; it is not equal to the
+ * production DATABASE_URL; it parses; its scheme is `postgres:`/`postgresql:`;
+ * it carries NO query parameters at all; it carries no production-like token; its
+ * host is loopback or carries a disposable marker; and its DB name carries a
+ * disposable marker. Any other case fails closed.
+ */
+export function assessExecutionTarget(input) {
+  const targetDsn = input?.targetDsn;
+  const productionDsn = input?.productionDsn;
+
+  if (targetDsn === undefined || targetDsn === null) {
+    return { accepted: false, refusals: [EXECUTION_TARGET_REFUSAL.TARGET_MISSING] };
+  }
+  if (typeof targetDsn !== 'string' || targetDsn.trim().length === 0) {
+    return { accepted: false, refusals: [EXECUTION_TARGET_REFUSAL.TARGET_EMPTY] };
+  }
+  if (
+    typeof productionDsn === 'string' &&
+    productionDsn.trim().length > 0 &&
+    targetDsn === productionDsn
+  ) {
+    // Terminal: the production DSN is never a valid target. Stop before parsing.
+    return { accepted: false, refusals: [EXECUTION_TARGET_REFUSAL.TARGET_EQUALS_PRODUCTION_DSN] };
+  }
+
+  let url;
+  try {
+    url = new URL(targetDsn);
+  } catch {
+    return { accepted: false, refusals: [EXECUTION_TARGET_REFUSAL.TARGET_MALFORMED] };
+  }
+
+  // Scheme allowlist FIRST: only a Postgres scheme may ever reach a `pg` client.
+  // A non-Postgres scheme (http:, ftp:, file:, …) is terminal — refuse before the
+  // host is trusted, so a loopback hostname can never launder a wrong protocol.
+  if (!ALLOWED_TARGET_PROTOCOLS.has((url.protocol || '').toLowerCase())) {
+    return { accepted: false, refusals: [EXECUTION_TARGET_REFUSAL.TARGET_UNSUPPORTED_PROTOCOL] };
+  }
+
+  // Query parameters are refused WHOLESALE and terminally: any present key could
+  // redirect the effective network target (`?host=` / `?hostaddr=` / `?port=`) or
+  // change file/TLS behavior (`?ssl*=`), and an unknown libpq/pg key could do so
+  // in ways this pure policy cannot anticipate. Refusing all of them means the
+  // host the policy validates below (url.hostname) is exactly the host `pg`
+  // connects to. Only the KEY names are inspected — never the (possibly secret)
+  // values — and the codes are de-duplicated and order-stable.
+  if ([...url.searchParams.keys()].length > 0) {
+    const queryRefusals = [];
+    const seen = new Set();
+    for (const key of url.searchParams.keys()) {
+      const code = classifyQueryParamRefusal(key.toLowerCase());
+      if (!seen.has(code)) {
+        seen.add(code);
+        queryRefusals.push(code);
+      }
+    }
+    return { accepted: false, refusals: queryRefusals };
+  }
+
+  const host = (url.hostname || '').toLowerCase();
+  let dbName = '';
+  try {
+    dbName = decodeURIComponent((url.pathname || '').replace(/^\//, '')).toLowerCase();
+  } catch {
+    dbName = (url.pathname || '').replace(/^\//, '').toLowerCase();
+  }
+  // Structural surface only (host + DB name). The user/password are excluded.
+  const surface = `${host} ${dbName}`;
+
+  const refusals = [];
+  if (PRODUCTION_TOKENS.some((t) => surface.includes(t))) {
+    refusals.push(EXECUTION_TARGET_REFUSAL.TARGET_PRODUCTION_TOKEN);
+  }
+  const hostIsLocalOrDev =
+    LOOPBACK_HOSTS.has(host) || DISPOSABLE_MARKERS.some((m) => host.includes(m));
+  if (!hostIsLocalOrDev) {
+    refusals.push(EXECUTION_TARGET_REFUSAL.TARGET_NOT_LOCAL_OR_DEV);
+  }
+  if (!DISPOSABLE_MARKERS.some((m) => dbName.includes(m))) {
+    refusals.push(EXECUTION_TARGET_REFUSAL.TARGET_NO_DISPOSABLE_MARKER);
+  }
+  return { accepted: refusals.length === 0, refusals };
+}
+
+// ── Execution sink (Phase 47I §12) — real client wrapper, constructed here. ────
+
+/**
+ * Wrap an injected DB client (the only place a real client is ever built — in
+ * `defaultConnect` below) into an `IsolationSpikeStatementSink`. The sink runs an
+ * explicit transaction: `begin → applyStatement* → commit`, with `rollback` on
+ * any fault (orchestrated all-or-nothing by `applyIsolationSpikePlan`). The
+ * statement text is the static, already-validated `.sql` content from the plan —
+ * never dynamic / user-derived SQL.
+ */
+export function createPgClientStatementSink(client) {
+  return {
+    async begin() {
+      await client.query('BEGIN');
+    },
+    async applyStatement(statementsText) {
+      await client.query(statementsText);
+    },
+    async commit() {
+      await client.query('COMMIT');
+    },
+    async rollback() {
+      await client.query('ROLLBACK');
+    },
+  };
+}
+
+/** Default connector — the ONLY place a real `pg` client is ever constructed,
+ *  and ONLY after every gate has passed. Lazy-imports `pg` so merely importing
+ *  this runner (e.g. in unit tests, which inject a fake connector) never loads or
+ *  connects to a database. */
+async function defaultConnect(targetDsn) {
+  const pgModule = await import('pg');
+  const PgClient = pgModule.default?.Client ?? pgModule.Client;
+  const client = new PgClient({ connectionString: targetDsn });
+  await client.connect();
+  return {
+    query: (text) => client.query(text),
+    end: () => client.end(),
+  };
+}
+
+// ── Arg parsing ───────────────────────────────────────────────────────────────
+
+export function parseRunnerArgs(argv) {
   let direction = 'forward';
   let apply = false;
   for (const arg of argv) {
@@ -70,55 +349,150 @@ function parseArgs(argv) {
   return { help: false, direction, apply };
 }
 
-function printHelp() {
-  console.log(
-    [
-      'Phase 47F aw_* SQL isolation spike runner (dev/operator-only, NON-PRODUCTION).',
-      '',
-      `Gate: set ${AW_SQL_ISOLATION_SPIKE_GATE_ENV}=true (and NODE_ENV != production).`,
-      '',
-      'Options:',
-      '  --direction=forward|cleanup   which manifest list to plan (default: forward)',
-      '  --apply                       REFUSED in this spike (no client is injected)',
-      '  --help                        show this help',
-    ].join('\n'),
-  );
+function helpText() {
+  return [
+    'Phase 47J aw_* SQL execution-sink spike runner (dev/operator/test-only, NON-PRODUCTION).',
+    '',
+    `Base gate:      set ${AW_SQL_ISOLATION_SPIKE_GATE_ENV}=true (and NODE_ENV != production).`,
+    `Execution gate: set ${AW_SQL_EXECUTION_APPLY_ENV}=true AND provide`,
+    `                ${AW_SQL_EXECUTION_TARGET_DSN_ENV}=<non-production DSN> (the production`,
+    `                ${PRODUCTION_DB_ENV} is always refused as a target).`,
+    `Cleanup gate:   --direction=cleanup also requires ${AW_SQL_EXECUTION_CLEANUP_ENV}=true.`,
+    '',
+    'Options:',
+    '  --direction=forward|cleanup   which manifest list to plan/apply (default: forward)',
+    '  --apply                       run the bounded execution-sink proof (all gates required)',
+    '  --help                        show this help',
+    '',
+    'Without --apply the runner is a DRY-RUN PLAN: it opens no connection and applies nothing.',
+    'The target DSN is never logged; refusals carry stable, non-secret reason codes only.',
+  ].join('\n');
+}
+
+// ── Orchestrator — dependency-injected so it is fully testable with fakes. ─────
+
+/**
+ * Run the spike. Dependencies (plan builder, plan applier, DB connector, log
+ * sinks) are injected so tests can drive every path with fakes and NEVER open a
+ * real connection. The default deps wire the real planner / applier / `pg`
+ * connector and `console`.
+ *
+ * Order is fail-closed by construction: the base dev/operator gate is asserted
+ * first; the plan (manifest + path containment + unlisted-SQL reconciliation) is
+ * built next; for `--apply`, the strict target policy and the full execution-gate
+ * conjunction are evaluated BEFORE the connector is ever called. Any unmet gate
+ * throws a typed, non-secret error and no connection is opened.
+ */
+export async function runExecutionSinkSpike(opts = {}) {
+  const {
+    argv = [],
+    env = {},
+    spikeRoot = sourceSpikeRoot(),
+    explicitRunnerInvocation = true,
+    deps = {},
+  } = opts;
+  const {
+    buildPlan = buildIsolationSpikePlan,
+    applyPlan = applyIsolationSpikePlan,
+    connect = defaultConnect,
+    log = () => {},
+    logError = () => {},
+  } = deps;
+
+  const args = parseRunnerArgs(argv);
+  if (args.help) {
+    log(helpText());
+    return { mode: 'help' };
+  }
+
+  // Gate 1 — base dev/operator opt-in, non-production. Fail closed otherwise.
+  assertDevOperatorGateOpen({
+    enabledFlag: env[AW_SQL_ISOLATION_SPIKE_GATE_ENV],
+    nodeEnv: env.NODE_ENV,
+  });
+
+  // Build (and therefore verify) the plan: exact manifest, strict schema, path
+  // containment (lexical + symlink + realpath), and on-disk reconciliation (no
+  // unlisted / no missing SQL). A failure here throws before any execution gate.
+  const plan = buildPlan(spikeRoot, args.direction);
+
+  if (!args.apply) {
+    log(`aw_* SQL isolation spike — DRY-RUN PLAN (${plan.direction})`);
+    log(`  spike root: ${plan.spikeRoot}`);
+    log(`  steps: ${plan.steps.length}`);
+    for (const step of plan.steps) {
+      log(`    - ${step.relPath} (${step.statementsText.length} bytes; not executed)`);
+    }
+    log('  NON-PRODUCTION dry-run only — no connection opened, nothing applied.');
+    return { mode: 'dry-run', direction: plan.direction, steps: plan.steps.length };
+  }
+
+  // ── Execution path (`--apply`) — fail closed behind the full gate conjunction.
+  const targetDsn = env[AW_SQL_EXECUTION_TARGET_DSN_ENV];
+  const productionDsn = env[PRODUCTION_DB_ENV];
+  const target = assessExecutionTarget({ targetDsn, productionDsn });
+  if (!target.accepted) {
+    // Codes only — never the DSN or any secret.
+    logError(`execution target refused (non-secret codes): ${target.refusals.join(', ')}`);
+  }
+
+  const gateInput = {
+    applyRequested: true,
+    executionOptInPresent: env[AW_SQL_EXECUTION_APPLY_ENV] === 'true',
+    devOperatorModeAccepted: isDevOperatorGateOpen({
+      enabledFlag: env[AW_SQL_ISOLATION_SPIKE_GATE_ENV],
+      nodeEnv: env.NODE_ENV,
+    }),
+    nonProductionTargetAccepted: target.accepted,
+    explicitRunnerInvocation: explicitRunnerInvocation === true,
+    manifestVerified: true,
+    pathContainmentVerified: true,
+    noUnlistedSql: true,
+    cleanupRequested: plan.direction === 'cleanup',
+    cleanupOptInPresent: env[AW_SQL_EXECUTION_CLEANUP_ENV] === 'true',
+  };
+
+  // Throws IsolationSpikeExecutionRefusedError (non-secret reason codes) if any
+  // gate is unmet — BEFORE a connection is opened or anything is applied.
+  assertIsolationSpikeExecutionGateOpen(gateInput);
+
+  // All gates passed: construct the real client from the accepted non-production
+  // target and run the static plan in a single all-or-nothing transaction.
+  const client = await connect(targetDsn);
+  try {
+    const sink = createPgClientStatementSink(client);
+    const result = await applyPlan(plan, sink);
+    log(`aw_* SQL execution-sink proof — APPLIED (${result.direction})`);
+    log(`  statements applied: ${result.appliedCount}`);
+    log('  committed in a single transaction against a NON-PRODUCTION target.');
+    return { mode: 'applied', direction: result.direction, appliedCount: result.appliedCount };
+  } finally {
+    try {
+      await client.end();
+    } catch {
+      // A connector close fault must not mask a real apply outcome / error.
+    }
+  }
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
-  if (args.help) {
-    printHelp();
-    return;
-  }
-
-  // Fail closed unless the opt-in is exactly `true` AND not production.
-  assertDevOperatorGateOpen({
-    enabledFlag: process.env[AW_SQL_ISOLATION_SPIKE_GATE_ENV],
-    nodeEnv: process.env.NODE_ENV,
+  await runExecutionSinkSpike({
+    argv: process.argv.slice(2),
+    env: process.env,
+    explicitRunnerInvocation: true,
+    deps: {
+      log: (...a) => console.log(...a),
+      logError: (...a) => console.error(...a),
+    },
   });
-
-  if (args.apply) {
-    // Execution requested but no client is injected by this spike — fail closed.
-    throw new Error(
-      '--apply is refused: the Phase 47F spike injects no client. Execution is dry-run/plan-only here; ' +
-        'real execution requires a separately-authorized lane that injects a sink (never a production database).',
-    );
-  }
-
-  const spikeRoot = sourceSpikeRoot();
-  const plan = buildIsolationSpikePlan(spikeRoot, args.direction);
-
-  console.log(`Phase 47F aw_* SQL isolation spike — DRY-RUN PLAN (${plan.direction})`);
-  console.log(`  spike root: ${plan.spikeRoot}`);
-  console.log(`  steps: ${plan.steps.length}`);
-  for (const step of plan.steps) {
-    console.log(`    - ${step.relPath} (${step.statementsText.length} bytes; not executed)`);
-  }
-  console.log('  NON-PRODUCTION dry-run only — no connection opened, nothing applied.');
 }
 
-main().catch((err) => {
-  console.error(`aw-sql-isolation-spike-runner: ${err instanceof Error ? err.message : String(err)}`);
-  process.exit(1);
-});
+// Run main() ONLY when invoked directly as a script — never when imported (so a
+// test can import the exported functions without triggering execution / exit).
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1] ?? '').href;
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(`aw-sql-execution-sink-runner: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+}

--- a/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts
+++ b/app/src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts
@@ -592,6 +592,120 @@ export async function applyIsolationSpikePlan(
   };
 }
 
+// ── Phase 47J — bounded execution-sink gate conjunction (pure; runner-fed) ─────
+//
+// The execution-sink proof (Phase 47J) lets the EXPLICIT dev/operator runner
+// inject a real sink and apply the already-validated static plan — but ONLY when
+// every independent gate below holds. This module stays the pure, pool-free,
+// `node:`-only seam: it parses NO DSN, names NO client, reads NO env, and opens
+// NO connection. The runner does the raw env / DSN parsing and the strict
+// non-production target policy, then hands this conjunction the ALREADY-DECIDED
+// booleans. Any unmet gate fails closed BEFORE the runner opens a connection.
+
+/** The independent gates that must ALL hold before a real sink may be injected
+ *  and the static plan executed. Each field is an already-decided boolean — the
+ *  raw env / DSN parsing + non-production target policy that produce them live
+ *  ONLY in the explicit runner (this module stays pool-free and never parses a
+ *  target). A missing / false / non-`true` field fails closed. */
+export interface IsolationSpikeExecutionGateInput {
+  /** Execution was explicitly requested (`--apply`). */
+  applyRequested: boolean;
+  /** A DISTINCT execution opt-in (separate from the base spike opt-in) is set. */
+  executionOptInPresent: boolean;
+  /** The base dev/operator gate is open AND the environment is not production. */
+  devOperatorModeAccepted: boolean;
+  /** A strictly-non-production target was accepted by the runner target policy. */
+  nonProductionTargetAccepted: boolean;
+  /** The runner is the explicit out-of-band caller (never startup / route / hook). */
+  explicitRunnerInvocation: boolean;
+  /** The exact manifest verified (a plan was built — strict schema + literals). */
+  manifestVerified: boolean;
+  /** SQL path containment verified (lexical + symlink + realpath, per the plan). */
+  pathContainmentVerified: boolean;
+  /** No unlisted SQL is present (on-disk reconciliation passed during plan build). */
+  noUnlistedSql: boolean;
+  /** Whether the requested direction is the cleanup / down path. */
+  cleanupRequested: boolean;
+  /** A DISTINCT cleanup opt-in is set (required only when cleanup is requested). */
+  cleanupOptInPresent: boolean;
+}
+
+/** The outcome of evaluating the execution-sink gate conjunction. */
+export interface IsolationSpikeExecutionGateResult {
+  /** True iff EVERY required gate holds. */
+  open: boolean;
+  /** Stable, non-secret reason codes for each unmet gate (never a DSN / secret). */
+  refusals: string[];
+}
+
+/** Stable, non-secret reason codes for an unmet execution gate. */
+export const ISOLATION_SPIKE_EXECUTION_REFUSAL = Object.freeze({
+  APPLY_NOT_REQUESTED: 'APPLY_NOT_REQUESTED',
+  EXECUTION_OPT_IN_MISSING: 'EXECUTION_OPT_IN_MISSING',
+  DEV_OPERATOR_MODE_MISSING: 'DEV_OPERATOR_MODE_MISSING',
+  NON_PRODUCTION_TARGET_NOT_ACCEPTED: 'NON_PRODUCTION_TARGET_NOT_ACCEPTED',
+  NOT_EXPLICIT_RUNNER_INVOCATION: 'NOT_EXPLICIT_RUNNER_INVOCATION',
+  MANIFEST_NOT_VERIFIED: 'MANIFEST_NOT_VERIFIED',
+  PATH_CONTAINMENT_NOT_VERIFIED: 'PATH_CONTAINMENT_NOT_VERIFIED',
+  UNLISTED_SQL_PRESENT: 'UNLISTED_SQL_PRESENT',
+  CLEANUP_OPT_IN_MISSING: 'CLEANUP_OPT_IN_MISSING',
+} as const);
+
+/**
+ * Evaluate the execution-sink gate conjunction. Returns `open: true` ONLY when
+ * EVERY required gate holds; otherwise `open: false` with a list of stable,
+ * non-secret reason codes. This is a pure function: it parses nothing, opens
+ * nothing, and logs nothing. The runner calls it (and refuses, fail-closed)
+ * BEFORE constructing a client or opening a connection.
+ */
+export function evaluateIsolationSpikeExecutionGate(
+  input: IsolationSpikeExecutionGateInput,
+): IsolationSpikeExecutionGateResult {
+  const R = ISOLATION_SPIKE_EXECUTION_REFUSAL;
+  const refusals: string[] = [];
+  if (input.applyRequested !== true) refusals.push(R.APPLY_NOT_REQUESTED);
+  if (input.executionOptInPresent !== true) refusals.push(R.EXECUTION_OPT_IN_MISSING);
+  if (input.devOperatorModeAccepted !== true) refusals.push(R.DEV_OPERATOR_MODE_MISSING);
+  if (input.nonProductionTargetAccepted !== true) refusals.push(R.NON_PRODUCTION_TARGET_NOT_ACCEPTED);
+  if (input.explicitRunnerInvocation !== true) refusals.push(R.NOT_EXPLICIT_RUNNER_INVOCATION);
+  if (input.manifestVerified !== true) refusals.push(R.MANIFEST_NOT_VERIFIED);
+  if (input.pathContainmentVerified !== true) refusals.push(R.PATH_CONTAINMENT_NOT_VERIFIED);
+  if (input.noUnlistedSql !== true) refusals.push(R.UNLISTED_SQL_PRESENT);
+  if (input.cleanupRequested === true && input.cleanupOptInPresent !== true) {
+    refusals.push(R.CLEANUP_OPT_IN_MISSING);
+  }
+  return { open: refusals.length === 0, refusals };
+}
+
+/** Thrown when the execution-sink gate conjunction is not fully open — carries
+ *  the stable, non-secret unmet-gate reason codes (never a DSN / secret). */
+export class IsolationSpikeExecutionRefusedError extends Error {
+  /** Stable reason codes for each unmet gate. */
+  readonly refusals: string[];
+  constructor(refusals: string[]) {
+    super(
+      `Phase 47J aw_* SQL execution sink refused (fail-closed): every execution gate must hold before a connection is opened. Unmet gate codes: ${refusals.join(', ')}.`,
+    );
+    this.name = 'IsolationSpikeExecutionRefusedError';
+    this.refusals = refusals;
+  }
+}
+
+/**
+ * Assert the execution-sink gate conjunction is fully open; throw a typed,
+ * non-secret error (with reason codes only) otherwise. The runner calls this
+ * before injecting a real sink — so a missing gate refuses, fails closed, and
+ * exits non-zero, never silently opening a connection or applying anything.
+ */
+export function assertIsolationSpikeExecutionGateOpen(
+  input: IsolationSpikeExecutionGateInput,
+): void {
+  const { open, refusals } = evaluateIsolationSpikeExecutionGate(input);
+  if (!open) {
+    throw new IsolationSpikeExecutionRefusedError(refusals);
+  }
+}
+
 // ── Bounded opaque references + dev-only replay / conflict reducer ─────────────
 //
 // The experimental schema persists ONLY short, bounded, opaque `awref:` strings —

--- a/app/tests/unit/admission-wedge-spike/aw-sql-execution-sink-spike.test.ts
+++ b/app/tests/unit/admission-wedge-spike/aw-sql-execution-sink-spike.test.ts
@@ -1,0 +1,951 @@
+// Phase 47J — Lane-1 aw_* SQL ISOLATED dev/operator EXECUTION-SINK spike tests.
+//
+// Proves the Phase 47I §8–§21 execution-sink obligations for the bounded,
+// dev/operator/test-only, disabled-by-default, NON-PRODUCTION execution sink:
+//
+//   * §10 — the apply-mode gate conjunction (G1–G13): --apply, a DISTINCT
+//     execution opt-in, dev/operator non-production mode, an accepted
+//     non-production target, explicit runner invocation, exact manifest, path
+//     containment, no-unlisted-SQL, and the cleanup opt-in all required; ANY
+//     unmet gate fails closed BEFORE a connection is opened or anything applied;
+//   * §11 — the database-target policy: production DATABASE_URL refused, DSN ==
+//     DATABASE_URL refused, missing / empty / malformed / non-local / no-marker /
+//     production-token DSNs refused; only explicit local/dev/test disposable
+//     targets accepted; NO DSN / secret in refusal output;
+//   * §12 — execution-sink design: the real sink is constructed only in the
+//     runner (outside the guarded SPIKE_FILES), injected via
+//     applyIsolationSpikePlan; statements run in manifest order in a single
+//     all-or-nothing transaction; index.ts stays pool-free;
+//   * §13/§14 — transaction / rollback / conflict / cleanup-gate semantics;
+//   * §17 — no public response expansion, 114-key no-leak parity preserved;
+//   * §20 (M1–M19) — the execution-sink test matrix.
+//
+// NO REAL DATABASE IS TOUCHED. Every path injects a FAKE connector / sink, so the
+// runner's gate / target / sink / transaction behavior is proven in isolation.
+// Real external-DB execution (the runner's `defaultConnect` pg path) is NOT
+// exercised here — it remains gated by the Phase 47I envelope and would require a
+// disposable non-production Postgres, which is out of scope for these unit tests.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, symlinkSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  AW_SQL_ISOLATION_SPIKE_GATE_ENV,
+  buildIsolationSpikePlan,
+  applyIsolationSpikePlan,
+  evaluateIsolationSpikeExecutionGate,
+  assertIsolationSpikeExecutionGateOpen,
+  ISOLATION_SPIKE_EXECUTION_REFUSAL,
+  IsolationSpikeExecutionRefusedError,
+  IsolationSpikeApplyError,
+  type IsolationSpikeExecutionGateInput,
+} from '../../../src/services/admission-wedge-spike/aw-sql-isolation-spike/index.js';
+import {
+  runExecutionSinkSpike,
+  parseRunnerArgs,
+  assessExecutionTarget,
+  createPgClientStatementSink,
+  EXECUTION_TARGET_REFUSAL,
+  AW_SQL_EXECUTION_APPLY_ENV,
+  AW_SQL_EXECUTION_CLEANUP_ENV,
+  AW_SQL_EXECUTION_TARGET_DSN_ENV,
+  PRODUCTION_DB_ENV,
+} from '../../../scripts/aw-sql-isolation-spike-runner.mjs';
+import {
+  findAdmissionPublicLeaks,
+  isAdmissionPublicSafe,
+} from '../../../src/services/admission-wedge-spike/index.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const OK_MANIFEST = {
+  spike: 'phase-47f-aw-sql-isolation-spike',
+  kind: 'experimental-dev-operator-only',
+  production: false,
+  schemaFinal: false,
+  forward: ['sql/0001_init.sql'],
+  cleanup: ['sql/0001_init_down.sql'],
+};
+const OK_SQL = {
+  '0001_init.sql': 'CREATE TABLE IF NOT EXISTS aw_isolation_spike_assertion (x TEXT);',
+  '0001_init_down.sql': 'DROP TABLE IF EXISTS aw_isolation_spike_assertion;',
+};
+
+const tempRoots: string[] = [];
+function tempSpike(manifest: unknown, sqlFiles: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'aw-sql-exec-sink-'));
+  mkdirSync(join(root, 'sql'), { recursive: true });
+  for (const [name, body] of Object.entries(sqlFiles)) {
+    writeFileSync(join(root, 'sql', name), body, 'utf8');
+  }
+  writeFileSync(join(root, 'manifest.json'), JSON.stringify(manifest), 'utf8');
+  tempRoots.push(root);
+  return root;
+}
+function trackTemp(root: string): string {
+  tempRoots.push(root);
+  return root;
+}
+afterEach(() => {
+  while (tempRoots.length) rmSync(tempRoots.pop()!, { recursive: true, force: true });
+});
+
+/** A DSN that the strict target policy accepts (loopback host + disposable DB
+ *  name). The password segment is a marker so the no-leak tests can prove it is
+ *  never echoed. */
+const GOOD_TARGET_DSN = 'postgres://spikeuser:SECRETPW123@localhost:5432/dixie_aw_spike_dev';
+const PROD_DSN = 'postgres://produser:PRODPW@prod-db.example-cloud.com:5432/app_main';
+
+/** A fake connector that records the queries it is asked to run and never opens
+ *  a real connection. `failOn(text)` makes a statement throw, modelling a DB
+ *  fault / conflict. */
+function fakeConnector(
+  record: { connectedWith?: string; queries: string[]; ended: boolean; called: number },
+  opts: { failOn?: (text: string) => boolean } = {},
+) {
+  return async (dsn: string) => {
+    record.called += 1;
+    record.connectedWith = dsn;
+    return {
+      query: async (text: string) => {
+        record.queries.push(text);
+        if (opts.failOn && opts.failOn(text)) {
+          throw new Error('synthetic db fault: duplicate key value violates unique constraint');
+        }
+        return { rows: [] };
+      },
+      end: async () => {
+        record.ended = true;
+      },
+    };
+  };
+}
+function newRecord() {
+  return { queries: [] as string[], ended: false, called: 0 } as {
+    connectedWith?: string;
+    queries: string[];
+    ended: boolean;
+    called: number;
+  };
+}
+
+/** Build a full env where every gate is satisfiable; tests delete keys to prove
+ *  each missing gate fails closed. */
+function fullEnv(extra: Record<string, string | undefined> = {}): Record<string, string | undefined> {
+  return {
+    [AW_SQL_ISOLATION_SPIKE_GATE_ENV]: 'true',
+    NODE_ENV: 'development',
+    [AW_SQL_EXECUTION_APPLY_ENV]: 'true',
+    [AW_SQL_EXECUTION_TARGET_DSN_ENV]: GOOD_TARGET_DSN,
+    ...extra,
+  };
+}
+
+// ── §10 — pure execution-gate conjunction ─────────────────────────────────────
+
+describe('Phase 47J — execution-gate conjunction (§10, pure)', () => {
+  const open: IsolationSpikeExecutionGateInput = {
+    applyRequested: true,
+    executionOptInPresent: true,
+    devOperatorModeAccepted: true,
+    nonProductionTargetAccepted: true,
+    explicitRunnerInvocation: true,
+    manifestVerified: true,
+    pathContainmentVerified: true,
+    noUnlistedSql: true,
+    cleanupRequested: false,
+    cleanupOptInPresent: false,
+  };
+
+  it('opens only when EVERY gate holds', () => {
+    const r = evaluateIsolationSpikeExecutionGate(open);
+    expect(r.open).toBe(true);
+    expect(r.refusals).toEqual([]);
+    expect(() => assertIsolationSpikeExecutionGateOpen(open)).not.toThrow();
+  });
+
+  it('each missing gate fails closed with its stable, non-secret reason code', () => {
+    const cases: Array<[Partial<IsolationSpikeExecutionGateInput>, string]> = [
+      [{ applyRequested: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.APPLY_NOT_REQUESTED],
+      [{ executionOptInPresent: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.EXECUTION_OPT_IN_MISSING],
+      [{ devOperatorModeAccepted: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.DEV_OPERATOR_MODE_MISSING],
+      [{ nonProductionTargetAccepted: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.NON_PRODUCTION_TARGET_NOT_ACCEPTED],
+      [{ explicitRunnerInvocation: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.NOT_EXPLICIT_RUNNER_INVOCATION],
+      [{ manifestVerified: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.MANIFEST_NOT_VERIFIED],
+      [{ pathContainmentVerified: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.PATH_CONTAINMENT_NOT_VERIFIED],
+      [{ noUnlistedSql: false }, ISOLATION_SPIKE_EXECUTION_REFUSAL.UNLISTED_SQL_PRESENT],
+    ];
+    for (const [override, code] of cases) {
+      const r = evaluateIsolationSpikeExecutionGate({ ...open, ...override });
+      expect(r.open).toBe(false);
+      expect(r.refusals).toContain(code);
+      expect(() => assertIsolationSpikeExecutionGateOpen({ ...open, ...override })).toThrow(
+        IsolationSpikeExecutionRefusedError,
+      );
+    }
+  });
+
+  it('cleanup direction requires the distinct cleanup opt-in', () => {
+    const cleanupNoOptIn = { ...open, cleanupRequested: true, cleanupOptInPresent: false };
+    const r = evaluateIsolationSpikeExecutionGate(cleanupNoOptIn);
+    expect(r.open).toBe(false);
+    expect(r.refusals).toContain(ISOLATION_SPIKE_EXECUTION_REFUSAL.CLEANUP_OPT_IN_MISSING);
+    // With the cleanup opt-in present, cleanup is allowed.
+    expect(
+      evaluateIsolationSpikeExecutionGate({ ...open, cleanupRequested: true, cleanupOptInPresent: true }).open,
+    ).toBe(true);
+  });
+
+  it('the thrown error carries reason codes only — never a DSN or secret', () => {
+    try {
+      assertIsolationSpikeExecutionGateOpen({ ...open, executionOptInPresent: false });
+      throw new Error('expected refusal');
+    } catch (err) {
+      expect(err).toBeInstanceOf(IsolationSpikeExecutionRefusedError);
+      const msg = (err as Error).message;
+      expect(msg).toContain('EXECUTION_OPT_IN_MISSING');
+      expect(msg).not.toContain('postgres://');
+      expect(msg).not.toContain('SECRETPW');
+    }
+  });
+});
+
+// ── §11 — database target policy (pure; no connection) ────────────────────────
+
+describe('Phase 47J — database target policy (§11, pure)', () => {
+  it('refuses a missing DSN', () => {
+    const r = assessExecutionTarget({ targetDsn: undefined, productionDsn: undefined });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_MISSING);
+  });
+
+  it('refuses an empty / whitespace DSN', () => {
+    for (const empty of ['', '   ']) {
+      const r = assessExecutionTarget({ targetDsn: empty, productionDsn: undefined });
+      expect(r.accepted).toBe(false);
+      expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_EMPTY);
+    }
+  });
+
+  it('refuses a DSN equal to the production DATABASE_URL (before parsing)', () => {
+    const r = assessExecutionTarget({ targetDsn: PROD_DSN, productionDsn: PROD_DSN });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toEqual([EXECUTION_TARGET_REFUSAL.TARGET_EQUALS_PRODUCTION_DSN]);
+  });
+
+  it('refuses a production DATABASE_URL value as a target (production tokens)', () => {
+    const r = assessExecutionTarget({ targetDsn: PROD_DSN, productionDsn: 'postgres://other' });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_PRODUCTION_TOKEN);
+  });
+
+  it('refuses a malformed DSN', () => {
+    const r = assessExecutionTarget({ targetDsn: 'not a dsn at all', productionDsn: undefined });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_MALFORMED);
+  });
+
+  it('refuses an unsafe remote DSN (non-local host, no disposable marker)', () => {
+    const r = assessExecutionTarget({
+      targetDsn: 'postgres://u:p@db.internal.example.com:5432/appmain',
+      productionDsn: undefined,
+    });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_NOT_LOCAL_OR_DEV);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_NO_DISPOSABLE_MARKER);
+  });
+
+  it('refuses an ambiguous default app DB on localhost without a disposable marker', () => {
+    const r = assessExecutionTarget({
+      targetDsn: 'postgres://u:p@localhost:5432/appdb',
+      productionDsn: undefined,
+    });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_NO_DISPOSABLE_MARKER);
+  });
+
+  it('refuses a production-like DSN even on a loopback host', () => {
+    const r = assessExecutionTarget({
+      targetDsn: 'postgres://u:p@localhost:5432/prod_clone',
+      productionDsn: undefined,
+    });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_PRODUCTION_TOKEN);
+  });
+
+  it('accepts only explicit local / dev / test disposable target examples', () => {
+    for (const dsn of [
+      'postgres://u:p@localhost:5432/dixie_aw_spike_dev',
+      'postgresql://u@127.0.0.1/spike_test_db',
+      'postgres://u:p@aw-dev-throwaway:5432/scratch_test',
+      'postgres://u:p@[::1]:5432/spike_ephemeral',
+    ]) {
+      const r = assessExecutionTarget({ targetDsn: dsn, productionDsn: PROD_DSN });
+      expect({ dsn, accepted: r.accepted, refusals: r.refusals }).toEqual({
+        dsn,
+        accepted: true,
+        refusals: [],
+      });
+    }
+  });
+
+  it('a refusal NEVER carries the DSN, host, or secret (codes only)', () => {
+    const r = assessExecutionTarget({
+      targetDsn: 'postgres://u:SUPERSECRET@db.example.com/appmain',
+      productionDsn: undefined,
+    });
+    const blob = JSON.stringify(r.refusals);
+    expect(blob).not.toContain('SUPERSECRET');
+    expect(blob).not.toContain('example.com');
+    expect(blob).not.toContain('postgres://');
+    // Every refusal is one of the stable code constants.
+    const codes = new Set(Object.values(EXECUTION_TARGET_REFUSAL));
+    for (const code of r.refusals) expect(codes.has(code)).toBe(true);
+  });
+});
+
+// ── §11 — target-policy bypass hardening (scheme allowlist + query rejection) ──
+//
+// A loopback-LOOKING DSN must not be able to launder a wrong protocol or redirect
+// the effective network target that `pg` actually connects to. `new URL()` reports
+// the literal `url.hostname` ('localhost'), but `pg` / `pg-connection-string`
+// resolve `?host=` / `?hostaddr=` / `?port=` to a DIFFERENT effective target — so a
+// host-only policy would approve an apparent loopback DSN while `pg` connects
+// remote. The policy therefore (1) accepts ONLY postgres:/postgresql: schemes and
+// (2) refuses ALL query parameters, so the host it validates is the host `pg` uses.
+
+describe('Phase 47J — target-policy bypass hardening (§11, pure)', () => {
+  it('refuses a non-Postgres scheme even on a loopback host (http / ftp / file)', () => {
+    for (const dsn of [
+      'http://localhost/dixie_spike_dev',
+      'ftp://localhost/dixie_spike_dev',
+      'file:///tmp/dixie_spike_dev',
+      'https://localhost:5432/dixie_spike_dev',
+    ]) {
+      const r = assessExecutionTarget({ targetDsn: dsn, productionDsn: undefined });
+      expect({ dsn, accepted: r.accepted }).toEqual({ dsn, accepted: false });
+      expect(r.refusals).toEqual([EXECUTION_TARGET_REFUSAL.TARGET_UNSUPPORTED_PROTOCOL]);
+    }
+  });
+
+  it('refuses a loopback-looking DSN whose ?host= redirects the effective target', () => {
+    for (const dsn of [
+      'postgres://u:p@localhost/dixie_spike_dev?host=remote.example',
+      'postgres://u:p@localhost/dixie_spike_dev?host=prod-db.example',
+      'postgresql://u:p@127.0.0.1:5432/spike_test_db?hostaddr=10.0.0.5',
+    ]) {
+      const r = assessExecutionTarget({ targetDsn: dsn, productionDsn: undefined });
+      expect({ dsn, accepted: r.accepted }).toEqual({ dsn, accepted: false });
+      expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_HOST_OVERRIDE_UNSUPPORTED);
+      // The refusal carries the stable code only — never the redirected hostname.
+      const blob = JSON.stringify(r.refusals);
+      expect(blob).not.toContain('remote.example');
+      expect(blob).not.toContain('prod-db.example');
+      expect(blob).not.toContain('10.0.0.5');
+    }
+  });
+
+  it('refuses a query-port override on an otherwise-loopback DSN', () => {
+    const r = assessExecutionTarget({
+      targetDsn: 'postgres://u:p@localhost/dixie_spike_dev?port=5432',
+      productionDsn: undefined,
+    });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_HOST_OVERRIDE_UNSUPPORTED);
+  });
+
+  it('refuses file-loading TLS query params (sslcert / sslkey / sslrootcert / sslcrl / sslmode)', () => {
+    for (const dsn of [
+      'postgres://u:p@localhost/dixie_spike_dev?sslcert=/tmp/client.crt',
+      'postgres://u:p@localhost/dixie_spike_dev?sslkey=/tmp/client.key',
+      'postgres://u:p@localhost/dixie_spike_dev?sslrootcert=/tmp/root.crt',
+      'postgres://u:p@localhost/dixie_spike_dev?sslcrl=/tmp/revoked.crl',
+      'postgres://u:p@localhost/dixie_spike_dev?sslmode=require',
+    ]) {
+      const r = assessExecutionTarget({ targetDsn: dsn, productionDsn: undefined });
+      expect({ dsn, accepted: r.accepted }).toEqual({ dsn, accepted: false });
+      expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_TLS_FILE_PARAMETER_UNSUPPORTED);
+      // The refusal carries the stable code only — never the file path value.
+      const blob = JSON.stringify(r.refusals);
+      expect(blob).not.toContain('/tmp/');
+      expect(blob).not.toContain('.crt');
+      expect(blob).not.toContain('.key');
+    }
+  });
+
+  it('refuses an unknown query parameter wholesale (closes unknown libpq behavior)', () => {
+    const r = assessExecutionTarget({
+      targetDsn: 'postgres://u:p@localhost/dixie_spike_dev?options=-c%20search_path%3Devil',
+      productionDsn: undefined,
+    });
+    expect(r.accepted).toBe(false);
+    expect(r.refusals).toContain(EXECUTION_TARGET_REFUSAL.TARGET_QUERY_PARAMETER_UNSUPPORTED);
+  });
+
+  it('still accepts the safe disposable loopback targets (no query string)', () => {
+    for (const dsn of [
+      'postgres://u:p@localhost:5432/dixie_aw_spike_dev',
+      'postgresql://u@127.0.0.1/spike_test_db',
+      'postgres://u:p@aw-dev-throwaway:5432/scratch_test',
+      'postgres://u:p@[::1]:5432/spike_ephemeral',
+    ]) {
+      const r = assessExecutionTarget({ targetDsn: dsn, productionDsn: PROD_DSN });
+      expect({ dsn, accepted: r.accepted, refusals: r.refusals }).toEqual({
+        dsn,
+        accepted: true,
+        refusals: [],
+      });
+    }
+  });
+});
+
+// ── §11/§10 — bypass DSNs are refused BEFORE any connection is opened ──────────
+
+describe('Phase 47J — runner refuses bypass DSNs before connect (§11, no-connect)', () => {
+  /** Each entry is a DSN that must be refused by the runner with NO connection
+   *  opened, and whose sensitive fragments must never appear in any output. */
+  const BYPASS_CASES: Array<{ name: string; dsn: string; mustNotLeak: string[] }> = [
+    {
+      name: 'http scheme',
+      dsn: 'http://localhost/dixie_spike_dev',
+      mustNotLeak: ['http://localhost'],
+    },
+    {
+      name: 'ftp scheme',
+      dsn: 'ftp://localhost/dixie_spike_dev',
+      mustNotLeak: ['ftp://localhost'],
+    },
+    {
+      name: '?host=remote.example redirect',
+      dsn: 'postgres://spikeuser:SECRETPW123@localhost/dixie_spike_dev?host=remote.example',
+      mustNotLeak: ['SECRETPW123', 'spikeuser', 'remote.example', 'postgres://'],
+    },
+    {
+      name: '?host=prod-db.example redirect',
+      dsn: 'postgres://spikeuser:SECRETPW123@localhost/dixie_spike_dev?host=prod-db.example',
+      mustNotLeak: ['SECRETPW123', 'spikeuser', 'prod-db.example', 'postgres://'],
+    },
+    {
+      name: '?port override',
+      dsn: 'postgres://spikeuser:SECRETPW123@localhost/dixie_spike_dev?port=5432',
+      mustNotLeak: ['SECRETPW123', 'spikeuser', 'postgres://'],
+    },
+    {
+      name: '?sslcert file param',
+      dsn: 'postgres://spikeuser:SECRETPW123@localhost/dixie_spike_dev?sslcert=/tmp/client.crt',
+      mustNotLeak: ['SECRETPW123', 'spikeuser', '/tmp/client.crt', 'postgres://'],
+    },
+    {
+      name: '?sslkey file param',
+      dsn: 'postgres://spikeuser:SECRETPW123@localhost/dixie_spike_dev?sslkey=/tmp/client.key',
+      mustNotLeak: ['SECRETPW123', 'spikeuser', '/tmp/client.key', 'postgres://'],
+    },
+    {
+      name: '?sslrootcert file param',
+      dsn: 'postgres://spikeuser:SECRETPW123@localhost/dixie_spike_dev?sslrootcert=/tmp/root.crt',
+      mustNotLeak: ['SECRETPW123', 'spikeuser', '/tmp/root.crt', 'postgres://'],
+    },
+  ];
+
+  for (const tc of BYPASS_CASES) {
+    it(`refuses ${tc.name} with no connection and no secret/host/path leak`, async () => {
+      const rec = newRecord();
+      const root = tempSpike(OK_MANIFEST, OK_SQL);
+      const logs: string[] = [];
+      const errs: string[] = [];
+      let caught: unknown;
+      await expect(
+        runExecutionSinkSpike({
+          argv: ['--apply'],
+          env: fullEnv({ [AW_SQL_EXECUTION_TARGET_DSN_ENV]: tc.dsn }),
+          spikeRoot: root,
+          deps: {
+            connect: fakeConnector(rec),
+            log: (m: string) => logs.push(m),
+            logError: (m: string) => errs.push(m),
+          },
+        }),
+      ).rejects.toMatchObject({
+        refusals: expect.arrayContaining(['NON_PRODUCTION_TARGET_NOT_ACCEPTED']),
+      });
+      // Capture the thrown error message too, to scan it for leaks.
+      try {
+        await runExecutionSinkSpike({
+          argv: ['--apply'],
+          env: fullEnv({ [AW_SQL_EXECUTION_TARGET_DSN_ENV]: tc.dsn }),
+          spikeRoot: root,
+          deps: { connect: fakeConnector(rec) },
+        });
+      } catch (err) {
+        caught = err;
+      }
+      // The connection was NEVER opened — refusal precedes connect.
+      expect(rec.called).toBe(0);
+      // No DSN / credential / redirected host / file path in any sink.
+      const blob = [...logs, ...errs, (caught as Error)?.message ?? ''].join('\n');
+      for (const secret of tc.mustNotLeak) {
+        expect(blob).not.toContain(secret);
+      }
+    });
+  }
+});
+
+// ── arg parsing ───────────────────────────────────────────────────────────────
+
+describe('Phase 47J — runner arg parsing', () => {
+  it('defaults to a forward dry-run; recognizes --apply / --direction / --help', () => {
+    expect(parseRunnerArgs([])).toEqual({ help: false, direction: 'forward', apply: false });
+    expect(parseRunnerArgs(['--apply'])).toEqual({ help: false, direction: 'forward', apply: true });
+    expect(parseRunnerArgs(['--direction=cleanup'])).toEqual({
+      help: false,
+      direction: 'cleanup',
+      apply: false,
+    });
+    expect(parseRunnerArgs(['--help']).help).toBe(true);
+  });
+
+  it('rejects an unknown argument or invalid direction', () => {
+    expect(() => parseRunnerArgs(['--nope'])).toThrow(/unknown argument/);
+    expect(() => parseRunnerArgs(['--direction=sideways'])).toThrow(/invalid --direction/);
+  });
+});
+
+// ── Runner: default dry-run preserved; gate refusals open no connection ────────
+
+describe('Phase 47J — runner default behaviour is preserved (planning-only)', () => {
+  it('without --apply it stays a dry-run plan and opens NO connection', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    const logs: string[] = [];
+    const out = await runExecutionSinkSpike({
+      argv: [],
+      env: fullEnv(),
+      spikeRoot: root,
+      deps: { connect: fakeConnector(rec), log: (m: string) => logs.push(m) },
+    });
+    expect(out.mode).toBe('dry-run');
+    expect(rec.called).toBe(0);
+    expect(logs.join('\n')).toContain('DRY-RUN PLAN');
+  });
+
+  it('the base dev/operator gate still fails closed (disabled by default)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: { ...fullEnv(), [AW_SQL_ISOLATION_SPIKE_GATE_ENV]: undefined },
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toThrow(/disabled by default/);
+    expect(rec.called).toBe(0);
+  });
+
+  it('NODE_ENV=production is refused even with every other gate present', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv({ NODE_ENV: 'production' }),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toThrow(/production/);
+    expect(rec.called).toBe(0);
+  });
+});
+
+// ── §10 — runner refuses --apply unless EVERY gate is present ──────────────────
+
+describe('Phase 47J — runner --apply gate conjunction (§10, M2/M4)', () => {
+  it('refuses --apply when the execution opt-in is missing (no connection)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv({ [AW_SQL_EXECUTION_APPLY_ENV]: undefined }),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toMatchObject({ refusals: expect.arrayContaining(['EXECUTION_OPT_IN_MISSING']) });
+    expect(rec.called).toBe(0);
+  });
+
+  it('refuses --apply when the DSN target is missing (no connection)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv({ [AW_SQL_EXECUTION_TARGET_DSN_ENV]: undefined }),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toMatchObject({
+      refusals: expect.arrayContaining(['NON_PRODUCTION_TARGET_NOT_ACCEPTED']),
+    });
+    expect(rec.called).toBe(0);
+  });
+
+  it('refuses --apply when the DSN equals the production DATABASE_URL (no connection)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv({
+          [AW_SQL_EXECUTION_TARGET_DSN_ENV]: PROD_DSN,
+          [PRODUCTION_DB_ENV]: PROD_DSN,
+        }),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toMatchObject({
+      refusals: expect.arrayContaining(['NON_PRODUCTION_TARGET_NOT_ACCEPTED']),
+    });
+    expect(rec.called).toBe(0);
+  });
+
+  it('refuses --apply against a production-like / unsafe remote DSN (no connection)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv({ [AW_SQL_EXECUTION_TARGET_DSN_ENV]: PROD_DSN }),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toThrow(IsolationSpikeExecutionRefusedError);
+    expect(rec.called).toBe(0);
+  });
+
+  it('refuses --apply when invocation is not the explicit runner (no connection)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv(),
+        spikeRoot: root,
+        explicitRunnerInvocation: false,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toMatchObject({
+      refusals: expect.arrayContaining(['NOT_EXPLICIT_RUNNER_INVOCATION']),
+    });
+    expect(rec.called).toBe(0);
+  });
+
+  it('no DSN / secret appears in the refusal output (codes only)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv({ [AW_SQL_EXECUTION_TARGET_DSN_ENV]: PROD_DSN, [AW_SQL_EXECUTION_APPLY_ENV]: undefined }),
+        spikeRoot: root,
+        deps: {
+          connect: fakeConnector(rec),
+          log: (m: string) => logs.push(m),
+          logError: (m: string) => errs.push(m),
+        },
+      }),
+    ).rejects.toThrow();
+    const blob = [...logs, ...errs].join('\n');
+    expect(blob).not.toContain('PRODPW');
+    expect(blob).not.toContain('prod-db.example-cloud.com');
+    expect(blob).not.toContain('postgres://');
+    // The structured error message is also code-only.
+    try {
+      await runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv({ [AW_SQL_EXECUTION_APPLY_ENV]: undefined }),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      });
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).not.toContain('SECRETPW');
+      expect(msg).not.toContain('postgres://');
+    }
+    expect(rec.called).toBe(0);
+  });
+});
+
+// ── §8/§9 — manifest / path / unlisted SQL protections run BEFORE execution ────
+
+describe('Phase 47J — plan protections precede execution (§8/§9, M6/M7)', () => {
+  it('an unlisted .sql in sql/ fails closed before any connection (M6)', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, {
+      ...OK_SQL,
+      '0002_unlisted.sql': 'CREATE TABLE aw_isolation_spike_extra (x TEXT);',
+    });
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv(),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toThrow(/unlisted .sql/);
+    expect(rec.called).toBe(0);
+  });
+
+  it('a symlinked .sql escaping the isolated folder fails closed before any connection (M7)', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'aw-sql-exec-outside-'));
+    trackTemp(outside);
+    const outsideFile = join(outside, 'evil.sql');
+    writeFileSync(outsideFile, 'CREATE TABLE evil (x TEXT);', 'utf8');
+
+    const root = mkdtempSync(join(tmpdir(), 'aw-sql-exec-symlink-'));
+    trackTemp(root);
+    mkdirSync(join(root, 'sql'), { recursive: true });
+    writeFileSync(join(root, 'sql', '0001_init_down.sql'), OK_SQL['0001_init_down.sql'], 'utf8');
+    symlinkSync(outsideFile, join(root, 'sql', '0001_init.sql'));
+    writeFileSync(join(root, 'manifest.json'), JSON.stringify(OK_MANIFEST), 'utf8');
+
+    const rec = newRecord();
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv(),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toThrow(/symlink/);
+    expect(rec.called).toBe(0);
+  });
+});
+
+// ── §12/§13 — execution sink: statements in order, single transaction ──────────
+
+describe('Phase 47J — execution sink applies in order (§12/§13, M-happy)', () => {
+  it('when EVERY gate passes, the sink runs BEGIN → statements (in manifest order) → COMMIT', async () => {
+    const rec = newRecord();
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql', 'sql/0002_more.sql'] },
+      { ...OK_SQL, '0002_more.sql': 'CREATE TABLE IF NOT EXISTS aw_isolation_spike_two (x TEXT);' },
+    );
+    const logs: string[] = [];
+    const out = await runExecutionSinkSpike({
+      argv: ['--apply'],
+      env: fullEnv(),
+      spikeRoot: root,
+      deps: { connect: fakeConnector(rec), log: (m: string) => logs.push(m) },
+    });
+    expect(out).toMatchObject({ mode: 'applied', direction: 'forward', appliedCount: 2 });
+    expect(rec.called).toBe(1);
+    expect(rec.queries[0]).toBe('BEGIN');
+    expect(rec.queries[rec.queries.length - 1]).toBe('COMMIT');
+    expect(rec.queries[1]).toContain('aw_isolation_spike_assertion');
+    expect(rec.queries[2]).toContain('aw_isolation_spike_two');
+    expect(rec.ended).toBe(true);
+    // The committed-line log carries no DSN / secret / target name.
+    const blob = logs.join('\n');
+    expect(blob).not.toContain('SECRETPW');
+    expect(blob).not.toContain('localhost');
+    expect(blob).not.toContain('dixie_aw_spike_dev');
+  });
+
+  it('cleanup execution requires the explicit cleanup opt-in, then drops in order', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    // Without the cleanup opt-in: refused, no connection.
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply', '--direction=cleanup'],
+        env: fullEnv(),
+        spikeRoot: root,
+        deps: { connect: fakeConnector(rec) },
+      }),
+    ).rejects.toMatchObject({ refusals: expect.arrayContaining(['CLEANUP_OPT_IN_MISSING']) });
+    expect(rec.called).toBe(0);
+
+    // With the cleanup opt-in: the drop path applies.
+    const rec2 = newRecord();
+    const out = await runExecutionSinkSpike({
+      argv: ['--apply', '--direction=cleanup'],
+      env: fullEnv({ [AW_SQL_EXECUTION_CLEANUP_ENV]: 'true' }),
+      spikeRoot: root,
+      deps: { connect: fakeConnector(rec2) },
+    });
+    expect(out).toMatchObject({ mode: 'applied', direction: 'cleanup', appliedCount: 1 });
+    expect(rec2.queries[0]).toBe('BEGIN');
+    expect(rec2.queries[1]).toContain('DROP TABLE IF EXISTS aw_isolation_spike_assertion');
+    expect(rec2.queries[rec2.queries.length - 1]).toBe('COMMIT');
+  });
+});
+
+// ── §13 — execution errors fail closed; transaction rolls back ─────────────────
+
+describe('Phase 47J — execution error / conflict rolls back (§13, M12)', () => {
+  it('a fault mid-apply rolls back (no COMMIT) and surfaces a fail-closed error', async () => {
+    const rec = newRecord();
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    const failing = fakeConnector(rec, { failOn: (t) => t.includes('CREATE TABLE') });
+    await expect(
+      runExecutionSinkSpike({
+        argv: ['--apply'],
+        env: fullEnv(),
+        spikeRoot: root,
+        deps: { connect: failing },
+      }),
+    ).rejects.toThrow(IsolationSpikeApplyError);
+    expect(rec.queries).toContain('BEGIN');
+    expect(rec.queries).toContain('ROLLBACK');
+    expect(rec.queries).not.toContain('COMMIT');
+    // The connection is still closed (no leak of the fault).
+    expect(rec.ended).toBe(true);
+  });
+
+  it('a UNIQUE-conflict-style DB fault rolls back with no partial commit', async () => {
+    const rec = newRecord();
+    const root = tempSpike(
+      { ...OK_MANIFEST, forward: ['sql/0001_init.sql', 'sql/0002_more.sql'] },
+      { ...OK_SQL, '0002_more.sql': 'CREATE TABLE IF NOT EXISTS aw_isolation_spike_two (x TEXT);' },
+    );
+    // Fail on the SECOND statement (a conflict after a partial apply).
+    let n = 0;
+    const connect = async () => {
+      rec.called += 1;
+      return {
+        query: async (text: string) => {
+          rec.queries.push(text);
+          if (text.includes('aw_isolation_spike_two')) {
+            n += 1;
+            throw new Error('duplicate key value violates unique constraint');
+          }
+          return { rows: [] };
+        },
+        end: async () => {
+          rec.ended = true;
+        },
+      };
+    };
+    await expect(
+      runExecutionSinkSpike({ argv: ['--apply'], env: fullEnv(), spikeRoot: root, deps: { connect } }),
+    ).rejects.toThrow(IsolationSpikeApplyError);
+    expect(n).toBe(1);
+    expect(rec.queries).toEqual([
+      'BEGIN',
+      'CREATE TABLE IF NOT EXISTS aw_isolation_spike_assertion (x TEXT);',
+      'CREATE TABLE IF NOT EXISTS aw_isolation_spike_two (x TEXT);',
+      'ROLLBACK',
+    ]);
+    expect(rec.queries).not.toContain('COMMIT');
+  });
+});
+
+// ── §12 — the statement sink wrapper itself (BEGIN/apply*/COMMIT, ROLLBACK) ─────
+
+describe('Phase 47J — createPgClientStatementSink semantics (§12)', () => {
+  it('drives BEGIN / applyStatement / COMMIT / ROLLBACK on the injected client', async () => {
+    const queries: string[] = [];
+    const client = { query: async (t: string) => void queries.push(t) };
+    const sink = createPgClientStatementSink(client);
+    await sink.begin();
+    await sink.applyStatement('STMT-1');
+    await sink.applyStatement('STMT-2');
+    await sink.commit();
+    expect(queries).toEqual(['BEGIN', 'STMT-1', 'STMT-2', 'COMMIT']);
+    await sink.rollback();
+    expect(queries[queries.length - 1]).toBe('ROLLBACK');
+  });
+
+  it('all-or-nothing through applyIsolationSpikePlan: rollback on fault, no commit', async () => {
+    const queries: string[] = [];
+    const client = {
+      query: async (t: string) => {
+        queries.push(t);
+        if (t.includes('aw_isolation_spike_assertion')) throw new Error('fault');
+      },
+    };
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    const plan = buildIsolationSpikePlan(root, 'forward');
+    await expect(applyIsolationSpikePlan(plan, createPgClientStatementSink(client))).rejects.toThrow(
+      IsolationSpikeApplyError,
+    );
+    expect(queries).toContain('BEGIN');
+    expect(queries).toContain('ROLLBACK');
+    expect(queries).not.toContain('COMMIT');
+  });
+});
+
+// ── §10 G6 / §12 — startup / migrator / packaging / config isolation (M15–M17) ─
+
+describe('Phase 47J — isolation from startup / migrator / packaging / config (M15–M17)', () => {
+  const REPO_APP = join(__dirname, '..', '..', '..');
+  const read = (p: string) => readFileSyncUtf8(join(REPO_APP, p));
+
+  it('server.ts never imports or invokes the execution-sink runner / sink', () => {
+    const src = read('src/server.ts');
+    expect(src).not.toMatch(/aw-sql-isolation-spike-runner/);
+    expect(src).not.toMatch(/runExecutionSinkSpike|createPgClientStatementSink|assessExecutionTarget/);
+    expect(src).not.toMatch(/IsolationSpikeExecutionGate|assertIsolationSpikeExecutionGateOpen/);
+  });
+
+  it('the production migration runner (migrate.ts) is unchanged — no aw_/spike coupling', () => {
+    const src = read('src/db/migrate.ts');
+    expect(src).not.toMatch(/aw[_-]|isolation-spike|admission|execution-sink/i);
+  });
+
+  it('the packager (copy-migrations.mjs) still scans only src/db/migrations', () => {
+    const src = read('scripts/copy-migrations.mjs');
+    expect(src).toContain("'src', 'db', 'migrations'");
+    expect(src).not.toMatch(/aw-sql-isolation-spike|execution-sink/i);
+  });
+
+  it('config.ts is not wired with the draft execution env labels (runner-local only)', () => {
+    const src = read('src/config.ts');
+    expect(src).not.toContain('DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_ENABLED');
+    expect(src).not.toContain('DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_TARGET_DSN');
+    expect(src).not.toContain('DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_CLEANUP_ENABLED');
+  });
+
+  it('no package.json script references the runner; the build script is unchanged', () => {
+    const pkg = JSON.parse(read('package.json'));
+    expect(JSON.stringify(pkg.scripts ?? {})).not.toMatch(/aw-sql-isolation-spike/);
+    expect(pkg.scripts.build).toBe('tsc && node scripts/copy-migrations.mjs');
+  });
+
+  it('the spike module index.ts stays pool-free and node:-only (no pg / client import)', () => {
+    const src = read('src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts');
+    expect(src).not.toMatch(/from\s+['"]pg['"]/);
+    expect(src).not.toMatch(/\/db\/(client|pool|migrate)/);
+    // The DB-touching pg import lives ONLY in the runner (outside SPIKE_FILES).
+    const runner = read('scripts/aw-sql-isolation-spike-runner.mjs');
+    expect(runner).toMatch(/import\(['"]pg['"]\)/);
+  });
+});
+
+// ── §17 — no public response expansion / no-leak parity preserved (M18) ────────
+
+describe('Phase 47J — no public surface expansion / no-leak parity (§17, M18)', () => {
+  it('the runtime no-leak guard still flags forbidden keys and accepts the safe shape', () => {
+    expect(findAdmissionPublicLeaks({ tenant_id: 'x' })).not.toEqual([]);
+    expect(findAdmissionPublicLeaks({ receipt_hash: 'x' })).not.toEqual([]);
+    expect(isAdmissionPublicSafe({ outcome_class: 'accepted', recall_eligible: false })).toBe(true);
+  });
+
+  it('the execution-sink seam exposes no public-response builder', () => {
+    const REPO_APP = join(__dirname, '..', '..', '..');
+    const idx = readFileSyncUtf8(
+      join(REPO_APP, 'src', 'services', 'admission-wedge-spike', 'aw-sql-isolation-spike', 'index.ts'),
+    );
+    expect(idx).not.toMatch(/buildAdmissionSpikePublicResponse|PublicResponse/);
+  });
+});
+
+// Local fs reader (kept tiny so the test file reads stay legible at call sites).
+function readFileSyncUtf8(p: string): string {
+  return readFileSync(p, 'utf8');
+}

--- a/app/tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts
+++ b/app/tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts
@@ -162,6 +162,36 @@ describe('Phase 47F isolation — startup runs no experimental SQL (Section F / 
     // The runner has a top-level guard assertion before any plan is built.
     expect(runner).toContain('assertDevOperatorGateOpen');
   });
+
+  // ── Phase 47J — the execution sink stays runner-bound + import-safe ──────────
+
+  it('F.2–F.5 (47J) — server.ts never imports the execution-sink runner / sink / gate', () => {
+    const src = serverSrc();
+    expect(src).not.toMatch(/runExecutionSinkSpike|createPgClientStatementSink|assessExecutionTarget/);
+    expect(src).not.toMatch(/IsolationSpikeExecutionGate|assertIsolationSpikeExecutionGateOpen/);
+  });
+
+  it('F.5 (47J) — the real pg client / sink is constructed ONLY in the runner (outside SPIKE_FILES)', () => {
+    const runner = readFileSync(RUNNER_SRC, 'utf8');
+    // The DB-touching pg import lives in the runner (under app/scripts/, which the
+    // canonical scope guard does NOT scan), never in the planner module.
+    expect(runner).toMatch(/import\(['"]pg['"]\)/);
+    expect(runner).toContain('createPgClientStatementSink');
+    const planner = readFileSync(
+      join(SPIKE_SERVICE_DIR, 'aw-sql-isolation-spike', 'index.ts'),
+      'utf8',
+    );
+    expect(planner).not.toMatch(/from\s+['"]pg['"]/);
+    expect(planner).not.toMatch(/import\(['"]pg['"]\)/);
+  });
+
+  it('the runner runs main() only when invoked directly (import-safe direct-run guard)', () => {
+    const runner = readFileSync(RUNNER_SRC, 'utf8');
+    // Importing the runner in a test must NOT trigger main()/process.exit — the
+    // direct-run guard compares import.meta.url to the invoked argv path.
+    expect(runner).toMatch(/import\.meta\.url\s*===\s*pathToFileURL/);
+    expect(runner).toContain('if (isDirectRun)');
+  });
 });
 
 // ── Section C (§10 C.7) — no package-lifecycle invocation ─────────────────────

--- a/app/tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts
+++ b/app/tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts
@@ -120,6 +120,19 @@ describe('Phase 47F scope-guard — the new module is inside the canonical guard
       expect(specifiers.some((s) => fn(s))).toBe(false);
     }
   });
+
+  // ── Phase 47J — the new pure execution-gate seam stays token-clean ──────────
+
+  it('the Phase 47J execution-gate seam exists in index.ts yet adds ZERO durable-write hits', () => {
+    const raw = readFileSync(ISO_INDEX, 'utf8');
+    // The pure gate conjunction (runner-fed) lives in the planner module …
+    expect(raw).toContain('evaluateIsolationSpikeExecutionGate');
+    expect(raw).toContain('assertIsolationSpikeExecutionGateOpen');
+    // … and it remains pool-free: no pg / db client / migrate token in executable
+    // source (the DB-touching code lives only in the runner, outside SPIKE_FILES).
+    const code = stripComments(raw);
+    expect(durableWriteHits(code)).toEqual([]);
+  });
 });
 
 // ── G.2/G.3 — no allowlist / opt-out was added for this lane ───────────────────

--- a/app/tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts
+++ b/app/tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts
@@ -39,6 +39,9 @@ import {
   createSyntheticWriteReducer,
   isSyntheticOpaqueRef,
   SYNTHETIC_REF_MAX_LENGTH,
+  evaluateIsolationSpikeExecutionGate,
+  assertIsolationSpikeExecutionGateOpen,
+  ISOLATION_SPIKE_EXECUTION_REFUSAL,
   IsolationSpikeDisabledError,
   IsolationSpikeProductionRefusedError,
   IsolationSpikeManifestError,
@@ -46,7 +49,9 @@ import {
   IsolationSpikeApplyError,
   IsolationSpikeSyntheticInputError,
   IsolationSpikeReplayConflictError,
+  IsolationSpikeExecutionRefusedError,
   type IsolationSpikeStatementSink,
+  type IsolationSpikeExecutionGateInput,
   type SyntheticAssertionWrite,
 } from '../../../src/services/admission-wedge-spike/aw-sql-isolation-spike/index.js';
 import {
@@ -752,6 +757,57 @@ describe('Phase 47F — rollback / recovery (Section K / §18)', () => {
   it('dry-run plan building opens no connection and applies nothing (no sink involved)', () => {
     const p = buildIsolationSpikePlan(REAL_SPIKE_ROOT, 'forward');
     expect(Array.isArray(p.steps)).toBe(true);
+  });
+});
+
+// ── Phase 47J — execution-gate seam composes with the all-or-nothing apply ─────
+
+describe('Phase 47F/47J — execution-gate seam is pure and runner-fed', () => {
+  const openInput: IsolationSpikeExecutionGateInput = {
+    applyRequested: true,
+    executionOptInPresent: true,
+    devOperatorModeAccepted: true,
+    nonProductionTargetAccepted: true,
+    explicitRunnerInvocation: true,
+    manifestVerified: true,
+    pathContainmentVerified: true,
+    noUnlistedSql: true,
+    cleanupRequested: false,
+    cleanupOptInPresent: false,
+  };
+
+  it('evaluateIsolationSpikeExecutionGate is open only with every gate, refuses each missing one', () => {
+    expect(evaluateIsolationSpikeExecutionGate(openInput).open).toBe(true);
+    const closed = evaluateIsolationSpikeExecutionGate({ ...openInput, executionOptInPresent: false });
+    expect(closed.open).toBe(false);
+    expect(closed.refusals).toContain(ISOLATION_SPIKE_EXECUTION_REFUSAL.EXECUTION_OPT_IN_MISSING);
+    expect(() => assertIsolationSpikeExecutionGateOpen(openInput)).not.toThrow();
+    expect(() =>
+      assertIsolationSpikeExecutionGateOpen({ ...openInput, nonProductionTargetAccepted: false }),
+    ).toThrow(IsolationSpikeExecutionRefusedError);
+  });
+
+  it('once the gate is open, the same injected-sink apply path runs all-or-nothing', async () => {
+    const root = tempSpike(OK_MANIFEST, OK_SQL);
+    assertIsolationSpikeExecutionGateOpen(openInput);
+    const calls: string[] = [];
+    const sink: IsolationSpikeStatementSink = {
+      begin() {
+        calls.push('begin');
+      },
+      applyStatement() {
+        calls.push('apply');
+      },
+      commit() {
+        calls.push('commit');
+      },
+      rollback() {
+        calls.push('rollback');
+      },
+    };
+    const result = await applyIsolationSpikePlan(buildIsolationSpikePlan(root, 'forward'), sink);
+    expect(calls).toEqual(['begin', 'apply', 'commit']);
+    expect(result.appliedCount).toBe(1);
   });
 });
 

--- a/docs/ADMISSION-WEDGE-LANE1-AW-SQL-EXECUTION-SINK-IMPLEMENTATION-AUTHORIZATION-CHECKLIST-GATE.md
+++ b/docs/ADMISSION-WEDGE-LANE1-AW-SQL-EXECUTION-SINK-IMPLEMENTATION-AUTHORIZATION-CHECKLIST-GATE.md
@@ -82,6 +82,35 @@ adjacent `loa-straylight` repository (cross-repo references, not Dixie file:line
 
 ## 1. Status
 
+> **Phase 47J status note (forward traceability; added by the Phase 47J implementation lane, §8 / §24).** The
+> conditionally-authorized **Phase 47J — Lane-1 `aw_*` SQL execution-sink dev/operator spike** has been implemented
+> within the exact §8 file-scope envelope:
+> [`admission-wedge/PHASE-47J-AW-SQL-EXECUTION-SINK-SPIKE-RUNBOOK.md`](admission-wedge/PHASE-47J-AW-SQL-EXECUTION-SINK-SPIKE-RUNBOOK.md).
+> It added a pure execution-gate conjunction to the planner module (`index.ts`, still pool-free and `node:`-only), the
+> real sink / DB-client / non-production target policy to the explicit runner (`aw-sql-isolation-spike-runner.mjs`,
+> outside the guarded `SPIKE_FILES`), the new focused
+> `app/tests/unit/admission-wedge-spike/aw-sql-execution-sink-spike.test.ts`, and extended the three existing Phase 47F
+> test files. `--apply` is now possible **only** under the full §10 gate conjunction against a strictly-non-production
+> target accepted by the §11 policy; the production `DATABASE_URL` stays refused; the migration runner, packager, server
+> boot, `config.ts`, scope guard, package, and lockfile are **unchanged**. The §11 target policy was **hardened**
+> (beyond the original host-only check) to a **scheme allowlist** (`postgres:`/`postgresql:` only) plus **wholesale
+> query-parameter rejection**, so a loopback-looking DSN can no longer launder a wrong protocol or redirect the
+> effective network target `pg` uses via `?host=` / `?hostaddr=` / `?port=` / `?ssl*=` (stable non-secret refusal codes
+> `TARGET_UNSUPPORTED_PROTOCOL` / `TARGET_HOST_OVERRIDE_UNSUPPORTED` / `TARGET_TLS_FILE_PARAMETER_UNSUPPORTED` /
+> `TARGET_QUERY_PARAMETER_UNSUPPORTED`). The execution-sink seam, target policy, gate
+> conjunction, and transaction / rollback / conflict semantics are proven with an **injected fake/test sink** in the
+> automated unit suite (no external DB is contacted by the suite; no dependency / CI DB service added). **In addition**,
+> a **one-off, bounded, non-production operator run** against a **disposable, loopback-only, volume-less, auto-removed
+> Postgres 16 container** exercised the §15 real-engine `CHECK` enforcement (R.1–R.6), the §13 transaction / idempotency
+> / conflict checklist (all-or-nothing apply, idempotent replay, `UNIQUE`-conflict rollback with no partial admit), and
+> the §14 cleanup / down checklist against a **live** engine, with the DSN / password / host / port / DB name redacted
+> and absent from runner output (recorded in the Phase 47J runbook §8). This live-engine proof is a **bounded
+> dev/operator artifact only** — **not** a CI service, changing **no** dependency / lockfile / package script / config,
+> and proving **nothing** about production. **Real production DB
+> execution, production migration execution, Lane-2 canonical Straylight-store migrations, the route-contract /
+> final-schema freeze, and the operative ADR-022E gate #8 discharge all remain BLOCKED**; Phase 47J claims no production
+> readiness and does not claim `aw_*` SQL is production-safe.
+
 Phase 47I is the bounded, docs/decision-only **Lane-1 `aw_*` SQL execution-sink implementation-authorization checklist
 gate** named by Phase 47H §21. Its purpose is to take the Phase 47H execution-sink / real-DB boundary **decomposition**
 (47H §5–§18) and **convert it into a hard, enumerated, file:line-grounded implementation-authorization checklist and

--- a/docs/admission-wedge/PHASE-47J-AW-SQL-EXECUTION-SINK-SPIKE-RUNBOOK.md
+++ b/docs/admission-wedge/PHASE-47J-AW-SQL-EXECUTION-SINK-SPIKE-RUNBOOK.md
@@ -1,0 +1,283 @@
+# Phase 47J — Admission Wedge dev/operator/test-only Lane-1 `aw_*` SQL EXECUTION-SINK spike: runbook
+
+> **What this is.** Phase 47J is the **code-bearing execution-sink lane** conditionally authorized by the
+> Phase 47I checklist gate
+> ([`../ADMISSION-WEDGE-LANE1-AW-SQL-EXECUTION-SINK-IMPLEMENTATION-AUTHORIZATION-CHECKLIST-GATE.md`](../ADMISSION-WEDGE-LANE1-AW-SQL-EXECUTION-SINK-IMPLEMENTATION-AUTHORIZATION-CHECKLIST-GATE.md),
+> Verdict A). It adds a **bounded, dev/operator/test-only, disabled-by-default, NON-PRODUCTION** execution
+> sink to the existing Phase 47F isolation spike: experimental `aw_isolation_spike_*` SQL can be **executed**
+> against a **strictly non-production target**, but **only** through the explicit dev/operator runner /
+> injection seam, and **only** when the full Phase 47I §10 gate conjunction holds.
+>
+> **What it is NOT.** This is **not** production storage, **not** the final Straylight store, **not** a
+> route-contract freeze, **not** a final schema freeze, and **not** an ADR-022E gate #8 discharge. It
+> performs **no** production DB write, **no** production migration execution, and **no** startup wiring; it
+> opens **no** connection from app startup or any route; it changes **no** production migration runner,
+> packager, server boot, or config behavior; it adds **no** dependency, package script, or lockfile change;
+> it expands **no** public response; it persists **no** raw candidate payload; and it integrates **no**
+> Freeside runtime/client. Lane-2 canonical Straylight-store migrations and the operative Straylight-side
+> ADR-022E gate #8 remain **blocked**. **Phase 47J does not claim that `aw_*` SQL is production-safe and does
+> not claim this is production storage.**
+>
+> **Real-DB evidence (scope of this implementation).** The execution-sink seam, the strict target policy, the
+> gate conjunction, the transaction / rollback / conflict semantics, and the startup / migrator / packaging /
+> config isolation are all proven with an **injected fake / test sink** in the automated unit suite (no
+> external database is contacted by the unit tests, so the suite stays dependency-free and needs no CI DB
+> service). **In addition**, a **real-engine operator run was performed once against a disposable, loopback-only,
+> volume-less, auto-removed Postgres 16 container** (`127.0.0.1`, dedicated throwaway DB name and password,
+> destroyed after the run — see §8 for the exact redacted evidence): the forward `--apply` created the
+> 3-table `aw_isolation_spike_*` family and its `CHECK` constraints, every runtime `CHECK` (invalid payload
+> ref, wrong actor ref, wrong `awref` kind, over-`{0,59}`-length ref, out-of-range status / class) rejected the
+> violating row, the `UNIQUE (tenant_ref, estate_ref, actor_ref, assertion_ref)` constraint rejected a duplicate
+> and a mid-transaction conflict rolled the **whole** transaction back (no partial admit), idempotent forward
+> replay re-ran clean, and the gated cleanup `--apply --direction=cleanup` dropped the family
+> reversibly-by-recreation with no state left behind. The real DSN / password / host / port / DB name appeared
+> in **no** runner output. This is a **bounded, one-off, non-production dev/operator proof only** — it is **not**
+> a CI service, **not** added to the test suite, **not** a dependency or lockfile change, and proves **nothing**
+> about production admission, production storage, or production-readiness. It does **not** discharge ADR-022E
+> gate #8, authorize Lane-2 canonical Straylight-store migrations, freeze the route contract or the final
+> schema, or claim `aw_*` SQL is production-safe; all of those remain **blocked**.
+
+---
+
+## 1. Scope
+
+Phase 47J is bounded to the exact Phase 47I §8 file envelope:
+
+- **modified in place** — the planner module (`index.ts`, a pure execution-gate seam only), the explicit
+  runner (`aw-sql-isolation-spike-runner.mjs`, where the real sink / DB client / target policy live), and the
+  three existing spike test files (extended, no regression);
+- **new** — one focused execution-sink test file and this runbook.
+
+No production migration runner, packager, server boot, config, package, lockfile, CI, route, store, fixture,
+route-vector, scope-guard, or `.sql` file is touched. The experimental DDL stays exactly the 3-table
+`aw_isolation_spike_*` family already shipped by Phase 47F.
+
+## 2. Posture (disabled by default; dev/operator/test-only; NON-PRODUCTION)
+
+| Property | Value |
+|----------|-------|
+| Default | **off** — no execution unless every gate is explicitly set |
+| Mode | dev/operator/test-only; `NODE_ENV=production` is **refused** |
+| Target | **strictly non-production only**; the production `DATABASE_URL` is **always refused** |
+| Reachability | the **explicit runner** is the only caller — never startup, route, migrator, or a package script |
+| Default action | a **dry-run plan** (opens no connection, applies nothing) — `--apply` is required to execute |
+| Secrets | the target DSN / credentials are **never logged**; refusals carry stable, non-secret reason codes |
+
+## 3. Gates (Phase 47I §10 — all required; any one absent fails closed)
+
+Execution (`--apply`) is **impossible** unless **every** gate below holds. Any missing gate ⇒ refuse, fail
+closed, exit non-zero, open **no** connection, apply **nothing** — never a silent no-op, never a default
+target, never a partial apply.
+
+| Gate | Requirement |
+|------|-------------|
+| `--apply` | execution explicitly requested |
+| base opt-in | `DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true` |
+| non-production | `NODE_ENV` is not `production` |
+| execution opt-in | `DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_ENABLED=true` (DISTINCT from the base opt-in) |
+| target accepted | a non-production DSN accepted by the §11 target policy (below) |
+| production DSN refused | the target must not equal, or look like, the production `DATABASE_URL` |
+| explicit invocation | run out-of-band via the runner only — never startup / route / package script |
+| exact manifest | the strict manifest schema + literals verified (a plan was built) |
+| path containment | lexical + symlink + realpath containment verified |
+| no unlisted SQL | on-disk reconciliation passed (no unlisted / no missing `.sql`) |
+| cleanup opt-in | `--direction=cleanup` also requires `DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_CLEANUP_ENABLED=true` |
+
+> **Draft env labels.** The three `…_APPLY_*` / `…_TARGET_DSN` env names are **draft, non-final labels read
+> ONLY inside the runner**. They are **not** added to or parsed by `app/src/config.ts`, **not** wired into any
+> package lifecycle script, and **not** a config behavior change.
+
+## 4. Database target policy (Phase 47I §11 — pure; no connection opened)
+
+The target is assessed **structurally** (scheme + host + database name + query-parameter **key names** only —
+the credential portion of the DSN and every query **value** are **never** inspected, so a secret, a redirected
+hostname, or a file path can neither leak nor trip a rule). The policy validates the **same effective target
+`pg` will use**. A target is **accepted only when**: a DSN is present and non-empty; it is not equal to the
+production `DATABASE_URL`; it parses; **its scheme is exactly `postgres:` or `postgresql:`** (any other scheme —
+`http:` / `ftp:` / `file:` / … — is refused before the host is trusted); **it carries no query parameters at
+all**; it carries **no** production-like token (e.g. `prod` / `production` / `live` / managed-cloud markers);
+its host is loopback **or** carries a disposable marker; and its database name carries a disposable marker (e.g.
+`dev` / `test` / `spike` / `ephemeral` / `throwaway` / `sandbox` / `scratch`).
+
+> **Why all query parameters are refused (bypass hardening).** `new URL()` reports the literal `url.hostname`,
+> but `pg` / `pg-connection-string` resolve query keys such as `?host=` / `?hostaddr=` / `?port=` to a
+> **different effective network target** — so an apparent loopback DSN like
+> `postgres://…@localhost/spike_dev?host=remote.example` would otherwise pass a host-only check while `pg`
+> connects to `remote.example`. A `?ssl*=` key (`sslcert` / `sslkey` / `sslrootcert` / `sslcrl` / `sslmode` / …)
+> can alter file-loading / TLS behavior. Because an unknown libpq/pg query key could redirect the target in
+> ways a pure policy cannot anticipate, the policy refuses **every** query parameter wholesale; with no query
+> string present, `url.hostname` **is** the host `pg` connects to, so the host / DB-name disposable checks are
+> sound. Only query **key names** are classified — never their (possibly secret) values.
+
+Refusal reason codes (non-secret; the DSN / host / redirected hostname / file path / secret never appears —
+only these fixed code constants):
+
+`TARGET_MISSING`, `TARGET_EMPTY`, `TARGET_EQUALS_PRODUCTION_DSN`, `TARGET_MALFORMED`,
+`TARGET_UNSUPPORTED_PROTOCOL`, `TARGET_HOST_OVERRIDE_UNSUPPORTED` (a `host` / `hostaddr` / `port` query
+override), `TARGET_TLS_FILE_PARAMETER_UNSUPPORTED` (an `ssl*` file/TLS query param),
+`TARGET_QUERY_PARAMETER_UNSUPPORTED` (any other query param), `TARGET_NOT_LOCAL_OR_DEV`,
+`TARGET_NO_DISPOSABLE_MARKER`, `TARGET_PRODUCTION_TOKEN`.
+
+## 5. Use (explicit dev/operator invocation only — NOT a package script)
+
+> Placeholders only. Replace `<...>` with a **disposable, non-production** value; never paste a real
+> production DSN, credential, token, tenant id, actor id, or internal hostname.
+
+```bash
+cd app
+
+# Dry-run FORWARD plan (default). Opens no connection, applies nothing.
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true NODE_ENV=development \
+  npx tsx scripts/aw-sql-isolation-spike-runner.mjs
+
+# Dry-run CLEANUP plan (the reversible drop path).
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true NODE_ENV=development \
+  npx tsx scripts/aw-sql-isolation-spike-runner.mjs --direction=cleanup
+
+# EXECUTION-SINK proof (forward) against a DISPOSABLE non-production target.
+# All gates must be present; the target DSN is a placeholder for a throwaway dev DB.
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true \
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_ENABLED=true \
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_TARGET_DSN='postgres://<dev-user>:<dev-pass>@localhost:5432/<disposable_spike_dev_db>' \
+NODE_ENV=development \
+  npx tsx scripts/aw-sql-isolation-spike-runner.mjs --apply
+
+# EXECUTION-SINK CLEANUP (drop) against the same disposable target — needs the cleanup opt-in too.
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_ENABLED=true \
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_ENABLED=true \
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_CLEANUP_ENABLED=true \
+DIXIE_ADMISSION_INTAKE_AW_SQL_ISOLATION_SPIKE_APPLY_TARGET_DSN='postgres://<dev-user>:<dev-pass>@localhost:5432/<disposable_spike_dev_db>' \
+NODE_ENV=development \
+  npx tsx scripts/aw-sql-isolation-spike-runner.mjs --apply --direction=cleanup
+```
+
+## 6. Refusal cases
+
+| Situation | Result |
+|-----------|--------|
+| env var unset / not exactly `true` | disabled-by-default refusal, exit 1, no connection |
+| `NODE_ENV=production` | production-refused, exit 1, no connection |
+| `--apply` without the execution opt-in | `EXECUTION_OPT_IN_MISSING`, exit 1, no connection |
+| `--apply` with no target DSN | `NON_PRODUCTION_TARGET_NOT_ACCEPTED`, exit 1, no connection |
+| target DSN equals the production `DATABASE_URL` | refused (`TARGET_EQUALS_PRODUCTION_DSN`), exit 1 |
+| production-like / unsafe remote DSN | refused (`TARGET_PRODUCTION_TOKEN` / `TARGET_NOT_LOCAL_OR_DEV` / `TARGET_NO_DISPOSABLE_MARKER`) |
+| non-Postgres scheme (`http:` / `ftp:` / `file:` …), even on loopback | refused (`TARGET_UNSUPPORTED_PROTOCOL`), exit 1, no connection |
+| loopback-looking DSN with a `?host=` / `?hostaddr=` / `?port=` override | refused (`TARGET_HOST_OVERRIDE_UNSUPPORTED`), exit 1, no connection |
+| DSN with an `?ssl*=` file/TLS query param | refused (`TARGET_TLS_FILE_PARAMETER_UNSUPPORTED`), exit 1, no connection |
+| DSN with any other query parameter | refused (`TARGET_QUERY_PARAMETER_UNSUPPORTED`), exit 1, no connection |
+| unlisted `.sql` present in `sql/` | reconciliation fails closed, exit 1, no connection |
+| symlinked / out-of-folder `.sql` | path-containment refusal, exit 1, no connection |
+| `--apply --direction=cleanup` without the cleanup opt-in | `CLEANUP_OPT_IN_MISSING`, exit 1, no connection |
+
+Every refusal is evaluated **before** a connection is opened.
+
+## 7. Secret / DSN logging
+
+The runner **never** logs the target DSN, any credential, password, token, or an environment dump. The target
+policy and gate conjunction emit **stable, non-secret reason codes only**. The "applied N statements" success
+line carries the count and direction only — never the target name, host, or DSN.
+
+## 8. Evidence capture
+
+- **Unit suite (fake/test sink — no external DB):** `app/tests/unit/admission-wedge-spike/aw-sql-execution-sink-spike.test.ts`
+  plus the extended Phase 47F suites. Run:
+
+  ```bash
+  cd app
+  npm test -- --run \
+    tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts \
+    tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts \
+    tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts \
+    tests/unit/admission-wedge-spike/aw-sql-execution-sink-spike.test.ts
+  npm run typecheck
+  npm run lint
+  ```
+
+- **Operator-run live-engine step (performed once; out of scope for CI):** a **disposable, loopback-only,
+  volume-less, auto-removed** Postgres 16 container was stood up (`docker run -d --rm` bound to `127.0.0.1`
+  with a dedicated throwaway DB name and password, no named volume, removed with `docker rm -f` after the run),
+  `…_APPLY_TARGET_DSN` was pointed at it (a loopback DSN with no query string, accepted by the §4 policy), and
+  the runner was driven end-to-end. The exact commands stand the disposable container up, run the gated
+  forward / cleanup `--apply`, drive `psql` to exercise the `CHECK` / `UNIQUE` / transaction paths, then tear
+  the container down. **This is a bounded one-off dev/operator proof, not a CI service**, and **no dependency,
+  lockfile, package script, or config is changed** by it.
+
+  **Redacted real-engine evidence (DSN / password / host / port / DB name redacted; reproduced from the
+  operator run):**
+
+  ```text
+  engine:        PostgreSQL 16.14 (disposable docker container, 127.0.0.1, --rm, no volume, torn down after)
+  target DSN:    postgres://<redacted-user>:<redacted-pass>@<redacted-loopback>:<redacted-port>/<redacted-disposable-db>
+                 (loopback host, disposable DB-name marker, NO query string -> accepted by the §4 policy)
+
+  forward --apply  -> "aw_* SQL execution-sink proof — APPLIED (forward) / statements applied: 1 /
+                       committed in a single transaction against a NON-PRODUCTION target." (exit 0)
+                   -> 3 tables present: aw_isolation_spike_assertion, _supersession_link, _tombstone
+                   -> 17 CHECK constraints present (assertion/supersession/tombstone ref + status + class)
+
+  runtime CHECK enforcement (the live ENGINE rejects, not just the in-memory mirror):
+    R.1 invalid raw payload ref      -> ERROR: new row ... violates check constraint "..._candidate_payload_ref_chk"
+    R.2 wrong actor ref kind         -> ERROR: new row ... violates check constraint "..._actor_ref_chk"
+    R.3 over-{0,59}-length ref (61-char body, total 77 <= VARCHAR(80)) -> rejected by the CHECK regex, NOT by length
+    R.4 wrong awref kind (assertion) -> ERROR: new row ... violates check constraint "..._assertion_ref_chk"
+    R.6 out-of-range status / class  -> ERROR: new row ... violates check constraint "..._status_chk" / "..._class_chk"
+
+  conflict + transaction (no partial admit):
+    R.5 duplicate (tenant,estate,actor,assertion) -> ERROR: duplicate key violates unique constraint
+                                                      "aw_isolation_spike_assertion_uniq"
+    mid-transaction conflict in an explicit BEGIN ... COMMIT -> ROLLBACK; row count UNCHANGED; the would-be
+                                                                partial-admit row did NOT survive
+    explicit BEGIN/COMMIT persists; explicit BEGIN/ROLLBACK discards
+
+  idempotency + cleanup:
+    R.13 re-run forward --apply              -> APPLIED, clean (CREATE TABLE IF NOT EXISTS), 3 tables still present
+    C.3 cleanup --apply WITHOUT cleanup opt-in -> refused "CLEANUP_OPT_IN_MISSING" (exit 1); 3 tables UNTOUCHED
+    C.1/C.2 cleanup --apply WITH the cleanup opt-in -> APPLIED (cleanup); 0 tables (DROP ... IF EXISTS, reverse order)
+    C.4 forward --apply again                -> re-creates the 3-table family (reversible-by-recreation)
+    final cleanup                            -> 0 tables; container removed; no volume, no state left behind
+
+  secret hygiene: the runner's stdout/stderr on the success path contained NO DSN, password, host, port,
+                  or DB name (grep for the throwaway password / "postgres://" / host / port / DB name -> CLEAN).
+  ```
+
+  This evidence satisfies the §15 real-engine `CHECK` checklist (R.1–R.6), the §13 transaction / idempotency /
+  conflict checklist (T.1, T.4, T.5), and the §14 cleanup / down checklist (C.1–C.5) against a **live**
+  Postgres engine — going beyond the fake-sink unit suite. It remains a **bounded, non-production** proof and
+  is **not** added to CI; reproducing it requires an operator to stand up their own disposable Postgres.
+
+## 9. Rollback / cleanup / down behavior
+
+- **Partial-failure fail-closed.** A fault mid-apply triggers `ROLLBACK` and a wrapped fail-closed error; no
+  `COMMIT` is issued, so no half-applied footprint survives (proven deterministically with a fake sink).
+- **Cleanup / down is gated.** The `_down.sql` drop path runs only via `--apply --direction=cleanup` under the
+  **distinct** cleanup opt-in plus the full gate conjunction; absent any gate it refuses and exits non-zero.
+- **Bounded to the experimental family.** The drop targets exactly the three `aw_isolation_spike_*` tables
+  with `DROP TABLE IF EXISTS`, leaving no production state behind; the forward `CREATE TABLE IF NOT EXISTS`
+  re-creates the family, so the path is reversible-by-recreation.
+- **Reversible runner.** The spike persists nothing of its own at dry-run; a re-run re-derives the same plan
+  from the same manifest + `.sql` files.
+
+## 10. Non-goals
+
+Production storage; the final Straylight store; production DB writes; production migration execution; route /
+API behavior change; public response expansion; raw candidate payload persistence; route-contract freeze;
+final schema freeze; ADR-022E gate #8 discharge; signer / consent / auth resolution; package export of the
+spike; dependency / lockfile / config / CI change.
+
+## 11. Preserved blocked lanes
+
+Production migration files; production DB writes; production durable-store implementation; production
+migration execution; migration-runner (`migrate.ts`) / packager (`copy-migrations.mjs`) / startup
+(`server.ts`) / config (`config.ts`) / scope-guard (`scope-guards.test.ts`) changes; Lane-2 canonical
+Straylight-store migrations; route-contract freeze; final schema freeze; the operative Straylight-side
+ADR-022E gate #8 discharge; Freeside runtime/client integration; production admission / signer / auth /
+consent — **all remain blocked**. If the execution sink could not be bounded safely without weakening the
+production posture, the fallback is the Phase 47A `.json` Mode 2 store (Option C); the bounded, location- and
+gate-isolated execution sink was achievable here with no production-path change, so the spike stands as
+conditionally authorized.
+
+## 12. No adjacent repo involvement
+
+Phase 47J touches **no** adjacent repository — no `loa-straylight`, `freeside-characters`, or any sibling
+repo file is created or modified. The canonical Straylight `StorageAdapter` / `Assertion` /
+`TransitionReceipt` / `AuditEvent` shapes stay Straylight-owned (cross-repo references only).


### PR DESCRIPTION
## Summary

Phase 47J adds the Lane-1 `aw_*` SQL execution sink dev/operator spike.

This is a bounded, disabled-by-default, dev/operator/test-only, non-production, exact-scope-only execution-sink proof under the Phase 47I authorization envelope.

It adds a fail-closed execution gate, a runner-local target policy, a bounded execution sink path, targeted tests, and an operator runbook. It does not add startup wiring, production migration execution, production DB writes, config behavior, package changes, or production durable storage.

## Files

Modified:

- `app/src/services/admission-wedge-spike/aw-sql-isolation-spike/index.ts`
- `app/scripts/aw-sql-isolation-spike-runner.mjs`
- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-spike.test.ts`
- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-runner-isolation.test.ts`
- `app/tests/unit/admission-wedge-spike/aw-sql-isolation-scope-guard.test.ts`
- `docs/ADMISSION-WEDGE-LANE1-AW-SQL-EXECUTION-SINK-IMPLEMENTATION-AUTHORIZATION-CHECKLIST-GATE.md`

New:

- `app/tests/unit/admission-wedge-spike/aw-sql-execution-sink-spike.test.ts`
- `docs/admission-wedge/PHASE-47J-AW-SQL-EXECUTION-SINK-SPIKE-RUNBOOK.md`

## Implementation

Phase 47J:

- reuses the existing `IsolationSpikeStatementSink` / `applyIsolationSpikePlan(plan, sink)` seam;
- keeps `index.ts` pure, node-only, pool-free, and deterministic;
- keeps DB-touching code only in the explicit runner;
- keeps runner execution out of startup, route/API handling, config wiring, production migrator, and packaging/copy paths;
- requires a complete gate conjunction before connection;
- refuses missing, malformed, ambiguous, unsafe, production-like, or query-overridden targets before connect;
- refuses all query parameters in execution target DSNs;
- allows only `postgres:` / `postgresql:` schemes;
- logs stable non-secret refusal codes rather than DSNs, credentials, query values, or file paths;
- supports transaction ordering and rollback through the injected execution sink;
- gates cleanup/down execution separately.

## Codex PATCH resolution

Codex initially returned PATCH for two blockers:

1. The target policy could be bypassed because it accepted arbitrary URL protocols and trusted `URL.hostname` while `pg` could resolve an effective remote host through query parameters.
2. Phase 47I required real-engine transaction/CHECK evidence, but the runbook initially recorded that live-engine evidence had not been run.

Both blockers were resolved:

- target policy now accepts only `postgres:` / `postgresql:`;
- all query parameters are refused before connect;
- host, hostaddr, port, TLS/file, and unknown query override attempts have stable refusal codes;
- bypass tests prove wrong schemes and query host overrides refuse without connecting and without leaking DSN/secret/query/file-path data;
- the runbook records bounded, redacted local disposable Postgres evidence.

Codex re-audited ACCEPT.

## Evidence

Validated locally:

- targeted Phase 47J suite: 4 files / 147 tests passed
- `npm run typecheck`: pass
- `npm run lint`: pass
- full app `npm test`: 175 files / 3,323 tests passed; 1 file / 22 tests skipped
- docs fixture validator: PASS, 5/5
- route-vector validator: PASS, 5/5, no sixth vector
- route-vector self-check: PASS, 44/44
- `git diff --check`: pass
- `git diff --cached --check`: pass

The runbook records redacted local disposable PostgreSQL 16 evidence for:

- forward execution;
- BEGIN / COMMIT / ROLLBACK behavior;
- runtime CHECK constraint enforcement;
- invalid raw payload ref rejection;
- wrong `awref` kind rejection;
- overlength ref rejection;
- conflict rollback with no partial row;
- replay;
- gated cleanup/down;
- recreation after cleanup;
- final teardown.

The evidence is bounded local disposable-engine evidence, not CI, production, production-readiness, or production-role proof.

## Non-goals

This PR does not authorize:

- production DB execution
- production DB writes
- production migration execution
- production durable storage
- startup wiring
- config behavior changes
- package/lockfile changes
- production migration files
- public route/API behavior changes
- public response expansion
- raw candidate payload persistence
- route-contract freeze
- final schema freeze
- ADR-022E gate #8 discharge
- Freeside runtime/client integration
- Lane-2 canonical Straylight-store migrations
- production readiness
- any claim that `aw_*` SQL is production-safe

## Adjacent repo hygiene

No adjacent repositories are part of this PR.

For this workflow, adjacent repo dirt is report-only unless attributable to the current `loa-dixie` phase. This PR does not touch `loa-arcturus`, `loa-sensenet`, `loa-straylight`, `freeside-characters`, `loa`, `loa-finn`, `loa-hounfour`, or `loa-freeside`.

## Next lane

Recommended next lane:

Phase 47K — Lane-1 `aw_*` SQL execution sink spike acceptance / hardening decision gate

Phase 47K should be docs/decision-only. It should accept or patch Phase 47J, record what was proven, what remains blocked, and decide whether MVP-2 storage/audit proof can be closed or whether one more bounded hardening lane is needed.
