### PR TITLE
[codex] Add Eileen daily implementation agent runbook

### DIFF
--- a/eileendailyimplementationagentmodeagent.md
+++ b/eileendailyimplementationagentmodeagent.md
@@ -1,106 +1,63 @@
 # Eileen Daily Implementation Agent Mode Agent
 
-This file is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. This file is intentionally separate from `AGENTS.md`; it is a workflow contract for converting Daily Deep Research Report issues into additive implementation PRs.
+This repo-local runbook must be read by the daily GPT-5.5 Thinking implementation agent before editing `0xHoneyJar/loa-dixie`. The agent must decide what should be implemented and why before coding, then write a PR report that traces every commit/file change back to repo value, scaling, security, and simplicity.
 
 ## Repository responsibility
 
-`0xHoneyJar/loa-dixie` owns governed BFF/API integration: auth, tenant/estate binding, SIWE/JWT, recall/admission route contracts, middleware fail-closed behavior, observability, and service-boundary enforcement.
+`loa-dixie` owns governed BFF/API integration: auth, tenant/estate binding, SIWE/JWT, recall/admission route contracts, middleware fail-closed behavior, observability, and service-boundary enforcement.
 
-This repo is not the place for Freeside product strategy, character/persona UX, Hounfour schema packages, Finn experiment verdicts, Aleph research-précis doctrine, Arcturus revenue-oracle logic, or Straylight doctrine beyond integration boundaries.
+It must not own Freeside product strategy, character/persona UX, Hounfour schema packages, Finn experiment verdicts, Aleph research-précis doctrine, Arcturus revenue-oracle logic, or Straylight doctrine beyond integration boundaries.
 
 ## Eligible input
 
-Only implement from a Daily Deep Research Report issue or follow-up plan-audit issue/comment that contains:
+Implement only from a Daily Deep Research Report or plan-audit item with `PROPOSED_NEXT_LANE_SEED`, candidate ID, repo-fit reasoning, acceptance criteria, rollback path, and `VERDICT: ACCEPT_PLAN`.
 
-- `PROPOSED_NEXT_LANE_SEED`
-- candidate ID
-- repo-fit reasoning
-- acceptance criteria
-- rollback path
-- `VERDICT: ACCEPT_PLAN`
+Without `VERDICT: ACCEPT_PLAN`, the agent may self-audit only docs, fixtures, tests, or checkers. Runtime/API behavior requires explicit external acceptance.
 
-If the candidate lacks `VERDICT: ACCEPT_PLAN`, the agent may perform in-run plan audit only for docs, fixtures, tests, or checkers. Runtime/API behavior requires explicit external acceptance.
+## Required pre-implementation thesis
 
-## Selection rule
+Before editing, write and preserve this analysis:
 
-Pick at most one candidate per run. Prefer work that strengthens route tests, fail-closed behavior, tenant/estate binding evidence, or observability without changing public route behavior.
+1. candidate issue, candidate ID, and verdict
+2. what should be implemented
+3. why it should be implemented now
+4. why it belongs in Dixie and not a sibling repo
+5. what this is good for
+6. why the implementation path should work
+7. how it advances Dixie's endgame as a governed BFF/API integration layer
+8. creative future paths not implemented now
+9. mass-user scaling impact for API load, tenant isolation, route latency, rate limits, observability, and operational failure modes
+10. security scope for auth, wallet/session binding, tenant/estate boundaries, recall/admission routes, middleware order, and public/private response boundaries
+11. simplicity argument: how the design avoids fragile middleware or route complexity
+12. non-goals, forbidden surfaces, checks, and rollback
 
-Priority order:
-
-1. docs-only service-boundary notes
-2. fixture-only route examples
-3. test-only negative coverage
-4. checker/validator-only additions
-5. default-off route or middleware helpers
+If this thesis is weak, do not implement.
 
 ## Additive-only policy
 
-Nothing currently working may stop functioning.
+Allowed by default: new docs, fixtures, tests, negative route tests, validators/checkers, default-off helpers, and observability evidence.
 
-Allowed by default:
-
-- new docs
-- new fixtures
-- new tests
-- new negative route tests
-- new validators/checkers
-- default-off helpers
-- observability docs or test-only evidence
-
-Forbidden without explicit Eileen approval:
-
-- deleting files
-- changing public API behavior by default
-- changing auth/tenant binding semantics by default
-- weakening middleware fail-closed behavior
-- changing recall/admission route contracts without accepted plan
-- production migrations
-- broad refactors
-- unrelated dependency upgrades
-- secrets or real env changes
-- sibling repo mutation
-- deployment changes
-- auto-merge
-- closing source issues
+Forbidden without explicit Eileen approval: deleting files, changing public API behavior by default, changing auth/tenant binding semantics by default, weakening fail-closed behavior, changing recall/admission contracts without accepted plan, production migrations, broad refactors, unrelated dependency upgrades, secrets/env changes, sibling repo mutation, deployment changes, auto-merge, or closing source issues.
 
 ## Dixie-specific stop conditions
 
-Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would:
-
-- modify live auth or tenant/estate binding behavior by default
-- change route response shape without explicit acceptance
-- weaken fail-closed behavior
-- bypass or reorder security middleware without proof
-- duplicate Straylight or Hounfour ownership instead of consuming their contracts
+Stop with `VERDICT: NEEDS_HUMAN` if the candidate modifies live auth or tenant/estate binding by default, changes route response shape without acceptance, weakens fail-closed behavior, bypasses/reorders security middleware without proof, or duplicates Straylight/Hounfour ownership instead of consuming their contracts.
 
 ## Implementation steps
 
-1. Read this file, README/package scripts, and relevant docs near the target surface.
-2. Inspect the source issue and confirm `VERDICT: ACCEPT_PLAN`.
-3. Check for obvious duplicate open issues/PRs.
-4. Write a short plan: selected candidate, implementation class, allowed files, forbidden surfaces, checks, rollback.
-5. Create a branch named `daily-impl/YYYY-MM-DD-loa-dixie-<candidate>`.
-6. Implement exactly one candidate with a minimal diff.
-7. Run relevant checks from the repo.
-8. Open a draft PR.
-9. Add `CODEX AUDIT REQUEST` to the PR body.
-10. Comment: `@codex review for additive-only scope violations, accidental API/auth behavior changes, fail-closed regressions, failing or missing tests, rollback clarity, repo-boundary violations, and security regressions`.
-11. Do not merge and do not close the source issue.
+1. Read this file, README/package scripts, and nearby docs.
+2. Confirm `VERDICT: ACCEPT_PLAN`.
+3. Check for duplicate open issues/PRs.
+4. Write the required pre-implementation thesis.
+5. Create branch `daily-impl/YYYY-MM-DD-loa-dixie-<candidate>`.
+6. Implement exactly one candidate with minimal diff.
+7. Prefer explicit route tests and checks over clever abstractions.
+8. Run relevant checks.
+9. Open a draft PR.
+10. Add `CODEX AUDIT REQUEST` and the traceability report.
+11. Comment: `@codex review for additive-only scope violations, accidental API/auth behavior changes, fail-closed regressions, scaling risks, security regressions, unnecessary complexity, failing or missing tests, rollback clarity, and repo-boundary violations`.
+12. Do not merge or close the source issue.
 
-## PR body requirements
+## Required PR traceability report
 
-The PR must include:
-
-- source issue
-- candidate ID
-- implementation class
-- what changed
-- what did not change
-- checks run
-- skipped or failing checks
-- rollback path
-- Codex audit request
-
-## Final run report
-
-Report the selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and whether any boundary was approached.
+Every implementation PR must include source issue and candidate ID, pre-implementation thesis summary, file-by-file change rationale, why each changed file is good for Dixie, why it advances the repo endgame, why it should work, mass-user scaling analysis, security scope, simplicity analysis, tests/checks, skipped checks, rollback path, future creative paths not implemented, and `CODEX AUDIT REQUEST`.

--- a/eileendailyimplementationagentmodeagent.md
+++ b/eileendailyimplementationagentmodeagent.md
@@ -1,0 +1,106 @@
+# Eileen Daily Implementation Agent Mode Agent
+
+This file is the repo-local runbook for the daily GPT-5.5 Thinking implementation agent. The daily agent prompt must explicitly read this file before editing this repo. This file is intentionally separate from `AGENTS.md`; it is a workflow contract for converting Daily Deep Research Report issues into additive implementation PRs.
+
+## Repository responsibility
+
+`0xHoneyJar/loa-dixie` owns governed BFF/API integration: auth, tenant/estate binding, SIWE/JWT, recall/admission route contracts, middleware fail-closed behavior, observability, and service-boundary enforcement.
+
+This repo is not the place for Freeside product strategy, character/persona UX, Hounfour schema packages, Finn experiment verdicts, Aleph research-précis doctrine, Arcturus revenue-oracle logic, or Straylight doctrine beyond integration boundaries.
+
+## Eligible input
+
+Only implement from a Daily Deep Research Report issue or follow-up plan-audit issue/comment that contains:
+
+- `PROPOSED_NEXT_LANE_SEED`
+- candidate ID
+- repo-fit reasoning
+- acceptance criteria
+- rollback path
+- `VERDICT: ACCEPT_PLAN`
+
+If the candidate lacks `VERDICT: ACCEPT_PLAN`, the agent may perform in-run plan audit only for docs, fixtures, tests, or checkers. Runtime/API behavior requires explicit external acceptance.
+
+## Selection rule
+
+Pick at most one candidate per run. Prefer work that strengthens route tests, fail-closed behavior, tenant/estate binding evidence, or observability without changing public route behavior.
+
+Priority order:
+
+1. docs-only service-boundary notes
+2. fixture-only route examples
+3. test-only negative coverage
+4. checker/validator-only additions
+5. default-off route or middleware helpers
+
+## Additive-only policy
+
+Nothing currently working may stop functioning.
+
+Allowed by default:
+
+- new docs
+- new fixtures
+- new tests
+- new negative route tests
+- new validators/checkers
+- default-off helpers
+- observability docs or test-only evidence
+
+Forbidden without explicit Eileen approval:
+
+- deleting files
+- changing public API behavior by default
+- changing auth/tenant binding semantics by default
+- weakening middleware fail-closed behavior
+- changing recall/admission route contracts without accepted plan
+- production migrations
+- broad refactors
+- unrelated dependency upgrades
+- secrets or real env changes
+- sibling repo mutation
+- deployment changes
+- auto-merge
+- closing source issues
+
+## Dixie-specific stop conditions
+
+Stop and return `VERDICT: NEEDS_HUMAN` if the candidate would:
+
+- modify live auth or tenant/estate binding behavior by default
+- change route response shape without explicit acceptance
+- weaken fail-closed behavior
+- bypass or reorder security middleware without proof
+- duplicate Straylight or Hounfour ownership instead of consuming their contracts
+
+## Implementation steps
+
+1. Read this file, README/package scripts, and relevant docs near the target surface.
+2. Inspect the source issue and confirm `VERDICT: ACCEPT_PLAN`.
+3. Check for obvious duplicate open issues/PRs.
+4. Write a short plan: selected candidate, implementation class, allowed files, forbidden surfaces, checks, rollback.
+5. Create a branch named `daily-impl/YYYY-MM-DD-loa-dixie-<candidate>`.
+6. Implement exactly one candidate with a minimal diff.
+7. Run relevant checks from the repo.
+8. Open a draft PR.
+9. Add `CODEX AUDIT REQUEST` to the PR body.
+10. Comment: `@codex review for additive-only scope violations, accidental API/auth behavior changes, fail-closed regressions, failing or missing tests, rollback clarity, repo-boundary violations, and security regressions`.
+11. Do not merge and do not close the source issue.
+
+## PR body requirements
+
+The PR must include:
+
+- source issue
+- candidate ID
+- implementation class
+- what changed
+- what did not change
+- checks run
+- skipped or failing checks
+- rollback path
+- Codex audit request
+
+## Final run report
+
+Report the selected repo, source issue, branch, PR URL, files changed, checks run, Codex review status, blockers, and whether any boundary was approached.


### PR DESCRIPTION
## Summary

Adds top-level `eileendailyimplementationagentmodeagent.md` as the repo-local runbook for the daily GPT-5.5 Thinking implementation agent.

## Scope

Docs-only. This does not change runtime behavior, package files, tests, or CI.

## Validation

Not run; docs-only runbook addition.

## Notes

This file is intentionally separate from `AGENTS.md`. The daily agent-mode prompt should explicitly read it before editing this repo.

No Codex review was triggered automatically.