### PR TITLE
chore: close stuck bug #331 state record (TRIAGED → COMPLETED)

### DIFF
--- a/.run/bugs/20260215-i331-merge-delete/state.json
+++ b/.run/bugs/20260215-i331-merge-delete/state.json
@@ -3,13 +3,15 @@
   "issue": 331,
   "title": "cycle-014 merge deletes 933 downstream project files",
   "severity": "CRITICAL",
-  "state": "TRIAGED",
+  "state": "COMPLETED",
   "sprint": "sprint-bug-331",
   "global_sprint_id": 100,
   "timestamps": {
     "reported": "2026-02-15T00:00:00Z",
-    "triaged": "2026-02-15T17:00:00Z"
+    "triaged": "2026-02-15T17:00:00Z",
+    "completed": "2026-06-22T00:00:00Z"
   },
+  "closure_note": "Fix landed via PR #330 (commit cf67cd3f): .gitattributes merge=ours protection block + update-loa.md Phase 5.3 collateral-deletion safeguard and Phase 5.5 workflow revert. Record was stuck in TRIAGED; marked COMPLETED to stop /loa routing into the bug workflow.",
   "root_cause": "update-loa uses git merge loa/main which propagates upstream file deletions. Only README.md, CHANGELOG.md, .github/workflows/ protected via .gitattributes merge=ours. All other downstream files (app/, src/, grimoires/) are unprotected.",
   "fix_files": [
     ".claude/commands/update-loa.md",


### PR DESCRIPTION
## Summary

The cycle-014 merge-delete bug (**#331, CRITICAL**) was stuck in `TRIAGED` and never closed out. Because `golden_detect_active_bug` treats any state other than `COMPLETED`/`HALTED` as active, `/loa` kept routing into the bug workflow instead of the normal feature flow.

The fix for #331 **already landed** via PR #330 (commit `cf67cd3f`):
- `.gitattributes` `merge=ours` protection block (project identity, state-zone, CI/CD paths)
- `update-loa.md` Phase 5.3 collateral-deletion safeguard (`--diff-filter=D` restore) + Phase 5.5 workflow revert

So this record was simply never transitioned to a terminal state.

## Change

Mark the bug-state record `COMPLETED` (with a `completed` timestamp and a `closure_note` documenting the fix provenance). The full triage audit trail is preserved — no data deleted.

```
.run/bugs/20260215-i331-merge-delete/state.json | 6 ++++--
1 file changed, 4 insertions(+), 2 deletions(-)
```

## Verification

- `golden_detect_active_bug` → no active bug ✓
- `/loa` journey bar back to feature flow (`/plan → /build → /review → /ship`) ✓
- JSON validates ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)