### PR TITLE
Wire payment gate to settlement validator

### DIFF
--- a/app/src/middleware/payment.ts
+++ b/app/src/middleware/payment.ts
@@ -10,6 +10,11 @@ export interface PaymentGateConfig {
   x402FacilitatorUrl: string | null;
   /** Current environment (payment enforcement is fail-closed in production) */
   nodeEnv: string;
+  /** Settlement-backed validator for x402 payment headers. */
+  validatePaymentHeader?: (
+    paymentHeader: string,
+    context: { path: string },
+  ) => Promise<boolean>;
 }
 
 /** Routes that are always free — everything else is protected (default-deny) */
@@ -55,6 +60,16 @@ export function createPaymentGate(config?: PaymentGateConfig) {
     );
   }
 
+  // SEC-2: Production payment enforcement must use a real settlement-backed
+  // validator. Header presence alone is acceptable only for non-production
+  // shadow/dev paths.
+  if (config.nodeEnv === 'production' && !config.validatePaymentHeader) {
+    throw new Error(
+      'DIXIE_X402_ENABLED=true in production requires settlement-backed payment validation. ' +
+      'Payment enforcement without validatePaymentHeader is fail-open in disguise.',
+    );
+  }
+
   return createMiddleware(async (c, next) => {
     const path = c.req.path;
 
@@ -75,9 +90,25 @@ export function createPaymentGate(config?: PaymentGateConfig) {
       }, 402);
     }
 
-    // TODO: When @x402/hono is available, validate payment header against facilitator.
-    // Current state: accepts any non-empty header in non-production environments.
-    // Production gate above ensures this path only runs when facilitator is configured.
+    if (config.validatePaymentHeader) {
+      let validPayment = false;
+      try {
+        validPayment = await config.validatePaymentHeader(paymentHeader, { path });
+      } catch {
+        return c.json({
+          error: 'payment_validation_unavailable',
+          message: 'Payment validation is temporarily unavailable',
+        }, 503);
+      }
+
+      if (!validPayment) {
+        return c.json({
+          error: 'invalid_payment',
+          message: 'Payment header could not be validated',
+          facilitator: config.x402FacilitatorUrl,
+        }, 402);
+      }
+    }
 
     await next();
   });

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -447,6 +447,8 @@ export function createDixieApp(config: DixieConfig): DixieApp {
     x402Enabled: config.x402Enabled,
     x402FacilitatorUrl: config.x402FacilitatorUrl,
     nodeEnv: config.nodeEnv,
+    validatePaymentHeader: (paymentHeader, { path }) =>
+      settlementClient.validatePaymentHeader({ paymentHeader, path }),
   }));
 
   // --- Phase 2 Position 13: Conviction tier resolution ---

--- a/app/src/services/settlement-client.ts
+++ b/app/src/services/settlement-client.ts
@@ -33,6 +33,15 @@ export interface SettlementReceipt {
   settledAt: string;
 }
 
+export interface PaymentValidationRequest {
+  paymentHeader: string;
+  path: string;
+}
+
+export interface PaymentValidationResponse {
+  valid: boolean;
+}
+
 export interface SettlementClientConfig {
   facilitatorUrl: string | null;
   enabled: boolean;
@@ -94,6 +103,30 @@ export class SettlementClient {
       if (!res.ok) throw new Error(`Settlement failed: ${res.status}`);
       this.resetCircuit();
       return await res.json() as SettlementReceipt;
+    } catch (err) {
+      this.recordFailure();
+      throw err;
+    }
+  }
+
+  async validatePaymentHeader(request: PaymentValidationRequest): Promise<boolean> {
+    if (!this.config.enabled || !this.config.facilitatorUrl) {
+      return true;
+    }
+
+    if (this.isCircuitOpen()) {
+      throw new Error('Settlement circuit breaker open');
+    }
+
+    try {
+      const res = await this.authenticatedFetch(
+        `${this.config.facilitatorUrl}/api/settlement/validate-payment`,
+        request,
+      );
+      if (!res.ok) throw new Error(`Payment validation failed: ${res.status}`);
+      this.resetCircuit();
+      const body = await res.json() as PaymentValidationResponse;
+      return body.valid === true;
     } catch (err) {
       this.recordFailure();
       throw err;

--- a/app/tests/unit/middleware/payment.test.ts
+++ b/app/tests/unit/middleware/payment.test.ts
@@ -38,6 +38,7 @@ describe('createPaymentGate', () => {
       x402Enabled: true,
       x402FacilitatorUrl: 'https://freeside.example.com',
       nodeEnv: 'production',
+      validatePaymentHeader: async () => true,
     };
 
     it('returns 402 for protected route without payment header', async () => {
@@ -63,6 +64,42 @@ describe('createPaymentGate', () => {
         headers: { 'x-402-payment': 'valid-payment-token' },
       });
       expect(res.status).toBe(200);
+    });
+
+    it('returns 402 when payment header validation fails', async () => {
+      const app = createTestApp({
+        ...config,
+        validatePaymentHeader: async () => false,
+      });
+      const res = await app.request('/api/chat', {
+        headers: { 'x-payment': 'invalid-payment-token' },
+      });
+      expect(res.status).toBe(402);
+      const body = await res.json();
+      expect(body.error).toBe('invalid_payment');
+    });
+
+    it('returns 503 when payment header validation is unavailable', async () => {
+      const app = createTestApp({
+        ...config,
+        validatePaymentHeader: async () => {
+          throw new Error('validator unavailable');
+        },
+      });
+      const res = await app.request('/api/chat', {
+        headers: { 'x-payment': 'payment-token' },
+      });
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.error).toBe('payment_validation_unavailable');
+    });
+
+    it('fails closed in production when no validator is configured', () => {
+      expect(() => createTestApp({
+        x402Enabled: true,
+        x402FacilitatorUrl: 'https://freeside.example.com',
+        nodeEnv: 'production',
+      })).toThrow(/validatePaymentHeader/);
     });
 
     it('allows free routes without payment', async () => {

--- a/app/tests/unit/server-payment-wiring.test.ts
+++ b/app/tests/unit/server-payment-wiring.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDixieApp } from '../../src/server.js';
+import type { DixieConfig } from '../../src/config.js';
+
+function baseConfig(): DixieConfig {
+  return {
+    port: 3099,
+    finnUrl: 'http://localhost:14000',
+    finnWsUrl: 'ws://localhost:14000',
+    corsOrigins: ['*'],
+    allowlistPath: '',
+    adminKey: 'admin-key',
+    jwtPrivateKey: 'test-jwt-secret-32-characters-long',
+    jwtAlgorithm: 'HS256',
+    jwtLegacyHs256Secret: null,
+    nodeEnv: 'production',
+    logLevel: 'error',
+    rateLimitRpm: 1000,
+    otelEndpoint: null,
+    databaseUrl: null,
+    redisUrl: null,
+    natsUrl: null,
+    memoryProjectionTtlSec: 300,
+    memoryMaxEventsPerQuery: 100,
+    convictionTierTtlSec: 300,
+    personalityTtlSec: 1800,
+    autonomousPermissionTtlSec: 300,
+    autonomousBudgetDefaultMicroUsd: 100_000,
+    databasePoolSize: 10,
+    rateLimitBackend: 'memory',
+    scheduleCallbackSecret: '',
+    x402Enabled: true,
+    x402FacilitatorUrl: 'https://freeside.example.com',
+    billingJwtSecret: null,
+    pricingApiUrl: null,
+    pricingTtlSec: 300,
+    recallIntakeEnabled: false,
+    straylightRuntimeDixieKey: '',
+    recallIntakeBodyMaxBytes: 32_768,
+    recallIntakeRateRpm: 30,
+    recallIntakeMaxAssertionsPerTenant: 512,
+    recallIntakeMaxAssertionBytesPerTenant: 1_048_576,
+    recallIntakeIdempotencyTtlSec: 900,
+    recallIntakeIdempotencyMaxEntries: 4_096,
+    recallIntakeDevSeedEnabled: false,
+    recallIntakeDevSeedTenantId: '',
+    admissionIntakeSpikeEnabled: false,
+    admissionIntakeSpikeServiceToken: '',
+    admissionIntakeSpikeOperatorIds: [],
+    admissionIntakeStorageSpikeEnabled: false,
+    admissionIntakeDurableStorageSpikeEnabled: false,
+    admissionIntakeDurableStorageSpikeDir: '',
+  };
+}
+
+describe('createDixieApp payment gate wiring', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the settlement-backed validator adapter in the real app payment path', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ valid: false }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dixie = createDixieApp(baseConfig());
+    dixie.allowlistStore.addEntry('apiKey', 'dxk_payment_wiring_test');
+
+    const res = await dixie.app.request('/api/chat', {
+      headers: {
+        Authorization: 'Bearer dxk_payment_wiring_test',
+        'x-payment': 'payment-token',
+      },
+    });
+
+    expect(res.status).toBe(402);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://freeside.example.com/api/settlement/validate-payment',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          paymentHeader: 'payment-token',
+          path: '/api/chat',
+        }),
+      }),
+    );
+  });
+});

--- a/app/tests/unit/services/settlement-client-payment-validation.test.ts
+++ b/app/tests/unit/services/settlement-client-payment-validation.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SettlementClient } from '../../../src/services/settlement-client.js';
+
+describe('SettlementClient.validatePaymentHeader', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('delegates payment header validation to the facilitator', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ valid: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new SettlementClient({
+      enabled: true,
+      facilitatorUrl: 'https://freeside.example.com',
+      getServiceToken: async () => 'service-token',
+    });
+
+    await expect(client.validatePaymentHeader({
+      paymentHeader: 'payment-token',
+      path: '/api/chat',
+    })).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://freeside.example.com/api/settlement/validate-payment',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer service-token',
+        },
+        body: JSON.stringify({
+          paymentHeader: 'payment-token',
+          path: '/api/chat',
+        }),
+      }),
+    );
+  });
+
+  it('returns false when the facilitator rejects the payment header', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ valid: false }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })));
+
+    const client = new SettlementClient({
+      enabled: true,
+      facilitatorUrl: 'https://freeside.example.com',
+    });
+
+    await expect(client.validatePaymentHeader({
+      paymentHeader: 'payment-token',
+      path: '/api/chat',
+    })).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure the payment gate uses a real settlement-backed validator instead of only header-presence checks so production enforcement is provably backed by the facilitator.
- Fail closed in production when x402 enforcement is enabled but no validator is provided, preventing a silent fail-open where any header would bypass billing.
- Provide a narrow, verifiable call-site wiring so the middleware contract matches real runtime behavior for PR acceptance.

### Description
- Add an optional `validatePaymentHeader` adapter to `PaymentGateConfig` and enforce that production `x402Enabled` requires this validator; the middleware now calls the adapter and returns `402` or `503` for invalid or unavailable validation respectively (`app/src/middleware/payment.ts`).
- Implement `SettlementClient.validatePaymentHeader(request)` with request/response types and reuse the existing authenticated fetch and circuit-breaker semantics to call the facilitator endpoint (`app/src/services/settlement-client.ts`).
- Wire the real app bootstrap to delegate validation to the settlement client by passing `validatePaymentHeader: (paymentHeader, { path }) => settlementClient.validatePaymentHeader({ paymentHeader, path })` into `createPaymentGate(...)` (`app/src/server.ts`).
- Add focused tests: update middleware tests (`app/tests/unit/middleware/payment.test.ts`), add settlement-client validation unit tests (`app/tests/unit/services/settlement-client-payment-validation.test.ts`), and add a real-app wiring test to prove the bootstrap delegates to the settlement validator (`app/tests/unit/server-payment-wiring.test.ts`).

### Testing
- Added unit tests: `app/tests/unit/middleware/payment.test.ts`, `app/tests/unit/services/settlement-client-payment-validation.test.ts`, and `app/tests/unit/server-payment-wiring.test.ts` which assert middleware behavior, `SettlementClient` delegation, and real-app wiring respectively. 
- Attempted to run `pnpm exec vitest run tests/unit/middleware/payment.test.ts tests/unit/services/settlement-client-payment-validation.test.ts tests/unit/server-payment-wiring.test.ts` but it was blocked because `vitest` was not available in the environment. 
- Attempted dependency install with `corepack pnpm install --frozen-lockfile` and `npm install` but both were blocked: `pnpm` failed due to missing lockfile and `npm` failed due to environment Node version (`v20` vs required `>=22`) and a git dependency fetch failure for `@loa/straylight`. 
- Attempted typecheck with `./node_modules/.bin/tsc --noEmit` but it was blocked because dependencies (and the `tsc` binary) are not installed, so no test or typecheck completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42926746648321952ae2ab5e1cb6d7)