### PR TITLE
fix(evals): repair early-stop brace-default bug + over-broad metachar reject

### DIFF
--- a/evals/harness/run-eval.sh
+++ b/evals/harness/run-eval.sh
@@ -431,8 +431,12 @@ execute_task() {
     "$HARNESS_DIR/sandbox.sh" destroy --trial-id "$trial_id" 2>/dev/null || true
 
     # Track pass/fail for early stopping
+    # NOTE: do not inline a brace-default like ${composite_json:-{}} here — bash parses
+    # the trailing brace as a literal '}', producing invalid JSON ('{...}}') that makes jq
+    # emit "true\nfalse". Default to an empty object on a separate line instead.
     local trial_passed
-    trial_passed="$(echo "${composite_json:-{}}" | jq -r '.pass // false' 2>/dev/null || echo "false")"
+    [[ -n "$composite_json" ]] || composite_json='{}'
+    trial_passed="$(printf '%s' "$composite_json" | jq -r '.pass // false' 2>/dev/null || echo "false")"
     if [[ "$trial_passed" == "true" ]]; then
       es_passes=$((es_passes + 1))
     else

--- a/evals/harness/validate-task.sh
+++ b/evals/harness/validate-task.sh
@@ -159,8 +159,12 @@ else
     arg_count="$(yq -r ".graders[$i].args | length // 0" "$TASK_FILE")"
     for j in $(seq 0 $((arg_count - 1))); do
       arg="$(yq -r ".graders[$i].args[$j] // \"\"" "$TASK_FILE")"
-      # Reject args containing shell metacharacters
-      if [[ "$arg" =~ [\;\|\&\$\`\\] ]]; then
+      # Reject args containing shell metacharacters that enable command injection.
+      # Backslash is intentionally NOT in this class: grader args are regex patterns
+      # (e.g. 'describe\(' for pattern-match.sh) and are passed as argv via
+      # "${grader_args[@]}" with no eval/sh -c (see grade.sh), so '\' is inert.
+      # The blocked chars are command separators and substitution: ; | & $ `
+      if [[ "$arg" =~ [\;\|\&\$\`] ]]; then
         errors+=("graders[$i].args[$j]: contains shell metacharacter: '$arg'")
       fi
       # Reject path traversal


### PR DESCRIPTION
cc @deep-name

## Summary

While running the eval suites I hit a regression suite reporting **0/10 "passing"**. Digging in, both findings turned out to be **real harness bugs**, not config noise. This PR fixes both.

## Bug 1 — `run-eval.sh:435` (the serious one)

The early-stop check used `${composite_json:-{}}`. Bash parses this as default-value `{` **plus a stray literal `}`**. With `composite_json` set (every normal trial), the expansion appends `}` → invalid JSON `{...}}` → `jq` prints `true` then errors on the extra brace → the `|| echo "false"` fires → `trial_passed` becomes `"true\nfalse"`.

Cascade: a **passing** trial is miscounted as a failure → `es_passes` never increments → early-stop math runs with p=0/f=1/r=2 → best-case 0.67 < 0.90 → **"regression inevitable" → trials 2 & 3 skipped** → task marked failed.

The **framework** suite was unaffected only because it runs `trials: 1`, so the `[[ "$trials" -gt 1 ]]` early-stop block never executes — the bug was dormant at one trial.

**Fix:** default to `{}` on a separate line, then `printf '%s' | jq`. Verified the early-stop feature still fires correctly on genuine failures.

## Bug 2 — `validate-task.sh:163`

The shell-metachar denylist `[\;\|\&\$\`\\]` included backslash, rejecting legitimate regex escapes like `describe\(` (for `pattern-match.sh`). Grader args are passed as argv via `"${grader_args[@]}"` with **no `eval` / `sh -c`** (`grade.sh:103`), so backslash is inert. This silently excluded `impl-test-structure.yaml` (11→10 tasks).

**Fix:** drop `\` from the class; keep the genuinely dangerous separators/substitution chars (`; | & $ \``). Comment added citing the safe execution path.

## Verification

| Suite | Before | After |
|---|---|---|
| regression | 0/10 pass, 1 task skipped at validate | **11/11 pass**, all 3 trials run, no early-stops |
| framework | 39/39 | **39/39** (no regression from the parse change) |

```
evals/harness/run-eval.sh      | 6 +++++-
evals/harness/validate-task.sh | 8 ++++++--
```

## Note on baselines

I did **not** touch baselines (per C-EVAL-001 they require a separate PR + rationale). The regression baseline is currently empty (all results classed "New"). Now that the suite actually exercises its tasks, establishing a regression baseline would be a sensible follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)